### PR TITLE
feat(007): implement AI threat agents

### DIFF
--- a/agents/ai/agent-autonomy.md
+++ b/agents/ai/agent-autonomy.md
@@ -3,7 +3,7 @@ agent_name: agent-autonomy
 category: agentic
 threat_class: AG
 dfd_targets: [Process]
-owasp_references: [ASI-01]
+owasp_references: [ASI-01, ASI-06, ASI-08, ASI-09, ASI-10]
 output_schema: schemas/finding.yaml
 ---
 
@@ -33,6 +33,10 @@ This agent activates when a DFD element name or description matches any of the f
 ### Applicable DFD Element Types
 
 - **Process**: Any process node that represents an autonomous agent, agent orchestrator, task planner, action executor, or multi-agent coordination layer. This includes single-agent systems with iterative decision loops, multi-agent architectures with delegation chains, and workflow engines that grant agents discretion over task execution.
+
+### Empty Results Guidance
+
+If the architecture input contains **no** components matching the trigger keywords above (no agents, orchestrators, planners, executors, or agentic workflows), this agent MUST produce **zero findings**. Do not generate speculative findings about hypothetical agent components. An architecture composed entirely of traditional components (web servers, databases, APIs, message queues) without autonomous agent capabilities is outside this agent's detection scope. Return an empty findings list.
 
 ### Detection Patterns
 
@@ -83,13 +87,13 @@ This agent activates when a DFD element name or description matches any of the f
 id: "AG-{N}"
 category: agentic
 component: "{component name from architecture input}"
-threat: "{specific agent autonomy threat description}"
+threat: "{specific agent autonomy threat description — must describe attacker action and trust assumption violated}"
 likelihood: "{LOW | MEDIUM | HIGH}"
 impact: "{LOW | MEDIUM | HIGH}"
 risk_level: "{computed from OWASP 3x3 matrix}"
-mitigation: "{recommended countermeasure}"
+mitigation: "{actionable countermeasure with specific technology or configuration}"
 references:
-  - "ASI-01"
+  - "{one or more of: ASI-01, ASI-06, ASI-08, ASI-09, ASI-10 — select references relevant to the specific threat}"
 dfd_element_type: "Process"
 ```
 
@@ -101,13 +105,14 @@ dfd_element_type: "Process"
 id: "AG-1"
 category: agentic
 component: "Task Automation Agent"
-threat: "The task automation agent operates in an iterative loop where the LLM decides when to terminate based on its assessment of task completion. There is no maximum iteration count, no timeout, and no cost cap. A malformed task description or ambiguous success criteria can cause the agent to loop indefinitely, consuming API credits, generating unintended side effects on each iteration, and blocking the execution queue for other tasks."
+threat: "An attacker submits a malformed task description with ambiguous success criteria to the Task Automation Agent. The agent operates in an iterative loop where the LLM decides when to terminate based on its assessment of task completion, but there is no maximum iteration count, no timeout, and no cost cap. This violates the trust assumption that the model will reliably decide to stop — in practice, ambiguous inputs cause the agent to loop indefinitely, consuming API credits, generating unintended side effects on each iteration, and blocking the execution queue for other tasks."
 likelihood: HIGH
 impact: MEDIUM
 risk_level: High
 mitigation: "Implement mandatory termination constraints: maximum iteration count (e.g., 25 iterations), execution timeout (e.g., 10 minutes), and cumulative cost cap (e.g., $5 per task). Add a circuit breaker that halts execution if the agent repeats the same action pattern for 3 consecutive iterations. Log each iteration with action taken and reasoning for post-hoc analysis."
 references:
   - "ASI-01"
+  - "ASI-10"
 dfd_element_type: "Process"
 ```
 
@@ -117,13 +122,14 @@ dfd_element_type: "Process"
 id: "AG-2"
 category: agentic
 component: "Infrastructure Management Agent"
-threat: "The infrastructure management agent can execute irreversible actions (database drops, resource deletions, DNS changes) without human approval. The agent's tool access does not distinguish between reversible operations (scaling, configuration reads) and irreversible operations (deletions, data migrations). A misinterpreted instruction or goal misalignment can cause permanent data loss or service disruption with no rollback path."
+threat: "An attacker exploits a misinterpreted instruction or achieves goal misalignment in the Infrastructure Management Agent, which can execute irreversible actions (database drops, resource deletions, DNS changes) without human approval. The agent's tool access does not distinguish between reversible operations (scaling, configuration reads) and irreversible operations (deletions, data migrations). This violates the trust assumption that agents will only perform actions appropriate to the current task scope — the absence of a human approval gate for irreversible operations means a single misinterpreted instruction can cause permanent data loss or service disruption with no rollback path."
 likelihood: MEDIUM
 impact: HIGH
 risk_level: High
 mitigation: "Classify all agent-accessible actions into reversibility tiers: Tier 1 (read-only, auto-approve), Tier 2 (reversible writes, require confirmation), Tier 3 (irreversible actions, require human approval with mandatory wait period). Implement a pre-execution review step for Tier 2 and Tier 3 actions that presents the planned action, its justification, and its reversibility status to a human operator."
 references:
   - "ASI-01"
+  - "ASI-08"
 dfd_element_type: "Process"
 ```
 
@@ -133,13 +139,14 @@ dfd_element_type: "Process"
 id: "AG-3"
 category: agentic
 component: "Multi-Agent Orchestrator"
-threat: "The orchestrator delegates subtasks to specialist agents in a chain (planner -> researcher -> writer -> reviewer). Each downstream agent trusts the output of the upstream agent without validation. If the planner agent produces an incorrect task decomposition, the researcher agent gathers irrelevant data, the writer agent produces incorrect content, and the reviewer agent (using the same flawed plan as reference) approves it. No inter-agent validation or circuit breaker exists to detect the cascading error."
+threat: "An attacker provides a subtly flawed input to the Multi-Agent Orchestrator, which delegates subtasks to specialist agents in a chain (planner -> researcher -> writer -> reviewer). Each downstream agent trusts the output of the upstream agent without validation. This violates the trust assumption that inter-agent outputs are reliable — if the planner agent produces an incorrect task decomposition, the error cascades: the researcher gathers irrelevant data, the writer produces incorrect content, and the reviewer (using the same flawed plan as reference) approves it. No inter-agent validation or circuit breaker exists to detect the cascading error before it propagates through the entire chain."
 likelihood: MEDIUM
 impact: MEDIUM
 risk_level: Medium
 mitigation: "Implement inter-agent output validation at each delegation boundary. Add independent verification checks that compare agent outputs against the original user intent, not just the upstream agent's instructions. Deploy a circuit breaker that halts the delegation chain if any agent reports low confidence or if intermediate outputs diverge significantly from the original task specification. Add end-to-end observability across the agent chain."
 references:
   - "ASI-01"
+  - "ASI-06"
 dfd_element_type: "Process"
 ```
 
@@ -149,19 +156,34 @@ dfd_element_type: "Process"
 id: "AG-4"
 category: agentic
 component: "Content Optimization Agent"
-threat: "The content optimization agent is tasked with 'improving engagement' and measures success by click-through rate. Without constraints on content quality or brand safety, the agent can optimize toward clickbait, sensationalist headlines, or misleading previews that maximize clicks but damage brand reputation and user trust. The agent's goal (maximize CTR) is a proxy for the user's actual intent (improve meaningful engagement)."
+threat: "An attacker (or misconfigured objective) causes the Content Optimization Agent to optimize for click-through rate as a proxy metric rather than the user's true intent of meaningful engagement. Without constraints on content quality or brand safety, the agent generates clickbait, sensationalist headlines, or misleading previews. This violates the trust assumption that the agent's optimization target faithfully represents user intent — the proxy metric (CTR) diverges from the actual goal (quality engagement), and the agent has no mechanism to detect or correct this misalignment."
 likelihood: MEDIUM
 impact: MEDIUM
 risk_level: Medium
 mitigation: "Define multi-dimensional success criteria that include both the target metric and constraint metrics (e.g., maximize CTR subject to brand safety score >= 0.8 and content quality score >= 0.7). Implement guardrails that reject outputs violating constraint metrics regardless of target metric performance. Require periodic human review of agent-optimized content to detect goal drift."
 references:
   - "ASI-01"
+  - "ASI-09"
 dfd_element_type: "Process"
 ```
 
+### Risk Level Computation
+
+Apply the OWASP 3x3 matrix to determine `risk_level` from `likelihood` and `impact`:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
 ## References
 
-- **ASI-01 - Excessive Agency**: OWASP Agentic Security Initiative reference for unbounded agent autonomy
+- **ASI-01 - Excessive Agency**: OWASP Agentic Security Initiative reference for unbounded agent autonomy — agents operating with broader permissions than their task requires
+- **ASI-06 - Cascading Hallucination Attacks**: OWASP Agentic Security Initiative reference for error propagation in multi-agent delegation chains where one agent's flawed output corrupts downstream agents
+- **ASI-08 - Uncontrolled Autonomous Operations**: OWASP Agentic Security Initiative reference for agents executing without adequate human oversight, missing approval gates, and absent audit trails for consequential decisions
+- **ASI-09 - Lack of Agent Goal Alignment**: OWASP Agentic Security Initiative reference for agents optimizing proxy metrics instead of true user objectives, producing technically correct but undesirable outcomes
+- **ASI-10 - Insufficient Agent Monitoring**: OWASP Agentic Security Initiative reference for absent observability into agent decision-making, resource consumption, and multi-agent execution flows
 - **OWASP Agentic Security Initiative**: Framework for identifying and mitigating risks in autonomous AI agent systems
 - **MITRE ATLAS - Abuse of AI Agent Capabilities**: Techniques targeting autonomous agent decision-making
 - **Anthropic, 2024**: "Responsible Scaling Policy" — guidelines for constraining autonomous agent capabilities proportional to verified safety

--- a/agents/ai/data-poisoning.md
+++ b/agents/ai/data-poisoning.md
@@ -3,7 +3,7 @@ agent_name: data-poisoning
 category: llm
 threat_class: LLM
 dfd_targets: [Data Store, Data Flow]
-owasp_references: [OWASP LLM03:2025]
+owasp_references: [OWASP LLM03:2025, OWASP LLM04:2025, OWASP LLM08:2025]
 output_schema: schemas/finding.yaml
 ---
 
@@ -68,6 +68,10 @@ This agent activates when a DFD element name or description matches any of the f
    - Dynamic few-shot selection from user-modifiable example databases
    - System prompt templates that interpolate content from external data sources at runtime
    - Absence of input validation on data flows entering the context window
+
+### Empty Results Guidance
+
+When the architecture input contains no LLM, language model, training pipeline, RAG system, knowledge base, or vector store components (i.e., no DFD elements match any trigger keyword in the Detection Scope), this agent MUST produce zero findings. Do not generate speculative or hypothetical data poisoning findings for architectures that do not include LLM data pipelines or model training infrastructure.
 
 ## Finding Template
 
@@ -135,9 +139,22 @@ references:
 dfd_element_type: "Data Store"
 ```
 
+### Risk Level Computation
+
+Apply the OWASP 3x3 matrix to determine `risk_level` from `likelihood` and `impact`:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
 ## References
 
-- **OWASP LLM03:2025 - Training Data Poisoning**: https://genai.owasp.org/llmrisk/llm03-training-data-poisoning/
+- **OWASP LLM03:2025 - Supply Chain Vulnerabilities**: https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/
+- **OWASP LLM04:2025 - Data and Model Poisoning**: https://genai.owasp.org/llmrisk/llm04-data-and-model-poisoning/
+- **OWASP LLM08:2025 - Vector and Embedding Weaknesses**: https://genai.owasp.org/llmrisk/llm08-vector-and-embedding-weaknesses/
 - **MITRE ATLAS - Poisoning AI Training Data**: Tactic TA0040, Technique AML.T0020
+- **CWE-345 - Insufficient Verification of Data Authenticity**: Applicable to training data manipulation and RAG index poisoning where data integrity is not verified before consumption
 - **CWE-1395 - Dependency on Vulnerable Third-Party Component**: Applicable to model supply chain attacks
 - **Carlini et al., 2023**: "Poisoning Web-Scale Training Datasets is Practical" — demonstrates feasibility of training data poisoning at scale

--- a/agents/ai/model-theft.md
+++ b/agents/ai/model-theft.md
@@ -3,7 +3,7 @@ agent_name: model-theft
 category: llm
 threat_class: LLM
 dfd_targets: [Data Store, Process]
-owasp_references: [OWASP LLM10:2025]
+owasp_references: [OWASP LLM10:2025, OWASP LLM03:2025]
 output_schema: schemas/finding.yaml
 ---
 
@@ -70,6 +70,24 @@ This agent activates when a DFD element name or description matches any of the f
    - Fine-tuned model sharing between teams without tracking or authorization
    - Model export functionality that allows downloading fine-tuned weights
    - Absence of model asset inventory (unknown models cannot be protected)
+
+6. **Unbounded Inference Consumption**: Attackers exploit unrestricted access to model inference endpoints to consume excessive compute resources, effectively stealing model value through unconstrained usage. Look for:
+   - Model inference APIs without per-user or per-API-key usage quotas
+   - Absence of cost controls or budget caps on inference compute
+   - No monitoring of inference volume anomalies or consumption spikes per tenant
+   - Free-tier or unauthenticated access to model endpoints that enables unlimited querying
+   - Missing billing attribution that allows inference costs to be shifted to the model owner
+
+7. **Model Supply Chain Compromise**: Tampering with model artifacts, dependencies, or serving infrastructure within the supply chain to inject backdoors or replace legitimate models. Look for:
+   - Base models or pretrained checkpoints downloaded from public registries without cryptographic signature verification
+   - Model serving frameworks or inference libraries sourced from unverified package repositories
+   - CI/CD pipelines for model deployment that lack artifact integrity checks between build and deploy stages
+   - Model conversion tools (ONNX export, quantization) sourced from untrusted origins
+   - Absence of a software bill of materials (SBOM) for model inference dependencies
+
+### Empty Results Guidance
+
+When the architecture input contains no LLM, language model, model serving, or model storage components (i.e., no DFD elements match any trigger keyword in the Detection Scope), this agent MUST produce zero findings. Do not generate speculative or hypothetical model theft findings for architectures that do not include model hosting or model inference components.
 
 ## Finding Template
 
@@ -138,10 +156,22 @@ references:
 dfd_element_type: "Process"
 ```
 
+### Risk Level Computation
+
+Apply the OWASP 3x3 matrix to determine `risk_level` from `likelihood` and `impact`:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
 ## References
 
 - **OWASP LLM10:2025 - Model Theft**: https://genai.owasp.org/llmrisk/llm10-model-theft/
+- **OWASP LLM03:2025 - Supply Chain Vulnerabilities**: https://genai.owasp.org/llmrisk/llm03-supply-chain-vulnerabilities/
 - **MITRE ATLAS - ML Model Access**: Tactic TA0044, Technique AML.T0044
 - **Tramer et al., 2016**: "Stealing Machine Learning Models via Prediction APIs" — foundational work on API-based model extraction
+- **CWE-200 - Exposure of Sensitive Information to an Unauthorized Actor**: Parent category covering model weight exfiltration, API-based extraction, and metadata leakage
 - **CWE-209 - Generation of Error Message Containing Sensitive Information**: Applicable to model metadata leakage through error responses
 - **CWE-522 - Insufficiently Protected Credentials**: Analogous to insufficiently protected model artifacts

--- a/agents/ai/prompt-injection.md
+++ b/agents/ai/prompt-injection.md
@@ -3,7 +3,7 @@ agent_name: prompt-injection
 category: llm
 threat_class: LLM
 dfd_targets: [Process]
-owasp_references: [OWASP LLM01:2025]
+owasp_references: [OWASP LLM01:2025, OWASP LLM07:2025]
 output_schema: schemas/finding.yaml
 ---
 
@@ -58,6 +58,17 @@ This agent activates when a DFD element name or description matches any of the f
    - System prompts containing sensitive business logic, API keys, or internal URLs
    - No output filtering for content that resembles system prompt leakage
    - Absence of prompt-level guardrails that refuse meta-instruction queries
+
+5. **Cross-Plugin Injection**: Adversarial prompts that exploit multi-plugin or multi-tool LLM architectures to pivot between plugins, escalate privileges, or exfiltrate data across trust boundaries. Look for:
+   - LLM orchestrators that invoke multiple plugins/tools where one plugin's output feeds another plugin's input without sanitization
+   - Absence of trust boundary enforcement between plugins operating at different privilege levels
+   - Plugin architectures where a compromised or attacker-controlled plugin can influence the prompts sent to other plugins
+   - Missing input validation on cross-plugin data flows (e.g., Plugin A returns text that is interpolated into Plugin B's prompt)
+   - No isolation between plugin execution contexts, allowing shared state manipulation
+
+### Empty Results Guidance
+
+When the architecture input contains no LLM, language model, or generative AI components (i.e., no DFD elements match any trigger keyword in the Detection Scope), this agent MUST produce zero findings. Do not generate speculative or hypothetical prompt injection findings for architectures that do not include LLM-integrated components.
 
 ## Finding Template
 
@@ -126,9 +137,20 @@ references:
 dfd_element_type: "Process"
 ```
 
+### Risk Level Computation
+
+Apply the OWASP 3x3 matrix to determine `risk_level` from `likelihood` and `impact`:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
 ## References
 
 - **OWASP LLM01:2025 - Prompt Injection**: https://genai.owasp.org/llmrisk/llm01-prompt-injection/
+- **OWASP LLM07:2025 - System Prompt Leakage**: https://genai.owasp.org/llmrisk/llm07-system-prompt-leakage/
 - **MITRE ATLAS - LLM Prompt Injection**: Tactic TA0043, Technique AML.T0051
 - **CWE-77 - Improper Neutralization of Special Elements used in a Command**: Conceptual analog for prompt injection in LLM contexts
 - **Greshake et al., 2023**: "Not what you've signed up for: Compromising Real-World LLM-Integrated Applications with Indirect Prompt Injection"

--- a/agents/ai/tool-abuse.md
+++ b/agents/ai/tool-abuse.md
@@ -3,7 +3,7 @@ agent_name: tool-abuse
 category: agentic
 threat_class: AG
 dfd_targets: [Process]
-owasp_references: [MCP-03]
+owasp_references: [ASI-02, ASI-04, MCP-03, MCP-05]
 output_schema: schemas/finding.yaml
 ---
 
@@ -11,7 +11,7 @@ output_schema: schemas/finding.yaml
 
 ## Purpose
 
-Detects threats arising from agentic systems that invoke external tools, MCP servers, plugins, or APIs as part of their execution. Tool-use abuse occurs when an agent invokes tools it should not have access to, manipulates tool parameters to achieve unintended effects, or chains tool calls in sequences that escalate privileges beyond the agent's intended scope. This agent identifies unauthorized tool invocation, capability escalation through tool composition, parameter injection in tool calls, and tool chain manipulation where individually safe operations combine to produce dangerous outcomes.
+Detects threats arising from agentic systems that invoke external tools, MCP servers, plugins, or APIs as part of their execution. Tool-use abuse occurs when an agent invokes tools it should not have access to, manipulates tool parameters to achieve unintended effects, or chains tool calls in sequences that escalate privileges beyond the agent's intended scope. This agent identifies unauthorized tool invocation, capability escalation through tool composition, parameter injection in tool calls, tool chain manipulation where individually safe operations combine to produce dangerous outcomes, and tool poisoning attacks (direct poisoning, tool shadowing, and rug pulls) where malicious tool definitions alter agent behavior.
 
 ## Detection Scope
 
@@ -32,6 +32,10 @@ This agent activates when a DFD element name or description matches any of the f
 ### Applicable DFD Element Types
 
 - **Process**: Any process node that represents an agent, orchestrator, or tool execution layer. This includes MCP client processes, plugin hosts, function-calling middleware, and agentic frameworks that dispatch tool invocations based on model output.
+
+### Empty Results Guidance
+
+If the architecture input contains **no** components matching the trigger keywords above (no agents, MCP servers, tool servers, plugins, function-calling layers, or tool chains), this agent MUST produce **zero findings**. Do not generate speculative findings about hypothetical tool-use components. An architecture without tool servers, MCP integrations, plugin systems, or agentic tool invocation is outside this agent's detection scope. Return an empty findings list.
 
 ### Detection Patterns
 
@@ -59,10 +63,25 @@ This agent activates when a DFD element name or description matches any of the f
    - No maximum tool call depth or iteration limit on agentic loops
    - Tool results that are fed back to the model without integrity verification
 
-5. **Rug Pull / Tool Redefinition**: A tool server modifies its tool definitions after initial registration, altering behavior without the agent or user being aware. Look for:
+5. **Tool Poisoning**: A malicious or compromised tool server manipulates tool definitions to alter agent behavior without detection. This category covers three distinct attack vectors:
+
+   **5a. Direct Poisoning**: A tool server provides tool definitions with hidden malicious instructions embedded in descriptions or parameter schemas. Look for:
+   - Tool descriptions containing embedded instructions that influence model behavior beyond the tool's stated purpose
+   - Hidden directives in parameter descriptions that cause the model to pass sensitive data as arguments
+   - Tool definitions where the description payload exceeds what is necessary for functional use
+   - Absence of tool description sanitization or length limits at the MCP client level
+
+   **5b. Tool Shadowing**: A malicious tool server registers a tool with the same name or similar description as a legitimate tool, intercepting calls intended for the original. Look for:
+   - Multiple MCP servers registering tools with identical or near-identical names
+   - No namespace isolation or server-of-origin verification for tool registrations
+   - Tool discovery mechanisms that do not disambiguate between tools from different servers
+   - Absence of tool identity verification (server signature, hash of tool definition)
+
+   **5c. Rug Pull / Tool Redefinition**: A tool server modifies its tool definitions after initial registration, altering behavior without the agent or user being aware. Look for:
    - MCP servers that can dynamically update tool schemas after connection
    - No integrity verification or pinning of tool definitions at registration time
    - Absence of change detection for tool description, parameter schema, or behavior
+   - No versioning or changelog for tool definition updates
 
 ## Finding Template
 
@@ -70,13 +89,13 @@ This agent activates when a DFD element name or description matches any of the f
 id: "AG-{N}"
 category: agentic
 component: "{component name from architecture input}"
-threat: "{specific tool abuse threat description}"
+threat: "{specific tool abuse threat description — must describe attacker action and trust assumption violated}"
 likelihood: "{LOW | MEDIUM | HIGH}"
 impact: "{LOW | MEDIUM | HIGH}"
 risk_level: "{computed from OWASP 3x3 matrix}"
-mitigation: "{recommended countermeasure}"
+mitigation: "{actionable countermeasure with specific technology or configuration}"
 references:
-  - "MCP-03"
+  - "{one or more of: ASI-02, ASI-04, MCP-03, MCP-05 — select references relevant to the specific threat}"
 dfd_element_type: "Process"
 ```
 
@@ -88,12 +107,13 @@ dfd_element_type: "Process"
 id: "AG-1"
 category: agentic
 component: "Code Assistant Agent"
-threat: "The MCP server exposes all registered tools (filesystem, database, network, code execution) to every connected agent without per-agent capability scoping. A code review agent intended only for read operations can invoke file-write and shell-execute tools, enabling unintended modifications to the codebase or host system."
+threat: "An attacker exploits the Code Assistant Agent's connection to an MCP server that exposes all registered tools (filesystem, database, network, code execution) to every connected agent without per-agent capability scoping. This violates the trust assumption that agents can only invoke tools within their authorized capability set — a code review agent intended only for read operations can invoke file-write and shell-execute tools, enabling unintended modifications to the codebase or host system."
 likelihood: HIGH
 impact: HIGH
 risk_level: Critical
 mitigation: "Implement per-agent tool allowlists at the MCP server level. Each agent connection should declare its required capabilities, and the server should enforce that only declared tools are invocable. Log all tool invocations with agent identity for audit purposes."
 references:
+  - "ASI-02"
   - "MCP-03"
 dfd_element_type: "Process"
 ```
@@ -104,12 +124,13 @@ dfd_element_type: "Process"
 id: "AG-2"
 category: agentic
 component: "Data Analysis Agent"
-threat: "The agent has authorized access to a database-query tool and a file-write tool individually. By chaining these tools, the agent can export arbitrary database contents to the local filesystem, then use a file-share tool to transmit the export externally. No cross-tool policy evaluates the composite effect of this chain, enabling data exfiltration that no single tool authorization would permit."
+threat: "An attacker manipulates the Data Analysis Agent (via prompt injection or task specification) to chain individually authorized tools — a database-query tool and a file-write tool — to export arbitrary database contents to the local filesystem, then use a file-share tool to transmit the export externally. This violates the trust assumption that individually authorized tools cannot combine to exceed their intended permissions — no cross-tool policy evaluates the composite effect of this chain, enabling data exfiltration that no single tool authorization would permit."
 likelihood: MEDIUM
 impact: HIGH
 risk_level: High
 mitigation: "Implement a tool chain policy engine that evaluates composite effects of sequential tool calls. Define forbidden tool combinations (e.g., data-read + network-send) and require human approval for chains that cross trust boundaries. Enforce maximum chain depth limits."
 references:
+  - "ASI-04"
   - "MCP-03"
 dfd_element_type: "Process"
 ```
@@ -120,20 +141,34 @@ dfd_element_type: "Process"
 id: "AG-3"
 category: agentic
 component: "SQL Assistant Agent"
-threat: "The agent constructs SQL query parameters from model output without validation. An attacker who achieves prompt injection can manipulate the model to produce tool calls with malicious SQL fragments (DROP TABLE, UNION SELECT) as query parameters, bypassing application-level SQL injection protections because the query originates from a trusted agent process."
+threat: "An attacker achieves prompt injection against the SQL Assistant Agent and manipulates the model to produce tool calls with malicious SQL fragments (DROP TABLE, UNION SELECT) as query parameters. The agent constructs SQL query parameters from model output without validation. This violates the trust assumption that model-generated tool parameters are safe and well-formed — the query originates from a trusted agent process, bypassing application-level SQL injection protections that only guard against external user input."
 likelihood: MEDIUM
 impact: HIGH
 risk_level: High
 mitigation: "Enforce strict parameter schema validation at the tool server level. Use parameterized queries exclusively — never pass raw SQL from model output. Implement an output classifier on the model that detects tool calls with suspicious parameter patterns before execution."
 references:
+  - "MCP-05"
   - "MCP-03"
   - "CWE-89"
 dfd_element_type: "Process"
 ```
 
+### Risk Level Computation
+
+Apply the OWASP 3x3 matrix to determine `risk_level` from `likelihood` and `impact`:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
 ## References
 
-- **MCP-03 - Tool Poisoning / Rug Pull**: Model Context Protocol security advisory on tool definition manipulation
+- **ASI-02 - Unauthorized Tool Access**: OWASP Agentic Security Initiative reference for agents invoking tools outside their granted capability set due to absent per-agent scoping or allowlist enforcement
+- **ASI-04 - Cross-Agent Trust Exploitation**: OWASP Agentic Security Initiative reference for capability escalation through tool composition where individually authorized operations combine to exceed intended permissions
+- **MCP-03 - Tool Poisoning / Rug Pull**: Model Context Protocol security advisory on tool definition manipulation — covers direct poisoning, tool shadowing, and post-registration redefinition attacks
+- **MCP-05 - Tool Parameter Injection**: Model Context Protocol security advisory on unvalidated parameters in tool calls — SQL fragments, shell commands, or file paths passed as tool arguments without sanitization
 - **OWASP Agentic Security Initiative**: Framework for agentic application threat modeling
 - **Anthropic, 2024**: "Tool Use Security Considerations" — guidelines for safe tool-use patterns in agentic systems
 - **MITRE ATLAS - Abuse of AI Capabilities**: Techniques for exploiting tool-augmented AI systems

--- a/docs/architecture/01_system_design/README.md
+++ b/docs/architecture/01_system_design/README.md
@@ -359,3 +359,99 @@ Architecture Input (any format)
 | Schema | YAML | Machine-readable validation contract |
 | Reference frameworks | OWASP Top 10 2021, OWASP API Security 2023, CWE, MITRE ATT&CK | Industry-standard cross-references for threat findings |
 | Validation | Manual review + orchestrator integration run | No automated test framework needed for prompt files |
+
+---
+
+### Feature 007: AI Threat Agents
+
+## Components
+
+### Agent Validation Framework
+
+The validation approach follows the three-layer framework proven in F-005 (STRIDE agents):
+
+**Layer 1: Structural Audit** (per agent)
+- Frontmatter fields present and correct (`agent_name`, `category`, `threat_class`, `dfd_targets`, `owasp_references`, `output_schema`)
+- Section structure matches canonical organization (purpose, detection scope, patterns, finding template, risk computation, references)
+- `dfd_targets` matches interface contract AI extension dispatch rules
+
+**Layer 2: Content Quality** (per agent)
+- Detection patterns cover all attack subcategories from PRD FR-8
+- Finding template examples demonstrate component-specific threats (not generic)
+- Mitigation examples are actionable with specific technology references
+- Framework references include OWASP AI framework IDs (LLM0x:2025, ASI-xx, MCP-xx:2025)
+
+**Layer 3: Integration Validation** (all agents together)
+- Run orchestrator against `examples/mermaid-agentic-app/input.md`
+- Verify AG and LLM tables have findings in assembled `threats.md`
+- Verify two-layer keyword dispatch and dual-dispatch behavior
+- Verify 100% component specificity (zero generic findings)
+
+### AI Agent DFD Targeting Matrix
+
+| Agent | category | threat_class | dfd_targets | OWASP Framework |
+|-------|----------|-------------|-------------|-----------------|
+| prompt-injection.md | llm | LLM | [Process] | LLM Top 10 v2025 (LLM01) |
+| data-poisoning.md | llm | LLM | [Data Store, Data Flow] | LLM Top 10 v2025 (LLM03, LLM04) |
+| model-theft.md | llm | LLM | [Data Store, Process] | LLM Top 10 v2025 (LLM10) |
+| agent-autonomy.md | agentic | AG | [Process] | Agentic Top 10 (ASI01, ASI06, ASI08, ASI09, ASI10) |
+| tool-abuse.md | agentic | AG | [Process] | Agentic Top 10 (ASI02, ASI04), MCP Top 10 (MCP03) |
+
+## Data Flow
+
+```
+Architecture Input (any format)
+         │
+         ▼
+┌─────────────────────────────┐
+│ Orchestrator (F-003)        │
+│  Phase 1: Scope             │
+│  - Format detection         │
+│  - Component classification │
+│  - DFD element assignment   │
+└─────────┬───────────────────┘
+          │ dispatch per STRIDE-per-Element
+          │ + AI keyword dispatch (Layer 1)
+          ▼
+┌──────────────────┐    ┌──────────────────┐
+│ 6 STRIDE Agents  │    │ 5 AI Agents      │
+│ (F-005 validated)│    │ (F-007 — this)   │
+│                  │    │                  │
+│ Each agent:      │    │ Each agent:      │
+│ 1. Receives arch │    │ 1. Receives arch │
+│ 2. Filters by    │    │ 2. Filters by    │
+│    dfd_targets   │    │    dfd_targets   │
+│ 3. Applies       │    │ 3. Applies Layer │
+│    patterns      │    │    2 keywords    │
+│ 4. Produces      │    │ 4. Applies       │
+│    findings (IR) │    │    patterns      │
+│                  │    │ 5. Produces      │
+│                  │    │    findings (IR) │
+└────────┬─────────┘    └────────┬─────────┘
+         │                       │
+         └───────────┬───────────┘
+                     │ all findings per schemas/finding.yaml
+                     ▼
+┌─────────────────────────────┐
+│ Orchestrator (F-003)        │
+│  Phase 3-4: Assemble        │
+│  - Build 6 STRIDE tables    │
+│  - Build 2 AI tables        │
+│    (AG table + LLM table)   │
+│  - Generate coverage matrix │
+│  - Compute risk summary     │
+└─────────┬───────────────────┘
+          │
+          ▼
+    threats.md output
+    (8 threat tables total)
+```
+
+## Tech Stack
+
+| Component | Technology | Justification |
+|-----------|-----------|---------------|
+| Agent files | Markdown with YAML frontmatter | Platform-neutral, LLM-agnostic prompt format; matches F-005 STRIDE pattern |
+| Schema | YAML (`schemas/finding.yaml` v1.0) | Machine-readable validation contract; read-only for this feature |
+| OWASP references | LLM Top 10 v2025, Agentic Top 10 2026, MCP Top 10 2025 | Three complementary AI security frameworks |
+| Validation | Manual review + orchestrator integration run | No automated test framework needed for prompt files |

--- a/docs/product/02_PRD/007-ai-threat-agents-2026-03-22.md
+++ b/docs/product/02_PRD/007-ai-threat-agents-2026-03-22.md
@@ -1,0 +1,449 @@
+---
+prd:
+  number: "007"
+  topic: ai-threat-agents
+  created: 2026-03-22
+  status: Approved
+  type: feature
+triad:
+  pm_signoff: {agent: product-manager, date: 2026-03-22, status: approved, notes: "PRD drafted by PM via ~aod-define skill with GitHub Issue #7 user stories and consumer guide research as primary inputs"}
+  architect_signoff: {agent: architect, date: 2026-03-22, status: approved_with_concerns, notes: "Technically feasible. 3 findings (1 medium, 2 low) — all addressed: FR-3 keyword model clarified to two-layer dispatch/detection, model-theft DFD targets corrected to [Data Store, Process], LLM04 reference corrected. No blocking issues."}
+  techlead_signoff: {agent: team-lead, date: 2026-03-22, status: approved_with_concerns, notes: "Feasible in 1 sprint (90% confidence). Agents are content-complete (134-168 lines each). 3-wave execution strategy (parallel validation, consistency check, end-to-end). 3 low concerns addressed: model-theft DFD target, OWASP reference breadth, dual-dispatch testing. No blockers."}
+source:
+  idea_id: 7
+  story_id: null
+---
+
+# AI Threat Agents - Product Requirements Document
+
+**Status**: Approved
+**Created**: 2026-03-22
+**Author**: product-manager
+**Reviewers**: architect, team-lead
+**Phase**: Phase 1 (Foundation)
+**Priority**: P1 (High)
+
+---
+
+## Executive Summary
+
+### The One-Liner
+Build and validate 5 AI-specific threat agents so that agentic and LLM threats are systematically identified against OWASP frameworks, producing component-specific findings alongside traditional STRIDE analysis.
+
+### Problem Statement
+Developers building agentic AI applications face a critical gap: traditional STRIDE threat modeling (delivered in F-005) covers classical security threats but misses AI-specific attack vectors. Prompt injection, tool abuse, data poisoning, model theft, and agent autonomy risks are fundamentally different from Spoofing, Tampering, or Denial of Service — they require dedicated detection patterns grounded in AI-specific OWASP frameworks.
+
+The orchestrator (F-003) already supports AI agent dispatch via keyword-based detection (matching "LLM", "agent", "MCP server", etc. in architecture elements). The 5 AI agent prompt files exist in `agents/ai/` with detection patterns and finding templates. This feature validates, tests, and ensures end-to-end correctness of all 5 agents when invoked by the orchestrator against real architecture input containing AI/LLM/agentic components.
+
+### Proposed Solution
+Validate and complete all 5 AI agent prompt files (`agents/ai/*.md`) so each agent:
+
+1. **Analyzes through its assigned threat lens** — prompt injection, data poisoning, model theft (LLM category) or agent autonomy, tool abuse (Agentic category)
+2. **Targets correct DFD element types** — per the interface contract's AI extension dispatch rules
+3. **Produces component-specific findings** — every finding references a specific component from the input architecture; generic/untargeted threats are rejected
+4. **Follows consistent output format** — findings conform to `schemas/finding.yaml` with ID convention (LLM-N for LLM agents, AG-N for Agentic agents)
+5. **Includes OWASP reference IDs** — each finding maps to established AI vulnerability catalogs (LLM0x:2025, ASIxx, MCPxx:2025)
+
+Each agent is a **markdown prompt file**, not application code. Agents are platform-neutral and work with any LLM capable of following structured markdown prompts.
+
+**Dispatch model**: When the orchestrator dispatches to an AI agent, it follows that agent's analysis methodology within its own execution context. The orchestrator internalizes each agent's detection patterns and finding template to produce findings for that category. Platform-specific multi-call dispatch is an adapter concern addressed in F-009.
+
+### Success Criteria
+- All 5 AI agents produce specific, component-referencing findings when given the sample architecture (`examples/mermaid-agentic-app/input.md`)
+- No generic or untargeted threats appear in any agent's output — every finding references a named component from the input
+- Each agent's findings conform to `schemas/finding.yaml` with correct ID prefix (LLM-N or AG-N)
+- Each agent targets only its assigned DFD element types per the interface contract
+- Risk levels are computed correctly using the OWASP 3x3 matrix (likelihood x impact)
+- Each finding includes at least one OWASP reference ID (LLM0x:2025, ASIxx, or MCPxx:2025)
+- Orchestrator can dispatch to all 5 AI agents and assemble their findings into valid AG and LLM tables in `threats.md`
+- AI agents produce empty results for purely traditional architectures with no AI/LLM/agentic components
+
+### Timeline
+Target: 1 development sprint (estimated during Team-Lead feasibility review)
+
+---
+
+## Strategic Alignment
+
+### Product Vision Alignment
+**Reference**: [product-vision.md](../01_Product_Vision/product-vision.md)
+
+This feature directly delivers the core value proposition: "First toolkit to natively model AI-specific threat agents alongside traditional STRIDE." The STRIDE agents (F-005) provide the traditional threat layer; the AI agents provide the AI-specific layer. Together they form the complete threat model. Without validated AI agents, the toolkit cannot differentiate from generic STRIDE tools — the AI threat agents are the product's unique selling point.
+
+### Roadmap Fit
+**Phase**: Phase 1 (Foundation)
+**Dependencies**: F-001 (delivered) — repository skeleton, interface contract, schemas; F-003 (delivered) — orchestrator with AI dispatch logic; F-005 (delivered) — STRIDE agents validated (same pattern)
+**Blocks**: Dedup & Risk Rating (future — operates on combined STRIDE+AI findings), F-009 (Platform Adapters — wraps orchestrator+agents for specific platforms)
+
+The AI agents follow the same validated pattern as the STRIDE agents (F-005). This is the final critical path item to complete the core threat modeling capability. Once AI agents are validated, the toolkit can produce complete threat models covering both traditional and AI-specific threats.
+
+---
+
+## Target Users & Personas
+
+### Primary Persona: Security Analyst
+- **Role**: Security professional performing threat modeling on agentic AI systems
+- **Experience**: Familiar with STRIDE methodology, learning AI-specific threat landscape
+- **Goals**: Systematically identify AI-specific threats (prompt injection, tool abuse, agent autonomy) alongside traditional STRIDE threats
+- **Pain Points**: No established framework maps AI threats to DFD elements; manual AI threat identification is ad hoc and inconsistent
+
+**Why This Matters to Them**: Each AI agent encodes OWASP AI security expertise into reusable prompts with framework-grounded references (LLM Top 10, Agentic Top 10, MCP Top 10), ensuring complete coverage of AI-specific attack vectors.
+
+### Secondary Persona: AI Agent Developer
+- **Role**: Software developer building agentic AI applications
+- **Experience**: Proficient in code and AI/ML, new to security threat modeling
+- **Goals**: Get a complete threat model that covers both traditional and AI-specific threats without deep security expertise
+- **Pain Points**: Knows OWASP Top 10 for web but not the LLM/Agentic/MCP-specific variants; doesn't know what AI-specific threats to look for
+
+**Why This Matters to Them**: The AI agents automate AI-specific threat identification so developers get expert-level findings with OWASP reference IDs they can research and act on.
+
+---
+
+## User Stories
+
+### US-1: Agentic AI Threat Agent
+**When** a security analyst provides an architecture diagram containing autonomous AI components to the orchestrator,
+**I want** the Agentic AI threat agents (agent-autonomy, tool-abuse) to examine excessive agency, tool/function abuse, insecure plugin execution, agent-to-agent trust boundaries, MCP-specific threats, and multi-agent coordination risks,
+**So I can** have threats unique to systems with autonomous AI tool access identified against OWASP Agentic Top 10 (2026) and OWASP MCP Top 10 (2025).
+
+**Acceptance Criteria**:
+- **Given** an architecture with an AI orchestrator component, **when** the agent-autonomy agent analyzes it, **then** it produces findings referencing that specific component with AG-prefixed IDs covering excessive autonomy, goal misalignment, and missing human-in-the-loop
+- **Given** an architecture with MCP tool servers, **when** the tool-abuse agent analyzes it, **then** it produces findings referencing those components with AG-prefixed IDs covering tool poisoning, unauthorized invocation, and rug pull attacks
+- **Given** an architecture with multi-agent communication, **when** the agent-autonomy agent analyzes it, **then** it produces findings about cascading failures and autonomous resource consumption
+- Each finding includes OWASP reference IDs (ASIxx for agentic threats, MCPxx:2025 for MCP-specific threats)
+- AI agents produce empty results for architectures with no AI/agent/MCP components
+
+**Priority**: P0
+**Effort**: M
+
+### US-2: LLM Threat Agent
+**When** a security analyst provides an architecture diagram containing LLM integration to the orchestrator,
+**I want** the LLM threat agents (prompt-injection, data-poisoning, model-theft) to examine prompt injection vectors, training data integrity, model supply chain, sensitive information disclosure via model output, and unbounded resource consumption,
+**So I can** have threats specific to LLM integration identified against OWASP LLM Top 10 v2025.
+
+**Acceptance Criteria**:
+- **Given** an architecture with an LLM inference service, **when** the prompt-injection agent analyzes it, **then** it produces findings referencing that specific component with LLM-prefixed IDs covering direct injection, indirect injection, and system prompt leakage
+- **Given** an architecture with RAG pipeline and vector databases, **when** the data-poisoning agent analyzes it, **then** it produces findings referencing those components with LLM-prefixed IDs covering training data manipulation, RAG index poisoning, and knowledge base corruption
+- **Given** an architecture with model hosting, **when** the model-theft agent analyzes it, **then** it produces findings referencing that component with LLM-prefixed IDs covering model extraction, unbounded consumption, and supply chain risks
+- Each finding includes OWASP reference IDs (LLM0x:2025)
+- AI agents produce empty results for architectures with no LLM/model components
+
+**Priority**: P0
+**Effort**: M
+
+### US-3: OWASP-Referenced Findings with Consistent Format
+**When** any AI threat agent produces findings,
+**I want** each finding to follow a consistent format with ID, Component, Threat, OWASP Reference, Risk (likelihood + impact), and Mitigation,
+**So that** findings map directly to established vulnerability catalogs and the orchestrator can assemble them into unified AG and LLM threat tables.
+
+**Acceptance Criteria**:
+- Each agent outputs findings with fields: ID, Component, Threat, Likelihood, Impact, Risk Level, Mitigation, References (OWASP IDs), DFD Element Type
+- Agentic agent IDs follow convention AG-N; LLM agent IDs follow convention LLM-N
+- All findings conform to `schemas/finding.yaml`
+- Output includes OWASP Reference column in rendered tables (ASI-xx, MCP-xx, or LLM0x:2025)
+- Risk levels computed via OWASP 3x3 matrix match expected values
+- Quality guardrail: findings that don't reference specific components from the input are flagged for revision
+
+**Priority**: P0
+**Effort**: S
+
+---
+
+## Functional Requirements
+
+### FR-1: Five Agents Across Two AI Threat Categories
+Each AI agent analyzes architecture input through its assigned threat lens:
+
+| Agent File | Category | Threat Class | ID Prefix | OWASP Framework |
+|-----------|----------|-------------|-----------|-----------------|
+| `prompt-injection.md` | LLM | Prompt Injection | LLM-N | LLM Top 10 v2025 (LLM01) |
+| `data-poisoning.md` | LLM | Data & Model Poisoning | LLM-N | LLM Top 10 v2025 (LLM04) |
+| `model-theft.md` | LLM | Model Theft & Abuse | LLM-N | LLM Top 10 v2025 (LLM03, LLM10) |
+| `agent-autonomy.md` | Agentic | Agent Autonomy Risks | AG-N | Agentic Top 10 (ASI01, ASI06, ASI08, ASI09, ASI10) |
+| `tool-abuse.md` | Agentic | Tool Misuse & Exploitation | AG-N | Agentic Top 10 (ASI02, ASI04), MCP Top 10 (MCP03) |
+
+### FR-2: DFD Element Targeting
+Each agent targets DFD element types per the interface contract:
+
+| Agent | Primary DFD Targets | Rationale |
+|-------|-------------------|-----------|
+| `prompt-injection.md` | Process | LLM inference endpoints are processes receiving user input |
+| `data-poisoning.md` | Data Store, Data Flow | Poisoning targets training data stores and data flows feeding models |
+| `model-theft.md` | Data Store, Process | Model weights are stored in data stores; inference endpoints are processes exposing model behavior |
+| `agent-autonomy.md` | Process | Autonomous agents are processes with decision-making capability |
+| `tool-abuse.md` | Process | Tool servers and plugin hosts are processes executing actions |
+
+Agents MUST NOT produce findings for DFD element types outside their assigned scope.
+
+### FR-3: Two-Layer Keyword Dispatch
+AI agent activation uses a two-layer keyword model:
+
+**Layer 1 — Orchestrator Dispatch** (which category of agents to activate):
+The orchestrator uses interface contract Section 3 keywords to determine which agent categories apply to each architecture element:
+
+- **LLM dispatch keywords**: "LLM", "model", "GPT", "Claude", "language model", "completion", "chat", "inference", "prompt", "generative AI"
+  - Activates: prompt-injection, data-poisoning, model-theft agents
+- **Agentic dispatch keywords**: "agent", "autonomous", "orchestrator", "MCP server", "tool server", "plugin"
+  - Activates: agent-autonomy, tool-abuse agents
+- **Dual-dispatch**: Elements matching both LLM and agentic keywords trigger both agent categories
+
+**Layer 2 — Agent Detection Scope** (which components within the category to analyze):
+Each agent file defines its own trigger keywords that extend beyond the orchestrator dispatch keywords. These are per-agent refinements for targeted threat detection (e.g., data-poisoning adds "training", "RAG", "vector store"; tool-abuse adds "tool use", "function calling"). Agent-level keywords are documented in each agent's Detection Scope section and do not need to be duplicated in the interface contract.
+
+### FR-4: Component-Specific Findings
+Every finding MUST reference a named component from the architecture input. The finding's `component` field must match a component identified in the orchestrator's Phase 1 (Scope) output. Findings with generic component names (e.g., "the system", "the AI", "a model") are invalid and must be rejected.
+
+### FR-5: Finding Schema Compliance
+All findings conform to `schemas/finding.yaml` intermediate representation (IR):
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Sequential with category prefix (LLM-1, AG-1, etc.) |
+| `category` | string | `llm` or `agentic` |
+| `component` | string | Named component from architecture input |
+| `threat` | string | Specific threat description — what the attacker does and what trust assumption they violate |
+| `likelihood` | enum | LOW, MEDIUM, HIGH — assessed using OWASP factors |
+| `impact` | enum | LOW, MEDIUM, HIGH — assessed using OWASP factors |
+| `risk_level` | enum | Note, Low, Medium, High, Critical — computed from OWASP 3x3 matrix |
+| `mitigation` | string | Actionable countermeasure — specific technology or configuration |
+| `references` | array | OWASP LLM/Agentic/MCP IDs, CWE, MITRE ATLAS identifiers |
+| `dfd_element_type` | string | DFD classification of the target component |
+
+### FR-6: Risk Level Computation
+Risk levels computed from the OWASP 3x3 matrix:
+
+|  | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
+### FR-7: OWASP Framework References
+Each agent's findings must include references to established AI security frameworks:
+
+- **LLM agents**: OWASP LLM Top 10 v2025 (LLM01:2025 through LLM10:2025)
+- **Agentic agents**: OWASP Top 10 for Agentic Applications 2026 (ASI01 through ASI10)
+- **MCP-related findings**: OWASP MCP Top 10 2025 (MCP01:2025 through MCP10:2025)
+- **Cross-references**: CWE identifiers for vulnerability classification, MITRE ATLAS for AI attack taxonomy
+
+### FR-8: Detection Patterns Per Agent
+Each agent must include detailed detection patterns organized by attack category:
+
+- **Prompt Injection**: Direct injection, indirect injection (via documents/URLs), jailbreaking, system prompt extraction, cross-plugin injection
+- **Data Poisoning**: Training data manipulation, RAG index poisoning, knowledge base corruption, fine-tuning supply chain attacks, context window contamination
+- **Model Theft**: Model extraction via API queries, model weight exfiltration, unbounded inference consumption, model supply chain compromise
+- **Agent Autonomy**: Excessive autonomy, goal misalignment, unconstrained action scope, missing human-in-the-loop, cascading failures across agents, autonomous resource consumption
+- **Tool Abuse**: Unauthorized tool invocation, capability escalation, parameter injection, tool chain manipulation, tool poisoning (direct, shadowing, rug pulls)
+
+### FR-9: Empty Results for Non-AI Architectures
+AI agents MUST produce empty results (no findings) when the input architecture contains no AI/LLM/agentic components. This ensures the toolkit doesn't generate false positives for purely traditional systems.
+
+---
+
+## Non-Functional Requirements
+
+### Prompt Quality
+- Agent prompts must be clear enough for any LLM (Claude, GPT-4, Gemini) to follow without ambiguity
+- Detection patterns must be specific enough to produce targeted findings, not vague enough to produce generic ones
+- Finding templates must be unambiguous — the output format is deterministic given a component and threat
+
+### Platform Neutrality
+- Agents are markdown prompt files, not application code
+- No references to specific platforms, IDEs, or invocation frameworks
+- Works with any LLM capable of following structured markdown prompts
+
+### Consistency with STRIDE Agents
+- All 5 AI agents follow identical structure to STRIDE agents: frontmatter, purpose, detection scope, patterns, finding template, risk computation, references
+- Frontmatter schema is consistent across all agents (agent_name, category, threat_class, dfd_targets, owasp_references, output_schema)
+
+### OWASP Accuracy
+- All OWASP reference IDs must use official formats: LLM0x:2025, ASIxx, MCPxx:2025
+- Category mappings must align with official OWASP documentation
+- Detection patterns must reflect actual OWASP-documented attack vectors, not invented ones
+
+---
+
+## Success Metrics
+
+### Primary Metrics
+
+**Component Specificity Rate**: 100% of findings reference a named component from input
+- **Baseline**: Not yet validated
+- **Target**: 100% (zero generic findings)
+- **Measurement**: Run all 5 agents against sample input, count findings with/without specific component references
+
+**AI Category Coverage**: Both AI categories (AG, LLM) produce at least 1 finding for applicable components
+- **Baseline**: Not yet validated
+- **Target**: 2/2 categories produce findings for AI architectures; 0/2 for non-AI architectures
+- **Measurement**: Run orchestrator end-to-end against agentic architecture, verify both AG and LLM tables have findings
+
+**Schema Compliance**: 100% of findings conform to `schemas/finding.yaml`
+- **Baseline**: Not yet validated
+- **Target**: 100%
+- **Measurement**: Validate each finding's fields against schema definition
+
+### Secondary Metrics
+
+**OWASP Reference Coverage**: Every finding includes at least one OWASP reference ID
+- **Target**: 100% of findings include LLM0x:2025, ASIxx, or MCPxx:2025 references
+- **Measurement**: Check `references` field in each finding for OWASP ID presence
+
+**DFD Element Accuracy**: 0 findings produced for DFD element types outside the agent's assigned scope
+- **Target**: 0 out-of-scope findings
+- **Measurement**: Cross-reference each finding's `dfd_element_type` against the agent's `dfd_targets` frontmatter
+
+---
+
+## Scope & Boundaries
+
+### In Scope (This Feature)
+
+**Must Have (P0)**:
+- All 5 AI agent prompt files validated and complete
+- Each agent targets correct DFD element types per interface contract
+- All findings reference specific components from input architecture
+- Consistent finding format across all 5 agents (conforming to `schemas/finding.yaml`)
+- OWASP reference IDs in every finding (LLM0x:2025, ASIxx, MCPxx:2025)
+- End-to-end validation: orchestrator dispatches to AI agents and assembles valid AG and LLM tables in `threats.md`
+- Empty results for non-AI architectures
+
+**Should Have (P1)**:
+- MITRE ATLAS cross-references for AI attack taxonomy
+- CWE identifiers for vulnerability classification where applicable
+
+### Out of Scope (Future Features)
+
+- Deduplication and risk rating refinement across STRIDE + AI findings (future feature)
+- Platform-specific adapters for dispatching agents (F-009)
+- Custom AI threat categories beyond OWASP frameworks
+- Agent prompt fine-tuning for specific LLM providers
+- Additional AI agent categories (e.g., multimodal threats, embedding attacks)
+
+### Assumptions
+- The orchestrator (F-003) correctly parses architecture input and dispatches to AI agents based on keyword detection
+- The `schemas/finding.yaml` schema supports AI categories (`llm`, `agentic`) and ID prefixes (`LLM-N`, `AG-N`)
+- The sample architecture in `examples/mermaid-agentic-app/input.md` contains sufficient AI/LLM/agentic components for validation
+- STRIDE agents (F-005) are delivered and stable — AI agents follow the same validated pattern
+
+### Constraints
+
+**Technical Constraints**:
+- Agents are markdown prompt files only — no application code, no runtime dependencies
+- Output must conform to existing `schemas/finding.yaml` without schema modifications
+- Agents must work within the orchestrator's existing dispatch protocol (F-003)
+- AI agents must coexist with STRIDE agents — no conflicts in finding ID namespaces
+
+**External Dependencies**:
+- F-001 (delivered): Repository skeleton, interface contract, schemas
+- F-003 (delivered): Orchestrator with AI agent dispatch logic
+- F-005 (delivered): STRIDE agents (same pattern, validated)
+
+---
+
+## Interface Contract
+
+### Produces
+- `agents/ai/prompt-injection.md` — Prompt Injection threat agent (validated)
+- `agents/ai/data-poisoning.md` — Data & Model Poisoning threat agent (validated)
+- `agents/ai/model-theft.md` — Model Theft & Abuse threat agent (validated)
+- `agents/ai/agent-autonomy.md` — Agent Autonomy threat agent (validated)
+- `agents/ai/tool-abuse.md` — Tool Misuse & Exploitation threat agent (validated)
+
+### Consumes
+- `schemas/finding.yaml` — Finding output schema
+- `schemas/input.yaml` — Architecture input schema
+- `docs/INTERFACE-CONTRACT.md` — Interface contract specification (Section 3: AI Extension Dispatch Rules)
+- `examples/mermaid-agentic-app/input.md` — Sample architecture for validation
+
+### Output Format
+AI agents produce findings in two output tables:
+
+**Agentic Threats (AG)**:
+
+| ID | Component | Threat | OWASP Ref | Likelihood | Impact | Risk | Mitigation |
+|----|-----------|--------|-----------|------------|--------|------|------------|
+| AG-1 | {Named Component} | {Specific threat} | ASI-01 | HIGH | HIGH | Critical | {Actionable countermeasure} |
+
+**LLM Threats (LLM)**:
+
+| ID | Component | Threat | OWASP Ref | Likelihood | Impact | Risk | Mitigation |
+|----|-----------|--------|-----------|------------|--------|------|------------|
+| LLM-1 | {Named Component} | {Specific threat} | LLM01:2025 | HIGH | HIGH | Critical | {Actionable countermeasure} |
+
+---
+
+## Risks & Dependencies
+
+### Technical Risks
+
+**Risk 1**: Agent prompts produce generic rather than component-specific findings
+- **Likelihood**: Medium
+- **Impact**: High
+- **Mitigation**: Quality guardrail in each agent requiring component name from input; validation against sample architecture; same guardrail pattern validated in F-005
+- **Contingency**: Refine detection patterns with more specific component-targeting instructions
+
+**Risk 2**: OWASP framework mappings become outdated
+- **Likelihood**: Low
+- **Impact**: Medium
+- **Mitigation**: Pin to specific versions (LLM Top 10 v2025, Agentic Top 10 2026, MCP Top 10 v0.1 Beta); document update process
+- **Contingency**: Version lock references; update agents when new OWASP versions are published
+
+**Risk 3**: Overlap between AI agents and STRIDE agents produces duplicate findings
+- **Likelihood**: Medium
+- **Impact**: Low
+- **Mitigation**: Clear scope boundaries per agent; deduplication is a future feature operating on combined output
+- **Contingency**: Accept minor overlap in initial release; dedup feature will resolve
+
+### Dependencies
+
+**Internal Dependencies**:
+- **F-001 (delivered)**: Repository skeleton, schemas, interface contract
+- **F-003 (delivered)**: Orchestrator AI dispatch logic and keyword detection
+- **F-005 (delivered)**: STRIDE agents — validates the agent pattern this feature follows
+
+**Dependency Graph**:
+```
+F-001 (Skeleton) ─── delivered
+  └─ F-003 (Orchestrator) ─── delivered
+       ├─ F-005 (STRIDE Agents) ─── delivered
+       └─ F-007 (AI Threat Agents) ◄── THIS FEATURE
+            └─ Dedup & Risk Rating (future) ─── blocked
+```
+
+---
+
+## Open Questions
+
+- [ ] Should AI agents detect threats in non-AI components that interact with AI (e.g., a database storing model outputs)? — architect — 2026-03-29
+- [ ] Should cross-references between AI and STRIDE categories be noted in findings (e.g., a prompt injection finding that also has Tampering implications)? — architect — 2026-03-29
+- [ ] What is the minimum number of OWASP references per finding — 1 or should agents aim for comprehensive cross-referencing? — product-manager — 2026-03-29
+
+---
+
+## References
+
+### Product Documentation
+- Product Vision: [product-vision.md](../01_Product_Vision/product-vision.md)
+- STRIDE Agents PRD: [005-stride-threat-agents-2026-03-21.md](005-stride-threat-agents-2026-03-21.md)
+- Orchestrator PRD: [003-orchestrator-agent-2026-03-21.md](003-orchestrator-agent-2026-03-21.md)
+
+### Technical Documentation
+- Interface Contract: [INTERFACE-CONTRACT.md](../../INTERFACE-CONTRACT.md) (Section 3: AI Extension Dispatch Rules)
+- Finding Schema: [schemas/finding.yaml](../../../schemas/finding.yaml)
+- Input Schema: [schemas/input.yaml](../../../schemas/input.yaml)
+- Output Schema: [schemas/output.yaml](../../../schemas/output.yaml)
+- Output Template: [templates/threats.md](../../../templates/threats.md)
+
+### Research & Analysis
+- Consumer Guide Research: [CONSUMER_GUIDE_TACHI_RESEARCH.md](../../guides/CONSUMER_GUIDE_TACHI_RESEARCH.md)
+  - Section 2: OWASP Top 10 for LLM Applications v2025 (LLM01-LLM10)
+  - Section 3: OWASP Top 10 for Agentic Applications 2026 (ASI01-ASI10)
+  - Section 4: OWASP MCP Top 10 2025 (MCP01-MCP10)
+  - Section 13: Consumer Guide Corrections (ID format, coverage gaps)
+- Consumer Guide: [CONSUMER_GUIDE_TACHI.md](../../guides/CONSUMER_GUIDE_TACHI.md)
+
+### External Resources
+- OWASP Top 10 for LLM Applications v2025: https://genai.owasp.org/llm-top-10/
+- OWASP Top 10 for Agentic Applications 2026: https://genai.owasp.org/agentic-top-10/
+- OWASP MCP Top 10 2025: https://owasp.org/www-project-model-context-protocol-top-10/
+- MITRE ATLAS (Adversarial Threat Landscape for AI Systems): https://atlas.mitre.org/

--- a/docs/product/02_PRD/INDEX.md
+++ b/docs/product/02_PRD/INDEX.md
@@ -5,6 +5,7 @@
 
 | # | Feature | PM | Architect | Team-Lead | Status | Date |
 |---|---------|----|-----------|-----------| -------|------|
+| 007 | [AI Threat Agents](007-ai-threat-agents-2026-03-22.md) | ✓ | ⚠ | ⚠ | Approved | 2026-03-22 |
 | 005 | [STRIDE Threat Agents](005-stride-threat-agents-2026-03-21.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-22 |
 | 003 | [Orchestrator Agent](003-orchestrator-agent-2026-03-21.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-21 |
 | 001 | [Project Skeleton & Interface Contract](001-project-skeleton-interface-contract-2026-03-21.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-21 |

--- a/docs/product/_backlog/BACKLOG.md
+++ b/docs/product/_backlog/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-> Auto-generated from GitHub Issues on 2026-03-22T15:30:21Z.
+> Auto-generated from GitHub Issues on 2026-03-22T16:30:53Z.
 > Source of truth: GitHub Issues with `stage:*` labels.
 > Regenerate: `/aod.status` or `.aod/scripts/bash/backlog-regenerate.sh`
 
@@ -40,6 +40,7 @@
 
 | # | Title | State | Updated |
 |---|-------|-------|---------|
+| #7 | AI Threat Agents | OPEN | 2026-03-22 |
 | #5 | STRIDE Threat Agents | CLOSED | 2026-03-22 |
 | #3 | Orchestrator Agent | CLOSED | 2026-03-22 |
 | #1 | Project Skeleton & Interface Contract | CLOSED | 2026-03-21 |

--- a/specs/007-ai-threat-agents/NEXT-SESSION.md
+++ b/specs/007-ai-threat-agents/NEXT-SESSION.md
@@ -1,0 +1,68 @@
+# Session Continuation: AI Threat Agents (Feature 007)
+
+**Generated**: 2026-03-22
+**Branch**: `007-ai-threat-agents`
+**Last Commit**: 7d20b09 docs(005): regenerate BACKLOG.md after issue closure
+
+## Completed Across Sessions
+
+### Session 1 (Waves 1-3)
+- Wave 1 (T001-T010): Setup verification + structural audit — all 5 agents verified, Risk Level Computation sections added
+- Wave 2 (T011-T038): Content validation (agentic + LLM agents) + dispatch validation — detection patterns, finding templates, OWASP references, empty results guidance all verified/fixed
+- Wave 3 (T029-T034): Cross-agent consistency — section organization, finding templates, ID prefixes, category values, risk matrices, schema references all consistent
+- P0 Checkpoint: Architect APPROVED_WITH_CONCERNS (2 low concerns, both resolved in Wave 3)
+
+### Session 2 (Waves 4-5 + Final Validation)
+- Wave 4 (T039-T045): E2E integration — orchestrator dispatch traced against example input, AG+LLM tables verified, component specificity 100%, risk levels correct, namespace separation confirmed, empty results for non-AI components verified
+- Wave 5 (T046-T048): Polish — MITRE ATLAS refs verified on all 5 agents, CWE-200 added to model-theft, CWE-345 added to data-poisoning, README mapping accuracy confirmed
+- P1 Checkpoint + Final Validation (parallel):
+  - Architect: APPROVED (1 low observation)
+  - Code Reviewer: APPROVED (4 suggestions, 0 blocking)
+  - Security Analyst: PASS (2 informational/LOW, 0 blocking)
+
+### Key Changes Made (Both Sessions)
+- Added Risk Level Computation (OWASP 3x3 matrix) to all 5 agents
+- Expanded tool-abuse tool poisoning to 3 sub-types (direct, shadowing, rug pull)
+- Added attacker action + trust assumption language to agentic finding templates
+- Added cross-plugin injection pattern to prompt-injection agent
+- Added unbounded inference consumption + model supply chain compromise to model-theft
+- Added missing OWASP references: ASI-06/08/09/10, MCP-05, LLM07, LLM04, LLM08, LLM03
+- Added Empty Results Guidance to all 5 agents
+- Normalized heading levels for Empty Results Guidance across all agents
+- Added CWE-200 to model-theft, CWE-345 to data-poisoning
+
+## Current State
+
+- **Phase**: implement (complete)
+- **Uncommitted**: 12 files (5 agent files, 3 docs files, PRD, specs directory, wave results)
+- **Tasks**: 48/48 complete (100%)
+- **Final Validation**: All 3 reviewers APPROVED with 0 blocking issues
+
+## Next Actions
+
+1. **Step 6: Security Scan** — Run `/security` for SAST/SCA analysis (optional for markdown-only project)
+2. **Commit all changes** — Stage and commit all modified + untracked files
+3. **Create PR** — Push branch and create pull request
+4. **`/aod.deliver`** — Close feature with documentation updates
+5. **`/aod.document`** — Human-driven quality review (optional)
+
+## Context Files
+
+- `specs/007-ai-threat-agents/spec.md` — Feature specification (5 user stories, 14 FRs)
+- `specs/007-ai-threat-agents/plan.md` — Implementation plan (4-wave validation framework)
+- `specs/007-ai-threat-agents/tasks.md` — Task breakdown (48 tasks, 48 complete)
+- `specs/007-ai-threat-agents/agent-assignments.md` — Wave strategy (5 waves, 4 agents)
+- `specs/007-ai-threat-agents/research.md` — OWASP framework references
+- `specs/007-ai-threat-agents/data-model.md` — Agent inventory + DFD targeting matrix
+- `specs/007-ai-threat-agents/wave1-setup-results.md` — Wave 1 Phase 1 results
+- `specs/007-ai-threat-agents/wave1-structural-results.md` — Wave 1 Phase 2 results
+- `specs/007-ai-threat-agents/wave2-trackA-results.md` — Track A (agentic) results
+- `specs/007-ai-threat-agents/wave2-trackB-results.md` — Track B (LLM) results
+- `specs/007-ai-threat-agents/wave2-trackC-results.md` — Track C (dispatch) results
+- `specs/007-ai-threat-agents/wave3-consistency-results.md` — Wave 3 results
+- `specs/007-ai-threat-agents/wave4-e2e-results.md` — Wave 4 E2E integration results
+- `specs/007-ai-threat-agents/wave5-polish-results.md` — Wave 5 polish results
+- `.aod/results/architect-p0-checkpoint.md` — P0 checkpoint review
+- `.aod/results/architect-p1-final.md` — P1 + final architect review
+- `.aod/results/code-reviewer-p1-final.md` — Final code review
+- `.aod/results/security-analyst-p1-final.md` — Final security review

--- a/specs/007-ai-threat-agents/agent-assignments.md
+++ b/specs/007-ai-threat-agents/agent-assignments.md
@@ -1,0 +1,269 @@
+# Agent Assignments: Feature 007 — AI Threat Agents
+
+**Created**: 2026-03-22
+**Author**: team-lead
+**Feasibility**: APPROVED (90% confidence, 1 sprint)
+**Source**: `specs/007-ai-threat-agents/tasks.md` (48 tasks, 8 phases)
+
+---
+
+## Wave Strategy
+
+```
+Wave 1: Setup + Structural Audit (T001-T010)
+    |
+Wave 2: Agent Validation + Dispatch Validation (T011-T038) -- PARALLEL
+    |    Track A: Agentic Agents (T011-T018)
+    |    Track B: LLM Agents (T019-T028)
+    |    Track C: Dispatch Validation (T035-T038)
+    |
+Wave 3: Cross-Agent Consistency (T029-T034)
+    |
+Wave 4: E2E Integration (T039-T045)
+    |
+Wave 5: Polish (T046-T048)
+```
+
+---
+
+## Wave 1: Setup + Structural Audit
+
+**Phases**: Phase 1 (Setup) + Phase 2 (Foundational)
+**Tasks**: T001-T010 (10 tasks)
+**Estimated Duration**: 45 minutes wall-clock
+
+### Agent Assignment
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T001 | Verify schemas/finding.yaml supports AI categories | security-analyst | Schema validation requires understanding of AI threat taxonomy |
+| T002 [P] | Verify INTERFACE-CONTRACT.md Section 3 dispatch keywords | security-analyst | Interface contract verification, security domain knowledge |
+| T003 [P] | Verify example input contains AI/LLM/agentic components | security-analyst | Content verification against validation requirements |
+| T004 [P] | Verify all 5 AI agent files exist | security-analyst | File inventory check |
+| T005 [P] | Audit frontmatter: agent-autonomy.md | senior-backend-engineer | Structured YAML frontmatter validation |
+| T006 [P] | Audit frontmatter: tool-abuse.md | senior-backend-engineer | Structured YAML frontmatter validation |
+| T007 [P] | Audit frontmatter: prompt-injection.md | senior-backend-engineer | Structured YAML frontmatter validation |
+| T008 [P] | Audit frontmatter: data-poisoning.md | senior-backend-engineer | Structured YAML frontmatter validation |
+| T009 [P] | Audit frontmatter: model-theft.md | senior-backend-engineer | Structured YAML frontmatter validation |
+| T010 [P] | Audit section structure: all 5 agents | senior-backend-engineer | Canonical section order verification |
+
+### Execution Notes
+
+- T001-T004 can run in parallel (different files, read-only verification)
+- T005-T010 can all run in parallel (different agent files, no cross-dependencies)
+- T001-T004 and T005-T010 are sequential: Setup must complete before Structural Audit
+
+### Quality Gate
+
+**Checkpoint**: All 5 agents pass structural audit -- frontmatter correct, sections in order.
+**Gate Owner**: team-lead
+**Criteria**: Zero structural defects remaining. Content validation may begin.
+
+---
+
+## Wave 2: Agent Validation + Dispatch Validation (PARALLEL)
+
+**Phases**: Phase 3 (US1) + Phase 4 (US2) + Phase 6 (US4)
+**Tasks**: T011-T028 (18 tasks) + T035-T038 (4 tasks) = 22 tasks
+**Estimated Duration**: 75 minutes wall-clock (tracks run in parallel)
+
+### Track A: Agentic Agent Validation (US1)
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T011 [P] | Validate detection patterns: agent-autonomy.md | security-analyst | AI threat pattern expertise, OWASP Agentic knowledge |
+| T012 [P] | Validate detection patterns: tool-abuse.md | security-analyst | MCP/tool threat pattern expertise |
+| T013 | Verify finding template: agent-autonomy.md | security-analyst | Component-specificity and trust assumption review |
+| T014 | Verify finding template: tool-abuse.md | security-analyst | Component-specificity and trust assumption review |
+| T015 | Verify OWASP references: agent-autonomy.md | security-analyst | ASI reference verification |
+| T016 | Verify OWASP references: tool-abuse.md | security-analyst | ASI/MCP reference verification |
+| T017 | Verify empty results guidance: agent-autonomy.md | security-analyst | False positive prevention |
+| T018 | Verify empty results guidance: tool-abuse.md | security-analyst | False positive prevention |
+
+### Track B: LLM Agent Validation (US2)
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T019 [P] | Validate detection patterns: prompt-injection.md | security-analyst | LLM threat pattern expertise |
+| T020 [P] | Validate detection patterns: data-poisoning.md | security-analyst | Data/model poisoning expertise |
+| T021 [P] | Validate detection patterns: model-theft.md | security-analyst | Model extraction expertise |
+| T022 | Verify finding template: prompt-injection.md | security-analyst | Component-specificity review |
+| T023 | Verify finding template: data-poisoning.md | security-analyst | Component-specificity review |
+| T024 | Verify finding template: model-theft.md | security-analyst | Component-specificity review |
+| T025 [P] | Verify OWASP references: prompt-injection.md | security-analyst | LLM0x reference verification |
+| T026 [P] | Verify OWASP references: data-poisoning.md | security-analyst | LLM0x reference verification |
+| T027 [P] | Verify OWASP references: model-theft.md | security-analyst | LLM0x reference verification |
+| T028 | Verify empty results guidance: all 3 LLM agents | security-analyst | False positive prevention |
+
+### Track C: Dispatch Validation (US4)
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T035 | Verify Layer 1 dispatch keywords match orchestrator | senior-backend-engineer | Interface contract cross-reference |
+| T036 | Verify Layer 2 keywords extend (not conflict) Layer 1 | senior-backend-engineer | Keyword conflict detection |
+| T037 | Verify dual-dispatch behavior | senior-backend-engineer | Orchestrator logic verification |
+| T038 | Verify dispatch matrix against example input | senior-backend-engineer | End-to-end keyword trace |
+
+### Execution Notes
+
+- Track A and Track B run simultaneously (different agent files, zero overlap)
+- Track C runs simultaneously with A+B (reads orchestrator.md and INTERFACE-CONTRACT.md, not agents/ai/*)
+- Within Track A: T011, T012 can run in parallel; T013-T018 are sequential per-agent
+- Within Track B: T019-T021 can run in parallel; T025-T027 can run in parallel
+- Track C is sequential (each task builds on prior understanding)
+
+### Quality Gate
+
+**Checkpoint**: Both agentic agents validated (US1), all 3 LLM agents validated (US2), dispatch verified (US4).
+**Gate Owner**: team-lead
+**Criteria**: AG-prefixed findings are component-specific, schema-compliant, OWASP-grounded. LLM-prefixed findings same. Dispatch matrix matches expected behavior.
+
+---
+
+## Wave 3: Cross-Agent Consistency
+
+**Phase**: Phase 5 (US3)
+**Tasks**: T029-T034 (6 tasks)
+**Estimated Duration**: 25 minutes wall-clock
+
+### Agent Assignment
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T029 | Cross-check section organization: all 5 agents | code-reviewer | Cross-file structural consistency |
+| T030 | Cross-check finding templates: all 5 agents | code-reviewer | Field name/count consistency |
+| T031 | Verify ID prefix conventions | code-reviewer | AG-N vs LLM-N convention check |
+| T032 | Verify category field values | code-reviewer | Enum value consistency |
+| T033 | Verify risk computation sections | code-reviewer | OWASP 3x3 matrix consistency |
+| T034 | Verify output_schema references | code-reviewer | Frontmatter cross-reference |
+
+### Execution Notes
+
+- All tasks are sequential (each is a cross-agent comparison operation)
+- Single agent handles all consistency checks for uniform evaluation criteria
+
+### Quality Gate
+
+**Checkpoint**: All 5 agents produce format-consistent findings.
+**Gate Owner**: team-lead
+**Criteria**: Identical section organization, identical field names, correct ID prefixes, correct category values, identical risk matrix, consistent schema references.
+
+---
+
+## Wave 4: End-to-End Integration
+
+**Phase**: Phase 7 (US5)
+**Tasks**: T039-T045 (7 tasks)
+**Estimated Duration**: 40 minutes wall-clock
+
+### Agent Assignment
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T039 | Run orchestrator, verify AG threat table | orchestrator | Executes the dispatch protocol being validated |
+| T040 | Verify LLM threat table in output | orchestrator | Validates LLM agent assembly |
+| T041 | Verify 100% component specificity | orchestrator | Quality guardrail validation |
+| T042 | Verify risk_level matches 3x3 matrix | orchestrator | Computation correctness |
+| T043 | Verify coverage matrix (dual-dispatch, agentic-only) | orchestrator | Dispatch accuracy validation |
+| T044 | Verify finding ID namespace separation | orchestrator | AG/LLM vs S/T/R/I/D/E conflict check |
+| T045 | Verify empty results for non-AI components | orchestrator | False positive prevention |
+
+### Execution Notes
+
+- T039 must run first (produces the output file all other tasks validate)
+- T040-T045 could theoretically run in parallel once T039 completes, but sequential is acceptable given the same output file
+- This wave requires the orchestrator agent because it must execute the actual dispatch protocol
+
+### Quality Gate
+
+**Checkpoint**: End-to-end integration validated -- complete threat model with 8 tables (6 STRIDE + 2 AI).
+**Gate Owner**: team-lead
+**Criteria**: AG and LLM tables present with findings, 100% component specificity, correct risk levels, no namespace conflicts, empty results for non-AI components.
+
+---
+
+## Wave 5: Polish
+
+**Phase**: Phase 8
+**Tasks**: T046-T048 (3 tasks)
+**Estimated Duration**: 15 minutes wall-clock
+
+### Agent Assignment
+
+| Task | Description | Agent | Rationale |
+|------|-------------|-------|-----------|
+| T046 [P] | Add MITRE ATLAS cross-references | senior-backend-engineer | Reference addition, P1 |
+| T047 [P] | Add CWE identifiers | senior-backend-engineer | Reference addition, P1 |
+| T048 | Verify agents/ai/README.md accuracy | code-reviewer | Documentation consistency check |
+
+### Execution Notes
+
+- T046 and T047 can run in parallel (different reference types, same files but different sections)
+- T048 is sequential (depends on all prior waves completing)
+
+### Quality Gate
+
+**Checkpoint**: Feature complete.
+**Gate Owner**: team-lead
+**Criteria**: P1 cross-references added where applicable, README documentation accurate.
+
+---
+
+## Summary: Agent Workload Distribution
+
+| Agent | Waves | Task Count | Load % | Role |
+|-------|-------|------------|--------|------|
+| security-analyst | 1, 2 | 22 | 46% | Setup verification, all agent content validation (Tracks A+B) |
+| senior-backend-engineer | 1, 2, 5 | 12 | 25% | Frontmatter audit, dispatch validation, P1 references |
+| code-reviewer | 3, 5 | 7 | 15% | Cross-agent consistency, documentation verification |
+| orchestrator | 4 | 7 | 15% | E2E integration validation |
+| **Total** | | **48** | **100%** | |
+
+### Workload Balance Assessment
+
+- **security-analyst at 46%**: This is the correct assignment. The core value of this feature is validating AI threat agent content quality (detection patterns, finding templates, OWASP references). The security-analyst has the domain expertise to evaluate whether OWASP AI framework references are correctly applied, detection patterns cover the right attack subcategories, and findings demonstrate proper threat + trust assumption formulation. No other agent in the registry has this expertise.
+- **No agent exceeds 80% load**: Within target.
+- **No agent is idle across waves**: Each agent is utilized in non-overlapping waves, preventing bottlenecks.
+- **Sequential wave execution**: Agents are not double-booked. security-analyst finishes Waves 1-2 before code-reviewer starts Wave 3.
+
+### Agent Selection Rationale
+
+| Agent | Why Selected | Why Not Alternatives |
+|-------|-------------|---------------------|
+| security-analyst | Domain expertise in OWASP AI frameworks, threat patterns, and finding quality | No other agent understands AI threat taxonomy, OWASP ASI/LLM/MCP references, or component-specificity requirements for security findings |
+| senior-backend-engineer | Structured content validation (YAML frontmatter, keyword matching, reference insertion) | Tasks are structural, not security-analytical; code-reviewer would over-focus on style |
+| code-reviewer | Cross-file consistency checks requiring uniform evaluation criteria | Purpose-built for comparing structure across files and flagging inconsistencies |
+| orchestrator | Executes the actual dispatch protocol being validated | No other agent can run the orchestrator against sample input; tester could verify outputs independently but cannot execute dispatch |
+
+### Agents NOT Assigned (with justification)
+
+| Agent | Why Not Used |
+|-------|-------------|
+| product-manager | No scope decisions needed; requirements already defined |
+| architect | No technical design decisions; architecture already established |
+| team-lead | Governance only; does not execute tasks |
+| frontend-developer | No frontend work |
+| ux-ui-designer | No UI/UX work |
+| tester | Validation is inline (prompt files, not code); could supplement Wave 4 but orchestrator is primary |
+| debugger | No bugs to investigate |
+| devops | No deployment |
+| web-researcher | No external research needed; OWASP references already documented in research.md |
+
+---
+
+## Timeline Summary
+
+| Wave | Duration (Wall-Clock) | Cumulative | Blocking |
+|------|----------------------|------------|----------|
+| Wave 1: Setup + Structural | 45 min | 0:45 | Blocks Wave 2 |
+| Wave 2: Validation (parallel) | 75 min | 2:00 | Blocks Wave 3 |
+| Wave 3: Consistency | 25 min | 2:25 | Blocks Wave 4 |
+| Wave 4: E2E Integration | 40 min | 3:05 | Blocks Wave 5 |
+| Wave 5: Polish | 15 min | 3:20 | None |
+| **Total** | **3 hours 20 min** | | |
+
+**Sprint fit**: 3.3 hours wall-clock comfortably fits within 1 sprint. Even with the pessimistic multiplier (1.5x), the estimate is ~5 hours -- still within a single sprint.
+
+---
+
+**End of Agent Assignments**

--- a/specs/007-ai-threat-agents/checklists/requirements.md
+++ b/specs/007-ai-threat-agents/checklists/requirements.md
@@ -1,0 +1,32 @@
+# Specification Quality Checklist: AI Threat Agents
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-03-22
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+- All items pass. Spec covers 5 user stories with 42 acceptance scenarios, 14 functional requirements, 10 success criteria, and 5 edge cases.
+- Open questions are deferred with owners and deadlines (2026-03-29) — appropriate for spec stage.
+- Spec mirrors validated F-005 structure exactly, adapted for AI threat agent domain.

--- a/specs/007-ai-threat-agents/data-model.md
+++ b/specs/007-ai-threat-agents/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: AI Threat Agents
+
+## Agent Inventory
+
+| Agent File | Category | Threat Class | ID Prefix | Lines | Status |
+|-----------|----------|-------------|-----------|-------|--------|
+| `agents/ai/prompt-injection.md` | llm | LLM | LLM-N | 134 | Exists, needs validation |
+| `agents/ai/data-poisoning.md` | llm | LLM | LLM-N | 143 | Exists, needs validation |
+| `agents/ai/model-theft.md` | llm | LLM | LLM-N | 147 | Exists, needs validation |
+| `agents/ai/agent-autonomy.md` | agentic | AG | AG-N | 168 | Exists, needs validation |
+| `agents/ai/tool-abuse.md` | agentic | AG | AG-N | 139 | Exists, needs validation |
+
+## DFD Targeting Validation Matrix
+
+| Agent | dfd_targets (Expected) | Rationale |
+|-------|----------------------|-----------|
+| prompt-injection | [Process] | LLM inference endpoints are processes receiving user input |
+| data-poisoning | [Data Store, Data Flow] | Poisoning targets training data stores and data flows feeding models |
+| model-theft | [Data Store, Process] | Model weights stored in data stores; inference endpoints expose model behavior |
+| agent-autonomy | [Process] | Autonomous agents are processes with decision-making capability |
+| tool-abuse | [Process] | Tool servers and plugin hosts are processes executing actions |
+
+## Finding IR Schema (read-only)
+
+Schema: `schemas/finding.yaml` v1.0 — 10 required fields
+
+| Field | Type | AI-Specific Notes |
+|-------|------|-------------------|
+| id | string | Pattern: `^(AG\|LLM)-\d+$` for AI agents |
+| category | string | `agentic` or `llm` for AI agents |
+| component | string | Must match named component from input — zero tolerance for generic names |
+| threat | string | Must describe attacker action + trust assumption violated |
+| likelihood | enum | LOW, MEDIUM, HIGH |
+| impact | enum | LOW, MEDIUM, HIGH |
+| risk_level | enum | Computed from OWASP 3x3 matrix |
+| mitigation | string | Must be actionable with specific technology/configuration |
+| references | list[string] | Required for AI categories — must include OWASP AI framework IDs |
+| dfd_element_type | enum | Must be within agent's `dfd_targets` scope |
+
+## OWASP AI Framework Coverage
+
+### LLM Top 10 v2025 (for LLM agents)
+
+| ID | Name | Mapped To Agent |
+|----|------|----------------|
+| LLM01:2025 | Prompt Injection | prompt-injection |
+| LLM03:2025 | Supply Chain | model-theft, data-poisoning |
+| LLM04:2025 | Data and Model Poisoning | data-poisoning |
+| LLM07:2025 | System Prompt Leakage | prompt-injection |
+| LLM08:2025 | Vector and Embedding Weaknesses | data-poisoning |
+| LLM10:2025 | Unbounded Consumption | model-theft |
+
+### Agentic Top 10 2026 (for agentic agents)
+
+| ID | Name | Mapped To Agent |
+|----|------|----------------|
+| ASI01 | Agent Goal Hijack | agent-autonomy |
+| ASI02 | Tool Misuse and Exploitation | tool-abuse |
+| ASI04 | Agentic Supply Chain Vulnerabilities | tool-abuse |
+| ASI06 | Memory and Context Poisoning | agent-autonomy |
+| ASI08 | Cascading Failures | agent-autonomy |
+| ASI09 | Human-Agent Trust Exploitation | agent-autonomy |
+| ASI10 | Rogue Agents | agent-autonomy |
+
+### MCP Top 10 2025 (for tool-abuse agent)
+
+| ID | Name | Mapped To Agent |
+|----|------|----------------|
+| MCP03:2025 | Tool Poisoning | tool-abuse |
+| MCP05:2025 | Command Injection and Execution | tool-abuse |

--- a/specs/007-ai-threat-agents/plan.md
+++ b/specs/007-ai-threat-agents/plan.md
@@ -1,0 +1,279 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-22
+    status: APPROVED
+    notes: "Plan covers 13/14 spec FRs fully, 1 partially (FR-010, low risk). All 5 user stories addressed. All 10 success criteria achievable. No scope creep. 2 low observations noted."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-22
+    status: APPROVED
+    notes: "Technically sound across all 7 evaluation criteria. DFD targeting matrix verified correct against all 5 agent files and interface contract. Four-wave structure well-sequenced. 2 informational observations, no corrections needed."
+  techlead_signoff: null
+---
+
+# Implementation Plan: AI Threat Agents
+
+**Branch**: `007-ai-threat-agents` | **Date**: 2026-03-22 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/007-ai-threat-agents/spec.md`
+
+## Summary
+
+Validate, complete, and integration-test all 5 AI threat agent prompt files (`agents/ai/*.md`) to ensure they produce component-specific, schema-compliant, OWASP-grounded findings when dispatched by the orchestrator (F-003) against architecture input containing AI/LLM/agentic components. The agents already exist with substantial content (134-168 lines each); this feature validates correctness, verifies DFD element targeting, confirms OWASP AI framework references, and performs end-to-end integration testing alongside the validated STRIDE agents (F-005).
+
+## Technical Context
+
+**Language/Version**: Markdown + YAML (no application code — agents are structured prompt files)
+**Primary Dependencies**: Orchestrator agent (`agents/orchestrator.md`, F-003 delivered), Finding IR schema (`schemas/finding.yaml` v1.0), STRIDE agents (`agents/stride/*.md`, F-005 delivered)
+**Storage**: Filesystem only (markdown files in `agents/ai/`)
+**Testing**: Validation-by-example — run agents against sample architectures, verify output against schema and quality criteria
+**Target Platform**: Any LLM capable of following structured markdown prompts (platform-neutral)
+**Project Type**: Content/prompt engineering (not application code)
+**Performance Goals**: N/A (no runtime performance — prompt quality measured by output correctness)
+**Constraints**: No schema modifications (`schemas/finding.yaml` is stable); agents must work within orchestrator's existing two-layer dispatch protocol; agents must coexist with STRIDE agents without ID namespace conflicts
+**Scale/Scope**: 5 agent files, ~731 total lines of existing content to validate and complete
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. General-Purpose Architecture | PASS | Agents are domain-agnostic AI threat analysis prompts, applicable to any architecture with AI/LLM/agentic components |
+| II. API-First Design | N/A | No API — agents are markdown prompt files |
+| III. Backward Compatibility | PASS | No changes to existing schemas, interface contract, or STRIDE agents |
+| IV. Concurrency & Data Integrity | N/A | No state management — agents produce stateless findings |
+| V. Privacy & Data Isolation | PASS | Agents analyze architecture descriptions, not user data; outputs marked `classification: "confidential"` |
+| VI. Testing Excellence | PASS | Validation approach: run against sample architectures, verify 100% schema compliance, component specificity, and OWASP reference coverage |
+| VII. Definition of Done | PASS | 3-step DoD: pushed to branch, tested via sample runs, user-validated via orchestrator integration |
+| VIII. Observability & Root Cause | N/A | No runtime operations |
+| IX. Git Workflow | PASS | Feature branch `007-ai-threat-agents`, PR required |
+| X. Product-Spec Alignment | PASS | Spec approved by PM (APPROVED_WITH_CONCERNS) |
+| XI. SDLC Triad Collaboration | PASS | PRD approved by full Triad; spec PM-approved; plan dual-reviewed |
+
+No violations. No complexity tracking needed.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/007-ai-threat-agents/
+├── plan.md              # This file
+├── research.md          # Research phase output (completed during /aod.spec)
+├── data-model.md        # Validation matrix and agent inventory
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Task breakdown (/aod.tasks output)
+```
+
+### Source Content (repository root)
+
+```
+agents/ai/
+├── prompt-injection.md      # LLM agent — validate & complete (134 lines)
+├── data-poisoning.md        # LLM agent — validate & complete (143 lines)
+├── model-theft.md           # LLM agent — validate & complete (147 lines)
+├── agent-autonomy.md        # AG agent — validate & complete (168 lines)
+└── tool-abuse.md            # AG agent — validate & complete (139 lines)
+
+schemas/
+├── finding.yaml             # Finding IR schema (read-only, no changes)
+├── input.yaml               # Input schema (read-only)
+└── output.yaml              # Output schema (read-only)
+
+examples/
+└── mermaid-agentic-app/     # Primary validation input (contains AI/LLM/agentic components)
+```
+
+**Structure Decision**: No new directories needed. All work modifies existing agent files in `agents/ai/` and creates validation artifacts in `specs/007-ai-threat-agents/`.
+
+## Components
+
+### Agent Validation Framework
+
+The validation approach follows the three-layer framework proven in F-005 (STRIDE agents):
+
+**Layer 1: Structural Audit** (per agent)
+- Frontmatter fields present and correct (`agent_name`, `category`, `threat_class`, `dfd_targets`, `owasp_references`, `output_schema`)
+- Section structure matches canonical organization (purpose, detection scope, patterns, finding template, risk computation, references)
+- `dfd_targets` matches interface contract AI extension dispatch rules
+
+**Layer 2: Content Quality** (per agent)
+- Detection patterns cover all attack subcategories from PRD FR-8
+- Finding template examples demonstrate component-specific threats (not generic)
+- Mitigation examples are actionable with specific technology references
+- Framework references include OWASP AI framework IDs (LLM0x:2025, ASI-xx, MCP-xx:2025)
+- Risk computation section includes correct OWASP 3x3 matrix
+- Agent-level trigger keywords (Layer 2 dispatch) extend orchestrator-level keywords (Layer 1 dispatch)
+
+**Layer 3: Integration Validation** (all agents together)
+- Run orchestrator against `examples/mermaid-agentic-app/input.md`
+- Verify AG and LLM tables have findings in assembled `threats.md`
+- Verify two-layer keyword dispatch: correct components activated for correct agent categories
+- Verify dual-dispatch behavior for components matching both LLM and agentic keywords
+- Verify 100% component specificity (zero generic findings)
+- Verify risk levels match OWASP 3x3 matrix computations
+- Verify empty results for non-AI components
+
+### AI Agent DFD Targeting Matrix
+
+Reference table for Layer 1 structural audit — each agent's `dfd_targets` must match:
+
+| Agent | category | threat_class | dfd_targets (expected) | OWASP Framework |
+|-------|----------|-------------|----------------------|-----------------|
+| prompt-injection.md | llm | LLM | [Process] | LLM Top 10 v2025 (LLM01) |
+| data-poisoning.md | llm | LLM | [Data Store, Data Flow] | LLM Top 10 v2025 (LLM03, LLM04) |
+| model-theft.md | llm | LLM | [Data Store, Process] | LLM Top 10 v2025 (LLM10) |
+| agent-autonomy.md | agentic | AG | [Process] | Agentic Top 10 (ASI01, ASI06, ASI08, ASI09, ASI10) |
+| tool-abuse.md | agentic | AG | [Process] | Agentic Top 10 (ASI02, ASI04), MCP Top 10 (MCP03) |
+
+### OWASP AI Framework Reference Completeness
+
+Current state — verify each agent references its primary OWASP framework:
+
+| Agent | Primary OWASP | Expected References | P1 Cross-References |
+|-------|---------------|--------------------|--------------------|
+| prompt-injection.md | LLM01:2025 | LLM01:2025, LLM07:2025 | MITRE ATLAS, CWE-77 |
+| data-poisoning.md | LLM04:2025 | LLM03:2025, LLM04:2025, LLM08:2025 | MITRE ATLAS, CWE-1321 |
+| model-theft.md | LLM10:2025 | LLM03:2025, LLM10:2025 | MITRE ATLAS, CWE-200 |
+| agent-autonomy.md | ASI01 | ASI01, ASI06, ASI08, ASI09, ASI10 | MITRE ATLAS |
+| tool-abuse.md | ASI02, MCP03 | ASI02, ASI04, MCP03:2025, MCP05:2025 | MITRE ATLAS |
+
+### Two-Layer Keyword Dispatch Validation Matrix
+
+Expected dispatch behavior for `examples/mermaid-agentic-app/input.md`:
+
+| Component | DFD Type | Layer 1 Keywords Matched | STRIDE Dispatch | AI Dispatch |
+|-----------|----------|-------------------------|----------------|------------|
+| User | External Entity | None | S, R | None |
+| LLM Agent Orchestrator | Process | "LLM" + "Agent" + "Orchestrator" | S, T, R, I, D, E | All 5 AI agents (dual-dispatch) |
+| MCP Tool Server | Process | "MCP" + "Tool Server" | S, T, R, I, D, E | agent-autonomy, tool-abuse |
+| Knowledge Base | Data Store | None | T, I, D | None |
+| External API | External Entity | None | S, R | None |
+
+## Data Flow
+
+```
+Architecture Input (any format)
+         │
+         ▼
+┌─────────────────────────────┐
+│ Orchestrator (F-003)        │
+│  Phase 1: Scope             │
+│  - Format detection         │
+│  - Component classification │
+│  - DFD element assignment   │
+└─────────┬───────────────────┘
+          │ dispatch per STRIDE-per-Element
+          │ + AI keyword dispatch (Layer 1)
+          ▼
+┌──────────────────┐    ┌──────────────────┐
+│ 6 STRIDE Agents  │    │ 5 AI Agents      │
+│ (F-005 validated)│    │ (F-007 — this)   │
+│                  │    │                  │
+│ Each agent:      │    │ Each agent:      │
+│ 1. Receives arch │    │ 1. Receives arch │
+│ 2. Filters by    │    │ 2. Filters by    │
+│    dfd_targets   │    │    dfd_targets   │
+│ 3. Applies       │    │ 3. Applies Layer │
+│    patterns      │    │    2 keywords    │
+│ 4. Produces      │    │ 4. Applies       │
+│    findings (IR) │    │    patterns      │
+│                  │    │ 5. Produces      │
+│                  │    │    findings (IR) │
+└────────┬─────────┘    └────────┬─────────┘
+         │                       │
+         └───────────┬───────────┘
+                     │ all findings per schemas/finding.yaml
+                     ▼
+┌─────────────────────────────┐
+│ Orchestrator (F-003)        │
+│  Phase 3-4: Assemble        │
+│  - Validate risk_level      │
+│  - Build 6 STRIDE tables    │
+│  - Build 2 AI tables        │
+│    (AG table + LLM table)   │
+│  - Generate coverage matrix │
+│  - Compute risk summary     │
+└─────────┬───────────────────┘
+          │
+          ▼
+    threats.md output
+    (8 threat tables total)
+```
+
+## Tech Stack
+
+| Component | Technology | Justification |
+|-----------|-----------|---------------|
+| Agent files | Markdown with YAML frontmatter | Platform-neutral, LLM-agnostic prompt format; matches F-005 STRIDE pattern |
+| Schema | YAML (`schemas/finding.yaml` v1.0) | Machine-readable validation contract; read-only for this feature |
+| Validation | Manual review + orchestrator integration run | No automated test framework needed for prompt files |
+| Version control | Git | Standard for content versioning |
+| OWASP references | LLM Top 10 v2025, Agentic Top 10 2026, MCP Top 10 2025 | Three complementary AI security frameworks covering model, agent, and protocol layers |
+
+## Implementation Approach
+
+### Wave 1: Structural Audit (all 5 agents in parallel)
+
+Audit each agent for structural compliance:
+1. Verify frontmatter fields match expected schema (6 fields: agent_name, category, threat_class, dfd_targets, owasp_references, output_schema)
+2. Verify section order matches canonical structure (purpose, detection scope, patterns, finding template, risk computation, references)
+3. Verify `dfd_targets` matches AI Agent DFD Targeting Matrix above
+4. Verify `category` field uses correct value (`llm` or `agentic`)
+5. Flag any structural gaps
+
+**Parallelizable**: All 5 agents can be audited simultaneously — no cross-dependencies.
+
+### Wave 2: Content Validation (Agentic + LLM agents in parallel tracks)
+
+**Track A — Agentic agents** (agent-autonomy, tool-abuse):
+1. Verify detection patterns cover all PRD FR-8 subcategories for each agent
+2. Verify finding template demonstrates component-specific threats (references named components, not generic descriptions)
+3. Verify OWASP Agentic Top 10 (ASI-xx) references are present and correctly formatted
+4. Verify OWASP MCP Top 10 (MCP-xx:2025) references for tool-abuse agent
+5. Verify mitigation examples are actionable (specific technology/configuration)
+6. Add P1 cross-references (MITRE ATLAS, CWE) if missing
+
+**Track B — LLM agents** (prompt-injection, data-poisoning, model-theft):
+1. Verify detection patterns cover all PRD FR-8 subcategories for each agent
+2. Verify finding template demonstrates component-specific threats
+3. Verify OWASP LLM Top 10 v2025 (LLM0x:2025) references are present and correctly formatted
+4. Verify mitigation examples are actionable
+5. Add P1 cross-references (MITRE ATLAS, CWE) if missing
+
+**Parallelizable**: Track A and Track B have no cross-dependencies — agentic and LLM agents are independent.
+
+### Wave 3: Cross-Agent Consistency Check
+
+After individual agent validation, verify consistency across all 5 agents:
+1. All agents follow identical section organization (FR-012)
+2. Finding ID prefix conventions are consistent (AG-N for agentic, LLM-N for LLM)
+3. Risk computation sections use identical OWASP 3x3 matrix
+4. All agents reference `schemas/finding.yaml` as output_schema
+5. Frontmatter field names are identical across all 5 agents
+6. Detection scope keywords don't conflict with each other or with orchestrator Layer 1 keywords
+
+### Wave 4: Integration Validation (sequential — depends on Waves 1-3)
+
+End-to-end validation using orchestrator:
+1. Run orchestrator against `examples/mermaid-agentic-app/input.md`
+2. Verify assembled `threats.md` has AG and LLM tables with findings
+3. Verify two-layer keyword dispatch: "LLM Agent Orchestrator" triggers all 5 AI agents (dual-dispatch), "MCP Tool Server" triggers only agentic agents, "Knowledge Base" triggers no AI agents
+4. Verify 100% component specificity (zero generic findings across AG and LLM tables)
+5. Verify risk_level computations match OWASP 3x3 matrix
+6. Verify finding ID namespaces don't conflict with STRIDE findings (AG/LLM prefixes vs S/T/R/I/D/E)
+7. Verify coverage matrix shows correct AI dispatch targeting
+8. Verify empty results scenario: confirm AI agents produce zero findings for non-AI components
+
+### Post-Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| III. Backward Compatibility | PASS | No schema changes; only agent content validation and completion |
+| VI. Testing Excellence | PASS | Multi-layer validation; integration testing against sample architecture |
+| X. Product-Spec Alignment | PASS | All 14 spec FRs addressed; all 10 success criteria measurable |
+
+No violations introduced by design.

--- a/specs/007-ai-threat-agents/research.md
+++ b/specs/007-ai-threat-agents/research.md
@@ -1,0 +1,111 @@
+# Research Summary: AI Threat Agents (Feature 007)
+
+## Knowledge Base Findings
+
+- **PAT-002 (Parallel Agent Validation)**: Three-layer validation framework from F-005 directly applies — Layer 1: Structural Audit (frontmatter, sections), Layer 2: Content Quality (detection patterns, component specificity), Layer 3: Integration Validation (orchestrator end-to-end)
+- **F-005 Delivery Report**: 41 tasks completed in ~1 day with 3-way parallelism using a 5-wave execution pattern. Same strategy applies to F-007's 5 agents
+- **ADR-003 (STRIDE-per-Element Dispatch)**: Defines the deterministic dispatch model — DFD type → STRIDE categories + AI keyword matching → AI agent categories
+- **Anti-patterns to avoid**: Generic findings without component references, missing framework grounding (CWE/OWASP), inconsistent risk scoring, LLM variability in output
+
+## Codebase Analysis
+
+### Existing STRIDE Agent Pattern (agents/stride/)
+- 6 agents (102-130 lines each) with consistent structure:
+  - YAML frontmatter (6 fields: agent_name, category, threat_class, dfd_targets, owasp_references, output_schema)
+  - Sections: Purpose → Detection Scope → Patterns and Indicators → Finding Template → Risk Level Computation → References
+- All reference `schemas/finding.yaml` as output schema
+
+### Current AI Agent Files (agents/ai/)
+- 5 agents already exist and are content-complete (134-168 lines each):
+  - `prompt-injection.md` (134 lines) — LLM01:2025 — targets Process
+  - `data-poisoning.md` (143 lines) — LLM03:2025/LLM04:2025 — targets Data Store, Data Flow
+  - `model-theft.md` (147 lines) — LLM10:2025 — targets Data Store, Process
+  - `agent-autonomy.md` (168 lines) — ASI01 — targets Process
+  - `tool-abuse.md` (139 lines) — MCP03:2025 — targets Process
+- Follow identical structure to STRIDE agents with AI-specific frontmatter
+
+### Finding Schema (schemas/finding.yaml)
+- 10 required fields: id, category, component, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type
+- AI categories supported: `agentic`, `llm`
+- ID pattern: `^(S|T|R|I|D|E|AG|LLM)-\d+$`
+
+### Orchestrator Dispatch (agents/orchestrator.md)
+- Four-phase OWASP workflow: Scope → Determine Threats → Determine Countermeasures → Assess
+- Two-layer AI dispatch: Layer 1 (orchestrator keywords) → Layer 2 (per-agent detection scope)
+- Supports parallel and sequential dispatch modes
+
+### Sample Architecture (examples/mermaid-agentic-app/input.md)
+- Contains: LLM Agent Orchestrator (dual-dispatch), MCP Tool Server (AG-dispatch), Knowledge Base, External API, User
+- Expected: 11 threat categories for LLM Agent Orchestrator, 8 for MCP Tool Server
+
+## Architecture Constraints
+
+- **docs/architecture/README.md**: ADR authority governs technical decisions; pattern catalog for reusable patterns
+- **docs/standards/DEFINITION_OF_DONE.md**: 3-step DoD validation (pushed to production, tested, user validated). For documentation/prompt-file features, DoD may adapt
+- **docs/standards/TRIAD_COLLABORATION.md**: Feature PRD follows parallel review (PM + Architect + Tech-Lead)
+- **ADR-003**: STRIDE-per-Element normalization + AI keyword dispatch is the canonical dispatch model
+
+## Industry Research
+
+### OWASP Frameworks (Official Reference IDs)
+
+**OWASP LLM Top 10 v2025** (format: `LLM{NN}:2025`):
+- LLM01:2025 — Prompt Injection
+- LLM02:2025 — Sensitive Information Disclosure
+- LLM03:2025 — Supply Chain
+- LLM04:2025 — Data and Model Poisoning
+- LLM05:2025 — Improper Output Handling
+- LLM06:2025 — Excessive Agency
+- LLM07:2025 — System Prompt Leakage (new in 2025)
+- LLM08:2025 — Vector and Embedding Weaknesses (new in 2025)
+- LLM09:2025 — Misinformation
+- LLM10:2025 — Unbounded Consumption
+
+**OWASP Agentic Top 10 2026** (format: `ASI{NN}`):
+- ASI01 — Agent Goal Hijack
+- ASI02 — Tool Misuse and Exploitation
+- ASI03 — Identity and Privilege Abuse
+- ASI04 — Agentic Supply Chain Vulnerabilities
+- ASI05 — Unexpected Code Execution
+- ASI06 — Memory and Context Poisoning
+- ASI07 — Insecure Inter-Agent Communication
+- ASI08 — Cascading Failures
+- ASI09 — Human-Agent Trust Exploitation
+- ASI10 — Rogue Agents
+
+**OWASP MCP Top 10 2025** (format: `MCP{NN}:2025`):
+- MCP01:2025 — Token Mismanagement and Secret Exposure
+- MCP02:2025 — Privilege Escalation via Scope Creep
+- MCP03:2025 — Tool Poisoning
+- MCP04:2025 — Software Supply Chain Attacks
+- MCP05:2025 — Command Injection and Execution
+- MCP06:2025 — Prompt Injection via Contextual Payloads
+- MCP07:2025 — Insufficient Authentication and Authorization
+- MCP08:2025 — Lack of Audit and Telemetry
+- MCP09:2025 — Shadow MCP Servers
+- MCP10:2025 — Context Injection and Over-Sharing
+
+### Threat Category Cross-References
+| Pattern | LLM Top 10 | Agentic Top 10 | MCP Top 10 |
+|---------|------------|-----------------|------------|
+| Prompt Injection | LLM01:2025 | ASI01 | MCP06:2025 |
+| Supply Chain | LLM03:2025 | ASI04 | MCP04:2025 |
+| Excessive Autonomy | LLM06:2025 | ASI02, ASI10 | MCP02:2025 |
+| Data/Context Poisoning | LLM04:2025, LLM08:2025 | ASI06 | MCP03:2025 |
+| Code Execution | LLM05:2025 | ASI05 | MCP05:2025 |
+
+### Complementary Frameworks
+- **MAESTRO** (Cloud Security Alliance): Seven-layer agentic AI reference architecture
+- **ASTRIDE** (arXiv 2512.04785): Extends STRIDE with "A" category for AI agent-specific attacks
+- **MITRE ATLAS**: Adversarial AI attack taxonomy with techniques mapped to AI lifecycle
+
+## Recommendations for Spec
+
+- **Follow F-005 spec structure exactly**: Same user story organization (5 stories, P0/P1/P2), acceptance scenarios (Given/When/Then), success criteria pattern
+- **Emphasize validation over creation**: All 5 AI agent files exist and are content-complete — the spec should focus on validating correctness, not authoring from scratch
+- **Three-layer validation**: Structural audit → Content quality → Integration validation (proven in F-005)
+- **Component specificity as hard requirement**: 100% of findings must reference named components from input — zero tolerance for generic findings
+- **DFD element targeting compliance**: Each agent targets only its declared DFD types — no out-of-scope findings
+- **OWASP reference accuracy**: Use official ID formats (LLM{NN}:2025, ASI{NN}, MCP{NN}:2025) — verify against published lists
+- **Empty results for non-AI architectures**: Critical edge case — agents must produce zero findings for traditional-only architectures
+- **Wave-based parallel execution**: Independent agents can be validated in parallel (LLM agents vs. Agentic agents)

--- a/specs/007-ai-threat-agents/spec.md
+++ b/specs/007-ai-threat-agents/spec.md
@@ -1,0 +1,218 @@
+---
+prd_reference: docs/product/02_PRD/007-ai-threat-agents-2026-03-22.md
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-22
+    status: APPROVED_WITH_CONCERNS
+    notes: "All 9 PRD functional requirements, all 3 user stories, and all 5 success metrics fully traceable. Spec adds 5 FRs and 2 user stories as legitimate refinements. 3 low concerns: PRD NFRs not restated, dispatch validation promoted to P0, FR-010 trust assumption phrasing."
+  architect_signoff: null
+  techlead_signoff: null
+---
+
+# Feature Specification: AI Threat Agents
+
+**Feature Branch**: `007-ai-threat-agents`
+**Created**: 2026-03-22
+**Status**: Draft
+**Input**: PRD 007 - AI Threat Agents
+
+## User Scenarios & Testing
+
+### User Story 1 - Agentic Threat Agent Validation (Priority: P0)
+
+A security analyst provides an architecture diagram containing autonomous AI components to the orchestrator. The Agent Autonomy agent examines excessive agency, goal misalignment, missing human-in-the-loop controls, cascading failures, and autonomous resource consumption. The Tool Abuse agent examines unauthorized tool invocation, capability escalation, parameter injection, tool chain manipulation, and tool poisoning (direct, shadowing, rug pulls). Both agents produce component-specific findings referencing named components from the input with AG-prefixed IDs.
+
+**Why this priority**: Agentic threats represent the most novel and least understood attack surface in AI systems. Autonomous agents executing tool calls without adequate controls are uniquely dangerous because they can take real-world actions. Validating these agents first establishes the agentic security coverage.
+
+**Independent Test**: Run the Agent Autonomy agent against `examples/mermaid-agentic-app/input.md` and verify it produces findings with AG-prefixed IDs referencing specific components (e.g., "LLM Agent Orchestrator"). Run the Tool Abuse agent against the same input and verify AG-prefixed findings referencing tool-executing components (e.g., "MCP Tool Server").
+
+**Acceptance Scenarios**:
+
+1. **Given** an architecture with an LLM Agent Orchestrator (Process), **When** the Agent Autonomy agent analyzes it, **Then** it produces at least one finding with an AG-prefixed ID referencing "LLM Agent Orchestrator" by name covering excessive autonomy or goal misalignment
+2. **Given** an architecture with an MCP Tool Server (Process), **When** the Tool Abuse agent analyzes it, **Then** it produces at least one finding with an AG-prefixed ID referencing "MCP Tool Server" by name covering tool poisoning or unauthorized invocation
+3. **Given** an architecture with multi-agent communication (e.g., Orchestrator dispatching to Tool Server), **When** the Agent Autonomy agent analyzes it, **Then** it produces findings about cascading failures and autonomous resource consumption referencing the specific agent components involved
+4. **Given** a component classified as Process that matches agentic dispatch keywords, **When** the Agent Autonomy agent runs, **Then** it targets that component because Processes are in its `dfd_targets` scope
+5. **Given** a component classified as Data Store (e.g., "Knowledge Base"), **When** the Agent Autonomy agent runs, **Then** it does NOT produce findings for that component because Data Stores are outside its `dfd_targets` scope
+6. **Given** a component classified as Data Store, **When** the Tool Abuse agent runs, **Then** it does NOT produce findings for that component because Data Stores are outside its `dfd_targets` scope
+7. **Given** either agentic agent produces a finding, **When** the finding is examined, **Then** the `component` field matches a named component from the orchestrator's Phase 1 (Scope) output — generic names like "the AI agent" or "the system" are invalid
+8. **Given** the Agent Autonomy agent's findings, **When** examined for framework references, **Then** each finding includes at least one reference from OWASP Agentic Top 10 (ASI-xx format)
+9. **Given** the Tool Abuse agent's findings, **When** examined for framework references, **Then** each finding includes at least one reference from OWASP Agentic Top 10 (ASI-xx) or OWASP MCP Top 10 (MCP-xx:2025)
+10. **Given** a purely traditional architecture with no AI/agent/MCP components, **When** the agentic agents run, **Then** they produce zero findings (empty results)
+
+---
+
+### User Story 2 - LLM Threat Agent Validation (Priority: P0)
+
+A security analyst provides an architecture diagram containing LLM integration to the orchestrator. The Prompt Injection agent examines direct injection, indirect injection via documents/URLs, jailbreaking, system prompt extraction, and cross-plugin injection. The Data Poisoning agent examines training data manipulation, RAG index poisoning, knowledge base corruption, fine-tuning supply chain attacks, and context window contamination. The Model Theft agent examines model extraction via API queries, model weight exfiltration, unbounded inference consumption, and model supply chain compromise. All three agents produce component-specific findings with LLM-prefixed IDs.
+
+**Why this priority**: LLM threats target the foundational model layer that underpins all agentic capabilities. Prompt injection (LLM01:2025) is the #1 ranked OWASP LLM threat. Data poisoning and model theft complete coverage of the model lifecycle (input integrity, stored model, output extraction).
+
+**Independent Test**: Run the Prompt Injection agent against `examples/mermaid-agentic-app/input.md` and verify LLM-prefixed findings for LLM-related Processes. Run Data Poisoning against the same input and verify LLM-prefixed findings for Data Stores and Data Flows feeding models. Run Model Theft and verify LLM-prefixed findings for model-hosting components.
+
+**Acceptance Scenarios**:
+
+1. **Given** an architecture with an LLM inference service (Process), **When** the Prompt Injection agent analyzes it, **Then** it produces findings with LLM-prefixed IDs referencing that specific component covering direct injection, indirect injection, and system prompt leakage
+2. **Given** an architecture with a Knowledge Base (Data Store) feeding an LLM via RAG, **When** the Data Poisoning agent analyzes it, **Then** it produces findings with LLM-prefixed IDs referencing the Knowledge Base and the data flow between it and the LLM covering RAG index poisoning and knowledge base corruption
+3. **Given** an architecture with an LLM inference endpoint (Process), **When** the Model Theft agent analyzes it, **Then** it produces findings with LLM-prefixed IDs referencing that component covering model extraction and unbounded consumption
+4. **Given** a component classified as Process that matches LLM dispatch keywords, **When** the Prompt Injection agent runs, **Then** it targets that component because Processes are in its `dfd_targets` scope
+5. **Given** a component classified as External Entity, **When** the Prompt Injection agent runs, **Then** it does NOT produce findings for that component because External Entities are outside its `dfd_targets` scope
+6. **Given** a component classified as Data Store, **When** the Data Poisoning agent runs, **Then** it targets that component because Data Stores are in its `dfd_targets` scope
+7. **Given** a component classified as Data Flow feeding an LLM, **When** the Data Poisoning agent runs, **Then** it targets that data flow because Data Flows are in its `dfd_targets` scope
+8. **Given** a component classified as Data Store containing model weights, **When** the Model Theft agent runs, **Then** it targets that component because Data Stores are in its `dfd_targets` scope
+9. **Given** any LLM agent produces a finding, **When** examined for framework references, **Then** each finding includes at least one OWASP LLM Top 10 reference (LLM0x:2025 format)
+10. **Given** a purely traditional architecture with no LLM/model components, **When** the LLM agents run, **Then** they produce zero findings (empty results)
+
+---
+
+### User Story 3 - Consistent Output Format Across All AI Agents (Priority: P0)
+
+All 5 AI agents produce findings in a consistent format conforming to `schemas/finding.yaml`. The orchestrator can collect findings from any AI agent and assemble them into AG and LLM threat tables without format conversion or field mapping.
+
+**Why this priority**: Consistent output enables the orchestrator to assemble findings from independent AI agents into unified AG and LLM tables alongside STRIDE tables. Without format consistency, the end-to-end pipeline breaks.
+
+**Independent Test**: Run all 5 AI agents against the same architecture input and verify every finding contains all required IR fields, uses correct ID prefixes (AG-N or LLM-N), and has risk levels matching the OWASP 3x3 matrix computation.
+
+**Acceptance Scenarios**:
+
+1. **Given** any AI agent produces a finding, **When** the finding is examined, **Then** it contains all 10 IR fields: id, category, component, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type
+2. **Given** findings from all 5 AI agents, **When** IDs are examined, **Then** agentic agent findings use AG-N prefix and LLM agent findings use LLM-N prefix — where N is sequential within each category
+3. **Given** a finding with likelihood HIGH and impact HIGH, **When** the risk_level is computed, **Then** it equals Critical per the OWASP 3x3 matrix
+4. **Given** a finding with likelihood LOW and impact LOW, **When** the risk_level is computed, **Then** it equals Note per the OWASP 3x3 matrix
+5. **Given** a finding with likelihood MEDIUM and impact HIGH, **When** the risk_level is computed, **Then** it equals High per the OWASP 3x3 matrix
+6. **Given** any AI finding, **When** the `references` field is examined, **Then** it contains at least one OWASP AI framework identifier (LLM0x:2025, ASI-xx, or MCP-xx:2025)
+7. **Given** any AI finding, **When** the `dfd_element_type` field is examined, **Then** it contains one of: External Entity, Process, Data Store, or Data Flow
+8. **Given** findings that reference generic components (e.g., "the model", "an agent", "the AI system"), **When** validated, **Then** they are flagged as invalid — the quality guardrail requires every finding to name a specific component from the input architecture
+9. **Given** findings from agentic agents, **When** the `category` field is examined, **Then** it equals `agentic`
+10. **Given** findings from LLM agents, **When** the `category` field is examined, **Then** it equals `llm`
+
+---
+
+### User Story 4 - Two-Layer Keyword Dispatch Validation (Priority: P0)
+
+The orchestrator correctly dispatches to AI agents using the two-layer keyword model. Layer 1 (orchestrator dispatch) activates agent categories based on component names and descriptions matching LLM or agentic keywords. Layer 2 (agent detection scope) refines targeting using per-agent keywords for more precise threat detection.
+
+**Why this priority**: Correct dispatch is the prerequisite for all other validation. If the orchestrator doesn't activate the right agents for the right components, all downstream findings are invalid or missing.
+
+**Independent Test**: Run the orchestrator against `examples/mermaid-agentic-app/input.md` and verify the dispatch table shows correct agent activation per component based on keyword matching.
+
+**Acceptance Scenarios**:
+
+1. **Given** a component named "LLM Agent Orchestrator" containing both LLM and agentic keywords, **When** the orchestrator dispatches, **Then** it activates all 5 AI agents (dual-dispatch) plus applicable STRIDE agents for that component
+2. **Given** a component named "MCP Tool Server" containing agentic keywords but no LLM keywords, **When** the orchestrator dispatches, **Then** it activates only the 2 agentic agents (agent-autonomy, tool-abuse) plus applicable STRIDE agents
+3. **Given** a component named "Knowledge Base" containing no AI/LLM/agentic keywords, **When** the orchestrator dispatches, **Then** it activates only STRIDE agents — no AI agents are dispatched
+4. **Given** a component whose description (not just name) contains LLM keywords (e.g., "Manages LLM inference requests"), **When** the orchestrator dispatches, **Then** it activates LLM agents based on description keyword matching
+5. **Given** a component matching LLM dispatch keywords, **When** LLM agents run, **Then** each agent further refines its scope using Layer 2 detection keywords specific to its threat class (e.g., Data Poisoning looks for "training", "RAG", "vector store")
+6. **Given** a purely traditional architecture with no AI/LLM/agentic keywords in any component, **When** the orchestrator dispatches, **Then** zero AI agents are activated — only STRIDE agents run
+
+---
+
+### User Story 5 - End-to-End Orchestrator Integration (Priority: P1)
+
+The orchestrator dispatches to all 5 validated AI agents and assembles their findings into AG and LLM threat tables in `threats.md`. The end-to-end flow from architecture input to assembled threat model includes both STRIDE and AI tables without manual intervention.
+
+**Why this priority**: End-to-end integration validates that AI agents work correctly within the orchestrator's dispatch protocol alongside STRIDE agents. Individual agent validation (US-1 through US-4) ensures quality; integration testing ensures the complete pipeline works.
+
+**Independent Test**: Run the orchestrator against `examples/mermaid-agentic-app/input.md` and verify the output `threats.md` contains AG and LLM threat tables with findings, correct component references, and valid risk computations.
+
+**Acceptance Scenarios**:
+
+1. **Given** the mermaid-agentic-app example input, **When** the orchestrator dispatches to all 5 AI agents and assembles findings, **Then** the resulting `threats.md` contains one AG threat table and one LLM threat table with at least one finding each
+2. **Given** the assembled `threats.md`, **When** the AG table is examined, **Then** it contains findings from both agent-autonomy and tool-abuse agents with AG-prefixed IDs, each referencing named components
+3. **Given** the assembled `threats.md`, **When** the LLM table is examined, **Then** it contains findings from prompt-injection, data-poisoning, and model-theft agents with LLM-prefixed IDs, each referencing named components
+4. **Given** the assembled `threats.md`, **When** the coverage matrix is examined, **Then** it shows AI agent dispatch for components matching AI/LLM/agentic keywords and no AI dispatch for traditional components
+5. **Given** the assembled `threats.md`, **When** every finding across AG and LLM tables is examined, **Then** 100% reference a named component from the input architecture (zero generic findings)
+6. **Given** the assembled `threats.md`, **When** both STRIDE and AI tables are present, **Then** finding ID namespaces do not conflict (S/T/R/I/D/E prefixes are separate from AG/LLM prefixes)
+
+---
+
+### Edge Cases
+
+- What happens when a component matches both LLM and agentic dispatch keywords? The orchestrator activates all 5 AI agents for that component (dual-dispatch). Each agent independently evaluates the component through its own threat lens.
+- What happens when an AI agent targets a DFD element type outside its assigned scope? The finding is flagged as invalid by the quality guardrail (agent must not produce findings for element types outside its `dfd_targets`).
+- What happens when the architecture contains no AI/LLM/agentic components? All AI agents produce zero findings (empty results). Only STRIDE agents produce output. The `threats.md` contains STRIDE tables but empty or absent AG and LLM tables.
+- What happens when two AI agents identify overlapping threats (e.g., prompt injection and tool abuse both flag an MCP server)? Each agent produces its own finding with its category-specific lens and ID prefix. Deduplication is out of scope (future feature).
+- What happens when the orchestrator's Layer 1 keyword matching produces a false positive (e.g., a "data model" component triggering LLM dispatch)? The AI agent's Layer 2 detection patterns provide secondary filtering — if no AI-relevant characteristics are detected, the agent produces zero findings for that component despite being dispatched.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: Each of the 5 AI agents MUST analyze architecture input through exactly one threat lens corresponding to its assigned AI threat class (Prompt Injection, Data Poisoning, Model Theft, Agent Autonomy, or Tool Abuse)
+- **FR-002**: Each agent MUST target only the DFD element types defined in its `dfd_targets` frontmatter — Prompt Injection (Process), Data Poisoning (Data Store, Data Flow), Model Theft (Data Store, Process), Agent Autonomy (Process), Tool Abuse (Process) — and MUST NOT produce findings for element types outside its scope
+- **FR-003**: Every finding produced by any AI agent MUST reference a named component from the architecture input in the `component` field — findings with generic component names (e.g., "the AI", "a model", "the system") are invalid
+- **FR-004**: All findings MUST conform to `schemas/finding.yaml` intermediate representation with all 10 fields populated (id, category, component, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type)
+- **FR-005**: Finding IDs MUST follow the sequential prefix convention: LLM-N for LLM agents, AG-N for agentic agents (where N starts at 1 and increments per finding within each category)
+- **FR-006**: Risk levels MUST be computed from the OWASP 3x3 matrix (likelihood x impact) — HIGH/HIGH=Critical, HIGH/MEDIUM=High, MEDIUM/MEDIUM=Medium, LOW/LOW=Note, etc.
+- **FR-007**: Each finding MUST include at least one reference to an established AI security framework (OWASP LLM Top 10 v2025 using LLM0x:2025 format, OWASP Agentic Top 10 using ASI-xx format, or OWASP MCP Top 10 using MCP-xx:2025 format)
+- **FR-008**: Each agent MUST include detailed detection patterns organized by attack subcategory as defined in the PRD's FR-8 (prompt injection: direct/indirect/jailbreaking/system prompt extraction/cross-plugin; data poisoning: training data/RAG index/knowledge base/fine-tuning/context window; model theft: API extraction/weight exfiltration/unbounded consumption/supply chain; agent autonomy: excessive autonomy/goal misalignment/unconstrained scope/missing HITL/cascading failures/resource consumption; tool abuse: unauthorized invocation/capability escalation/parameter injection/tool chain manipulation/tool poisoning)
+- **FR-009**: Each agent's frontmatter MUST include consistent metadata: agent_name, category, threat_class, dfd_targets, owasp_references, and output_schema reference — matching the structure used by validated STRIDE agents
+- **FR-010**: Each finding's `threat` field MUST describe both what the attacker does and what trust assumption is violated — vague descriptions like "could be poisoned" or "may be compromised" are invalid
+- **FR-011**: Each finding's `mitigation` field MUST provide an actionable countermeasure with specific technology or configuration — generic advice like "implement AI safety" is invalid
+- **FR-012**: All 5 agents MUST follow identical structural organization: frontmatter, purpose, detection scope, detection patterns, finding template, risk computation, references
+- **FR-013**: AI agents MUST produce empty results (zero findings) when the input architecture contains no AI/LLM/agentic components, preventing false positives for purely traditional systems
+- **FR-014**: The orchestrator MUST use the two-layer keyword dispatch model: Layer 1 (orchestrator dispatch keywords) activates agent categories, Layer 2 (per-agent detection scope) refines targeting within activated categories
+
+### Key Entities
+
+- **AI Threat Agent**: A markdown prompt file in `agents/ai/` that encodes detection patterns, finding templates, and framework references for exactly one AI threat class (Prompt Injection, Data Poisoning, Model Theft, Agent Autonomy, or Tool Abuse)
+- **Finding (IR)**: A 10-field intermediate representation conforming to `schemas/finding.yaml` that captures a single identified AI-specific threat with component reference, risk assessment, mitigation, and OWASP AI framework cross-references
+- **AI Threat Category**: One of two top-level categories — `llm` (for Prompt Injection, Data Poisoning, Model Theft agents) or `agentic` (for Agent Autonomy, Tool Abuse agents) — determining the finding ID prefix and output table placement
+- **Detection Pattern**: A structured description within an agent prompt that defines what AI-specific indicators to look for (attack subcategory, trigger conditions, vulnerable configurations) within applicable DFD element types
+- **Two-Layer Keyword Dispatch**: The mechanism by which the orchestrator activates AI agents — Layer 1 matches component names/descriptions against category-level keywords, Layer 2 applies per-agent detection scope keywords for refined targeting
+- **OWASP AI Framework Reference**: Official vulnerability identifiers from three complementary frameworks — LLM Top 10 v2025 (LLM0x:2025), Agentic Top 10 2026 (ASI-xx), MCP Top 10 2025 (MCP-xx:2025) — required in every AI finding
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Component Specificity Rate — 100% of findings across all 5 AI agents reference a named component from the input architecture (zero generic findings)
+- **SC-002**: AI Category Coverage — Both AI categories (AG, LLM) produce at least 1 finding when given an architecture with applicable component types (verified against `examples/mermaid-agentic-app/input.md`)
+- **SC-003**: Schema Compliance — 100% of findings conform to all 10 fields defined in `schemas/finding.yaml` with correct data types, enum values, and AI-specific category values (`llm`, `agentic`)
+- **SC-004**: DFD Element Accuracy — Zero findings produced for DFD element types outside each agent's assigned scope (cross-referenced against the agent's `dfd_targets` frontmatter)
+- **SC-005**: Risk Computation Correctness — 100% of risk_level values match the OWASP 3x3 matrix computation from the finding's likelihood and impact values
+- **SC-006**: OWASP AI Reference Coverage — 100% of findings include at least one AI-specific OWASP reference ID (LLM0x:2025, ASI-xx, or MCP-xx:2025) in the `references` field
+- **SC-007**: End-to-End Integration — The orchestrator successfully dispatches to all 5 AI agents and assembles findings into valid AG and LLM threat tables in `threats.md`
+- **SC-008**: Structural Consistency — All 5 agent files follow identical section organization matching the validated STRIDE agent pattern (frontmatter, purpose, detection scope, patterns, finding template, risk computation, references)
+- **SC-009**: Empty Results for Non-AI Architectures — All 5 AI agents produce zero findings when given a purely traditional architecture with no AI/LLM/agentic components
+- **SC-010**: Dispatch Accuracy — The orchestrator's two-layer keyword dispatch correctly activates AI agents only for components matching AI/LLM/agentic keywords and produces no false activations for traditional components
+
+## Scope & Boundaries
+
+### In Scope
+
+**Must Have (P0)**:
+- All 5 AI agent prompt files validated for completeness and correctness
+- Each agent targets correct DFD element types per interface contract AI extension rules
+- All findings reference specific components from input architecture
+- Consistent finding format across all 5 agents conforming to `schemas/finding.yaml`
+- OWASP AI framework reference IDs in every finding (LLM0x:2025, ASI-xx, MCP-xx:2025)
+- End-to-end validation: orchestrator dispatches to AI agents and assembles valid AG and LLM tables
+- Empty results for non-AI architectures
+- Two-layer keyword dispatch validation
+
+**Should Have (P1)**:
+- MITRE ATLAS cross-references for AI attack taxonomy
+- CWE identifiers for vulnerability classification where applicable
+
+### Out of Scope
+- Deduplication and risk rating refinement across STRIDE + AI findings (future feature)
+- Platform-specific adapters for dispatching agents (F-009)
+- Custom AI threat categories beyond OWASP frameworks
+- Agent prompt fine-tuning for specific LLM providers
+- Additional AI agent categories (e.g., multimodal threats, embedding attacks)
+- Changes to `schemas/finding.yaml` or `docs/INTERFACE-CONTRACT.md`
+- Runtime schema validation scripts or tooling
+
+### Assumptions
+- The orchestrator (F-003) correctly parses architecture input and dispatches to AI agents based on keyword detection
+- The `schemas/finding.yaml` schema supports AI categories (`llm`, `agentic`) and ID prefixes (`LLM-N`, `AG-N`) without modification
+- The sample architecture in `examples/mermaid-agentic-app/input.md` contains sufficient AI/LLM/agentic components for validation
+- STRIDE agents (F-005) are delivered and stable — AI agents follow the same validated pattern
+- All 5 AI agent prompt files already exist with substantial content; this feature validates and completes them, not builds from scratch
+- "Validation" means running agents against sample input and checking output against schema and quality criteria
+
+### Open Questions
+- Should AI agents detect threats in non-AI components that interact with AI (e.g., a database storing model outputs)? — architect — 2026-03-29
+- Should cross-references between AI and STRIDE categories be noted in findings (e.g., a prompt injection finding that also has Tampering implications)? — architect — 2026-03-29
+- What is the minimum number of OWASP references per finding — 1 or should agents aim for comprehensive cross-referencing? — product-manager — 2026-03-29

--- a/specs/007-ai-threat-agents/tasks.md
+++ b/specs/007-ai-threat-agents/tasks.md
@@ -1,0 +1,247 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-22
+    status: APPROVED
+    notes: "All 5 user stories covered with 48 tasks across 8 phases. All 14 FRs addressed including FR-010. All 10 success criteria achievable. No scope creep detected."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-22
+    status: APPROVED_WITH_CONCERNS
+    notes: "Technically correct across all 5 evaluation criteria. 1 moderate concern: T010/T029 section structure naming may not match actual agent structure (sections vs subsections). 2 minor: T001 missing [P] marker, ASI format inconsistency. No blocking issues."
+  techlead_signoff:
+    agent: team-lead
+    date: 2026-03-22
+    status: APPROVED
+    notes: "48 tasks, 5 waves, 4 agents. Feasible in 1 sprint (3.3 hours wall-clock, 90% confidence). Dependency chains correct. Parallelism maximized across Phase 3+4+6. 2 informational observations, no blockers."
+---
+
+# Tasks: AI Threat Agents
+
+**Input**: Design documents from `/specs/007-ai-threat-agents/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md
+
+**Organization**: Tasks are grouped by user story to enable independent validation of each story. No test tasks — validation is performed inline via manual review and orchestrator integration runs.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Load reference materials and verify stable dependencies
+
+- [X] T001 Verify `schemas/finding.yaml` supports AI categories (`agentic`, `llm`) and ID prefixes (`AG-*`, `LLM-*`) — read-only check, no modifications
+- [X] T002 [P] Verify `docs/INTERFACE-CONTRACT.md` Section 3 defines AI dispatch keywords matching plan's DFD Targeting Matrix
+- [X] T003 [P] Verify `examples/mermaid-agentic-app/input.md` contains AI/LLM/agentic components suitable for validation (at minimum: LLM Agent Orchestrator, MCP Tool Server)
+- [X] T004 [P] Verify all 5 AI agent files exist in `agents/ai/` (prompt-injection.md, data-poisoning.md, model-theft.md, agent-autonomy.md, tool-abuse.md)
+
+---
+
+## Phase 2: Foundational — Structural Audit (Wave 1)
+
+**Purpose**: Verify all 5 agents have correct structure and frontmatter before content validation
+
+**CRITICAL**: No content validation can begin until structural compliance is confirmed
+
+- [X] T005 [P] Audit frontmatter of `agents/ai/agent-autonomy.md` — verify 6 fields (agent_name, category: agentic, threat_class: AG, dfd_targets: [Process], owasp_references, output_schema: schemas/finding.yaml) and fix any gaps
+- [X] T006 [P] Audit frontmatter of `agents/ai/tool-abuse.md` — verify 6 fields (agent_name, category: agentic, threat_class: AG, dfd_targets: [Process], owasp_references, output_schema: schemas/finding.yaml) and fix any gaps
+- [X] T007 [P] Audit frontmatter of `agents/ai/prompt-injection.md` — verify 6 fields (agent_name, category: llm, threat_class: LLM, dfd_targets: [Process], owasp_references, output_schema: schemas/finding.yaml) and fix any gaps
+- [X] T008 [P] Audit frontmatter of `agents/ai/data-poisoning.md` — verify 6 fields (agent_name, category: llm, threat_class: LLM, dfd_targets: [Data Store, Data Flow], owasp_references, output_schema: schemas/finding.yaml) and fix any gaps
+- [X] T009 [P] Audit frontmatter of `agents/ai/model-theft.md` — verify 6 fields (agent_name, category: llm, threat_class: LLM, dfd_targets: [Data Store, Process], owasp_references, output_schema: schemas/finding.yaml) and fix any gaps
+- [X] T010 [P] Audit section structure of all 5 agents in `agents/ai/` — verify each has canonical sections in order: Purpose, Detection Scope, Patterns/Indicators, Finding Template, Risk Level Computation, References. Flag missing or misordered sections
+
+**Checkpoint**: All 5 agents pass structural audit — content validation can begin
+
+---
+
+## Phase 3: User Story 1 — Agentic Threat Agent Validation (Priority: P0)
+
+**Goal**: Validate agent-autonomy and tool-abuse agents produce correct, component-specific findings with OWASP Agentic/MCP references
+
+**Independent Test**: Run each agentic agent against `examples/mermaid-agentic-app/input.md` and verify AG-prefixed findings reference named components (e.g., "LLM Agent Orchestrator", "MCP Tool Server")
+
+### Implementation for User Story 1
+
+- [X] T011 [P] [US1] Validate detection patterns in `agents/ai/agent-autonomy.md` cover all PRD FR-8 subcategories: excessive autonomy, goal misalignment, unconstrained action scope, missing human-in-the-loop, cascading failures across agents, autonomous resource consumption. Add any missing subcategories
+- [X] T012 [P] [US1] Validate detection patterns in `agents/ai/tool-abuse.md` cover all PRD FR-8 subcategories: unauthorized tool invocation, capability escalation, parameter injection, tool chain manipulation, tool poisoning (direct, shadowing, rug pulls). Add any missing subcategories
+- [X] T013 [US1] Verify finding template in `agents/ai/agent-autonomy.md` demonstrates component-specific threats — example must reference a named component (not generic "the agent"), describe attacker action + trust assumption violated (FR-010), and include actionable mitigation (FR-011)
+- [X] T014 [US1] Verify finding template in `agents/ai/tool-abuse.md` demonstrates component-specific threats — example must reference a named component, describe attacker action + trust assumption violated, and include actionable mitigation
+- [X] T015 [US1] Verify OWASP references in `agents/ai/agent-autonomy.md` — must include ASI01, ASI06, ASI08, ASI09, ASI10 in references section with correct format
+- [X] T016 [US1] Verify OWASP references in `agents/ai/tool-abuse.md` — must include ASI02, ASI04, MCP03:2025, MCP05:2025 in references section with correct format
+- [X] T017 [US1] Verify `agents/ai/agent-autonomy.md` produces empty results guidance — agent must include instructions to produce zero findings when no AI/agent components are present in architecture input
+- [X] T018 [US1] Verify `agents/ai/tool-abuse.md` produces empty results guidance — agent must include instructions to produce zero findings when no tool server/MCP/plugin components are present
+
+**Checkpoint**: Both agentic agents validated — AG-prefixed findings are component-specific, schema-compliant, and OWASP-grounded
+
+---
+
+## Phase 4: User Story 2 — LLM Threat Agent Validation (Priority: P0)
+
+**Goal**: Validate prompt-injection, data-poisoning, and model-theft agents produce correct, component-specific findings with OWASP LLM references
+
+**Independent Test**: Run each LLM agent against `examples/mermaid-agentic-app/input.md` and verify LLM-prefixed findings reference named components
+
+### Implementation for User Story 2
+
+- [X] T019 [P] [US2] Validate detection patterns in `agents/ai/prompt-injection.md` cover all PRD FR-8 subcategories: direct injection, indirect injection (via documents/URLs), jailbreaking, system prompt extraction, cross-plugin injection. Add any missing subcategories
+- [X] T020 [P] [US2] Validate detection patterns in `agents/ai/data-poisoning.md` cover all PRD FR-8 subcategories: training data manipulation, RAG index poisoning, knowledge base corruption, fine-tuning supply chain attacks, context window contamination. Add any missing subcategories
+- [X] T021 [P] [US2] Validate detection patterns in `agents/ai/model-theft.md` cover all PRD FR-8 subcategories: model extraction via API queries, model weight exfiltration, unbounded inference consumption, model supply chain compromise. Add any missing subcategories
+- [X] T022 [US2] Verify finding template in `agents/ai/prompt-injection.md` demonstrates component-specific threats — must reference a named LLM component, describe attacker action + trust assumption violated, include actionable mitigation
+- [X] T023 [US2] Verify finding template in `agents/ai/data-poisoning.md` demonstrates component-specific threats — must reference named data stores or data flows, not generic "the database"
+- [X] T024 [US2] Verify finding template in `agents/ai/model-theft.md` demonstrates component-specific threats — must reference named model hosting component, not generic "the model"
+- [X] T025 [P] [US2] Verify OWASP references in `agents/ai/prompt-injection.md` — must include LLM01:2025, LLM07:2025 with correct format
+- [X] T026 [P] [US2] Verify OWASP references in `agents/ai/data-poisoning.md` — must include LLM03:2025, LLM04:2025, LLM08:2025 with correct format
+- [X] T027 [P] [US2] Verify OWASP references in `agents/ai/model-theft.md` — must include LLM03:2025, LLM10:2025 with correct format
+- [X] T028 [US2] Verify all 3 LLM agents include empty results guidance — each must instruct to produce zero findings when no LLM/model components are present
+
+**Checkpoint**: All 3 LLM agents validated — LLM-prefixed findings are component-specific, schema-compliant, and OWASP-grounded
+
+---
+
+## Phase 5: User Story 3 — Consistent Output Format (Priority: P0)
+
+**Goal**: Verify all 5 agents produce findings in identical format conforming to `schemas/finding.yaml` with correct category values and ID prefixes
+
+**Independent Test**: Compare finding template sections across all 5 agents — all must define the same 10 IR fields with consistent formatting
+
+### Implementation for User Story 3
+
+- [X] T029 [US3] Cross-check all 5 agents in `agents/ai/` for identical section organization — verify each follows: Purpose, Detection Scope, Patterns/Indicators, Finding Template, Risk Level Computation, References (FR-012)
+- [X] T030 [US3] Cross-check finding templates across all 5 agents — verify all define 10 IR fields (id, category, component, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type) with consistent field names
+- [X] T031 [US3] Verify ID prefix conventions — agentic agents use AG-N, LLM agents use LLM-N, N starts at 1 and increments sequentially
+- [X] T032 [US3] Verify category field values — agentic agents use `agentic`, LLM agents use `llm` (matching `schemas/finding.yaml` enum)
+- [X] T033 [US3] Verify risk computation sections in all 5 agents use identical OWASP 3x3 matrix (HIGH/HIGH=Critical, HIGH/MEDIUM=High, MEDIUM/MEDIUM=Medium, LOW/LOW=Note)
+- [X] T034 [US3] Verify all 5 agents reference `schemas/finding.yaml` as output_schema in frontmatter
+
+**Checkpoint**: All 5 agents produce format-consistent findings — orchestrator can assemble without conversion
+
+---
+
+## Phase 6: User Story 4 — Two-Layer Keyword Dispatch Validation (Priority: P0)
+
+**Goal**: Verify orchestrator correctly dispatches to AI agents using two-layer keyword model
+
+**Independent Test**: Trace dispatch logic through `agents/orchestrator.md` and `docs/INTERFACE-CONTRACT.md` Section 3 against the expected dispatch matrix from plan.md
+
+### Implementation for User Story 4
+
+- [X] T035 [US4] Verify Layer 1 dispatch keywords in `docs/INTERFACE-CONTRACT.md` Section 3 match orchestrator implementation in `agents/orchestrator.md` — LLM keywords activate 3 LLM agents, agentic keywords activate 2 agentic agents
+- [X] T036 [US4] Verify Layer 2 detection scope keywords in each of the 5 agents in `agents/ai/` extend (not conflict with) Layer 1 keywords — document per-agent keyword additions
+- [X] T037 [US4] Verify dual-dispatch behavior — confirm `agents/orchestrator.md` activates both LLM and agentic agents when a component matches keywords from both categories (e.g., "LLM Agent Orchestrator")
+- [X] T038 [US4] Verify dispatch matrix against `examples/mermaid-agentic-app/input.md` — trace each component through Layer 1 keywords and confirm expected AI agent activation matches plan's Two-Layer Keyword Dispatch Validation Matrix
+
+**Checkpoint**: Two-layer dispatch verified — correct agents activate for correct components
+
+---
+
+## Phase 7: User Story 5 — End-to-End Orchestrator Integration (Priority: P1)
+
+**Goal**: Run orchestrator against sample architecture and verify complete threat model output with both STRIDE and AI tables
+
+**Independent Test**: Execute orchestrator against `examples/mermaid-agentic-app/input.md` and verify `threats.md` contains AG and LLM tables with component-specific findings
+
+### Implementation for User Story 5
+
+- [X] T039 [US5] Run orchestrator against `examples/mermaid-agentic-app/input.md` and verify output `threats.md` contains AG threat table with AG-prefixed findings from agent-autonomy and tool-abuse agents
+- [X] T040 [US5] Verify output `threats.md` contains LLM threat table with LLM-prefixed findings from prompt-injection, data-poisoning, and model-theft agents
+- [X] T041 [US5] Verify 100% component specificity — every finding across AG and LLM tables references a named component from the input (zero generic findings)
+- [X] T042 [US5] Verify risk_level values in all AI findings match OWASP 3x3 matrix computation from their likelihood and impact values
+- [X] T043 [US5] Verify coverage matrix in output shows AI agent dispatch for "LLM Agent Orchestrator" (dual-dispatch) and "MCP Tool Server" (agentic only), and no AI dispatch for "Knowledge Base", "User", "External API"
+- [X] T044 [US5] Verify finding ID namespaces don't conflict — AG/LLM prefixes are separate from S/T/R/I/D/E prefixes in the same `threats.md`
+- [X] T045 [US5] Verify empty results — confirm non-AI components (User, Knowledge Base, External API) have no entries in AG or LLM tables
+
+**Checkpoint**: End-to-end integration validated — complete threat model with 8 tables (6 STRIDE + 2 AI) works correctly
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: P1 improvements and documentation
+
+- [X] T046 [P] Add MITRE ATLAS cross-references to all 5 agents in `agents/ai/` where applicable (P1 deliverable)
+- [X] T047 [P] Add CWE identifiers to agents in `agents/ai/` where applicable — prompt-injection (CWE-77), data-poisoning (CWE-1321), model-theft (CWE-200)
+- [X] T048 Verify `agents/ai/README.md` accurately documents the 5-agent-to-2-table mapping (AG table: agent-autonomy + tool-abuse; LLM table: prompt-injection + data-poisoning + model-theft)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Setup — BLOCKS all user stories
+- **US1 Agentic (Phase 3)**: Depends on Foundational — can run in parallel with US2
+- **US2 LLM (Phase 4)**: Depends on Foundational — can run in parallel with US1
+- **US3 Format (Phase 5)**: Depends on US1 + US2 (requires individual agents validated)
+- **US4 Dispatch (Phase 6)**: Depends on Foundational — can run in parallel with US1/US2
+- **US5 E2E (Phase 7)**: Depends on US1 + US2 + US3 + US4 (all agents validated and dispatch verified)
+- **Polish (Phase 8)**: Depends on US5 (core validation complete)
+
+### User Story Dependencies
+
+- **US1 (P0)**: Can start after Foundational — No dependencies on other stories
+- **US2 (P0)**: Can start after Foundational — No dependencies on other stories
+- **US3 (P0)**: Depends on US1 + US2 completion (needs all agents individually validated)
+- **US4 (P0)**: Can start after Foundational — reads orchestrator and interface contract, independent of agent content
+- **US5 (P1)**: Depends on all P0 stories (US1-US4) — full integration test
+
+### Parallel Opportunities
+
+- **Phase 1**: T002, T003, T004 can run in parallel
+- **Phase 2**: T005-T010 can all run in parallel (different files)
+- **Phase 3 + Phase 4**: US1 and US2 can run entirely in parallel (agentic vs LLM tracks)
+- **Phase 3**: T011, T012 can run in parallel (different agents)
+- **Phase 4**: T019, T020, T021 can run in parallel; T025, T026, T027 can run in parallel
+- **Phase 6**: Can run in parallel with Phases 3-4 (reads different files)
+- **Phase 8**: T046, T047 can run in parallel
+
+---
+
+## Parallel Example: User Story 1 + User Story 2 (Wave 2)
+
+```
+# Track A (Agentic) — can run simultaneously with Track B:
+Task: T011 "Validate detection patterns in agents/ai/agent-autonomy.md"
+Task: T012 "Validate detection patterns in agents/ai/tool-abuse.md"
+
+# Track B (LLM) — can run simultaneously with Track A:
+Task: T019 "Validate detection patterns in agents/ai/prompt-injection.md"
+Task: T020 "Validate detection patterns in agents/ai/data-poisoning.md"
+Task: T021 "Validate detection patterns in agents/ai/model-theft.md"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2 — Core Agent Validation)
+
+1. Complete Phase 1: Setup (verify dependencies)
+2. Complete Phase 2: Structural Audit (all 5 agents)
+3. Complete Phase 3: US1 Agentic agents + Phase 4: US2 LLM agents (in parallel)
+4. **STOP and VALIDATE**: Each agent produces component-specific, schema-compliant findings
+5. Core value delivered — all 5 AI agents validated
+
+### Incremental Delivery
+
+1. Setup + Structural Audit -> Foundation ready
+2. US1 + US2 (parallel) -> Individual agents validated -> Core MVP
+3. US3 -> Cross-agent consistency confirmed
+4. US4 -> Dispatch correctness confirmed
+5. US5 -> End-to-end integration validated -> Feature complete
+6. Polish -> P1 cross-references added
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- No test tasks — validation is inline (prompt files, not code)
+- Each phase checkpoint is independently verifiable
+- Total: 48 tasks across 8 phases

--- a/specs/007-ai-threat-agents/wave1-setup-results.md
+++ b/specs/007-ai-threat-agents/wave1-setup-results.md
@@ -1,0 +1,91 @@
+# Wave 1 Setup Verification Results
+
+**Feature**: 007 - AI Threat Agents
+**Date**: 2026-03-22
+**Reviewer**: security-analyst
+**Verdict**: ALL PASS (4/4)
+
+---
+
+## T001: PASS — `schemas/finding.yaml` supports AI categories
+
+**Verified**:
+
+- `category` field enum includes both `agentic` and `llm` (lines 37-38)
+- `id` field pattern `^(S|T|R|I|D|E|AG|LLM)-\\d+$` supports `AG-*` and `LLM-*` prefixes (line 18)
+- Validation rules confirm prefix-to-category mapping: `AG-* -> agentic`, `LLM-* -> llm` (lines 127-128)
+- References field is marked required for AI categories (line 104): "Required for AI categories (agentic, llm)"
+- Examples include `AG-2` and `LLM-1` (lines 25-26)
+
+No issues found. Schema fully supports AI threat finding categories.
+
+---
+
+## T002: PASS — `docs/INTERFACE-CONTRACT.md` Section 3 defines AI dispatch keywords
+
+**Section 3 title**: "AI Extension Dispatch Rules" (line 215)
+
+**LLM keywords** (lines 225-228):
+- `"LLM"`, `"model"`, `"GPT"`, `"Claude"`
+- Dispatches 3 LLM agents: `prompt-injection` (OWASP LLM01:2025), `data-poisoning` (OWASP LLM03:2025), `model-theft` (OWASP LLM10:2025)
+
+**Agentic keywords** (lines 238-243):
+- `"agent"`, `"autonomous"`, `"orchestrator"`, `"MCP server"`, `"tool server"`, `"plugin"`
+- Dispatches 2 AG agents: `agent-autonomy` (ASI-01), `tool-abuse` (MCP-03)
+
+**Dispatch behavior** (lines 249-253):
+- Keyword matching is case-insensitive
+- AI dispatch is additive to STRIDE categories
+- Multi-word keywords match as a phrase
+- Dual-dispatch supported when element matches both LLM and Agentic keywords
+
+All dispatch rules match the plan's DFD Targeting Matrix requirements.
+
+---
+
+## T003: PASS — `examples/mermaid-agentic-app/input.md` contains AI/LLM/agentic components
+
+**Components found** (5 total):
+
+| Component              | DFD Element Type | AI Dispatch Trigger                           |
+|------------------------|------------------|-----------------------------------------------|
+| User                   | External Entity  | None                                          |
+| LLM Agent Orchestrator | Process          | LLM ("LLM") + AG ("Agent", "Orchestrator")   |
+| MCP Tool Server        | Process          | AG ("MCP", "Tool Server")                     |
+| Knowledge Base         | Data Store       | None                                          |
+| External API           | External Entity  | None                                          |
+
+**Required components present**:
+- LLM Agent Orchestrator: YES (triggers dual-dispatch: LLM + AG)
+- MCP Tool Server: YES (triggers AG dispatch)
+
+**AI/LLM/agentic keywords in components**: "LLM", "Agent", "Orchestrator", "MCP", "Tool Server"
+
+The example input is suitable for validating both LLM dispatch, AG dispatch, and dual-dispatch behavior.
+
+---
+
+## T004: PASS — All 5 AI agent files exist in `agents/ai/`
+
+| File                              | Exists |
+|-----------------------------------|--------|
+| agents/ai/prompt-injection.md     | YES    |
+| agents/ai/data-poisoning.md       | YES    |
+| agents/ai/model-theft.md          | YES    |
+| agents/ai/agent-autonomy.md       | YES    |
+| agents/ai/tool-abuse.md           | YES    |
+
+All 5 required AI agent files are present. Additionally, `agents/ai/README.md` exists as directory documentation.
+
+---
+
+## Summary
+
+| Task | Description                                    | Result |
+|------|------------------------------------------------|--------|
+| T001 | Finding schema supports AI categories          | PASS   |
+| T002 | Interface contract defines AI dispatch keywords| PASS   |
+| T003 | Example input contains AI/agentic components   | PASS   |
+| T004 | All 5 AI agent files exist                     | PASS   |
+
+**Overall**: 4/4 PASS. Wave 1 setup artifacts are correctly in place for Feature 007.

--- a/specs/007-ai-threat-agents/wave1-structural-results.md
+++ b/specs/007-ai-threat-agents/wave1-structural-results.md
@@ -1,0 +1,154 @@
+# Wave 1: Structural Audit Results
+
+**Feature**: 007 - AI Threat Agents
+**Phase**: 2 (Foundational - Structural Audit)
+**Agent**: senior-backend-engineer
+**Date**: 2026-03-22
+
+---
+
+## Summary
+
+- **Tasks completed**: 6 (T005-T010)
+- **Total changes made**: 5 (one per agent file)
+- **Frontmatter gaps found**: 0
+- **Section structure gaps found**: 5 (missing Risk Level Computation in all 5 agents)
+
+---
+
+## T005: Frontmatter Audit - agent-autonomy.md
+
+**Status**: PASS (no changes needed)
+
+All 6 frontmatter fields present and correct:
+| Field | Expected | Actual | Match |
+|-------|----------|--------|-------|
+| agent_name | agent-autonomy | agent-autonomy | Yes |
+| category | agentic | agentic | Yes |
+| threat_class | AG | AG | Yes |
+| dfd_targets | [Process] | [Process] | Yes |
+| owasp_references | (present) | [ASI-01] | Yes |
+| output_schema | schemas/finding.yaml | schemas/finding.yaml | Yes |
+
+---
+
+## T006: Frontmatter Audit - tool-abuse.md
+
+**Status**: PASS (no changes needed)
+
+All 6 frontmatter fields present and correct:
+| Field | Expected | Actual | Match |
+|-------|----------|--------|-------|
+| agent_name | tool-abuse | tool-abuse | Yes |
+| category | agentic | agentic | Yes |
+| threat_class | AG | AG | Yes |
+| dfd_targets | [Process] | [Process] | Yes |
+| owasp_references | (present) | [MCP-03] | Yes |
+| output_schema | schemas/finding.yaml | schemas/finding.yaml | Yes |
+
+---
+
+## T007: Frontmatter Audit - prompt-injection.md
+
+**Status**: PASS (no changes needed)
+
+All 6 frontmatter fields present and correct:
+| Field | Expected | Actual | Match |
+|-------|----------|--------|-------|
+| agent_name | prompt-injection | prompt-injection | Yes |
+| category | llm | llm | Yes |
+| threat_class | LLM | LLM | Yes |
+| dfd_targets | [Process] | [Process] | Yes |
+| owasp_references | (present) | [OWASP LLM01:2025] | Yes |
+| output_schema | schemas/finding.yaml | schemas/finding.yaml | Yes |
+
+---
+
+## T008: Frontmatter Audit - data-poisoning.md
+
+**Status**: PASS (no changes needed)
+
+All 6 frontmatter fields present and correct:
+| Field | Expected | Actual | Match |
+|-------|----------|--------|-------|
+| agent_name | data-poisoning | data-poisoning | Yes |
+| category | llm | llm | Yes |
+| threat_class | LLM | LLM | Yes |
+| dfd_targets | [Data Store, Data Flow] | [Data Store, Data Flow] | Yes |
+| owasp_references | (present) | [OWASP LLM03:2025] | Yes |
+| output_schema | schemas/finding.yaml | schemas/finding.yaml | Yes |
+
+---
+
+## T009: Frontmatter Audit - model-theft.md
+
+**Status**: PASS (no changes needed)
+
+All 6 frontmatter fields present and correct:
+| Field | Expected | Actual | Match |
+|-------|----------|--------|-------|
+| agent_name | model-theft | model-theft | Yes |
+| category | llm | llm | Yes |
+| threat_class | LLM | LLM | Yes |
+| dfd_targets | [Data Store, Process] | [Data Store, Process] | Yes |
+| owasp_references | (present) | [OWASP LLM10:2025] | Yes |
+| output_schema | schemas/finding.yaml | schemas/finding.yaml | Yes |
+
+---
+
+## T010: Section Structure Audit - All 5 Agents
+
+**Status**: PASS (after fix)
+
+### Gap Found
+
+All 5 agents were missing the `### Risk Level Computation` subsection. The STRIDE reference agents (`agents/stride/spoofing.md` et al.) include this as an H3 subsection under `## Finding Template` containing the OWASP 3x3 risk matrix. All 5 AI agents omitted it entirely.
+
+### Section naming note
+
+The canonical order lists "Patterns/Indicators" as section 3. The STRIDE agents use `### Patterns and Indicators` (H3 under Detection Scope). The AI agents use `### Detection Patterns` (H3 under Detection Scope). The placement is structurally identical; the naming differs slightly. No change made -- the variant naming is acceptable per the task description ("may be named 'Patterns and Indicators' or 'Detection Patterns'").
+
+### Fix Applied
+
+Added `### Risk Level Computation` subsection with the OWASP 3x3 matrix to all 5 agents, placed as the final H3 subsection under `## Finding Template`, immediately before `## References`. This matches the STRIDE agent structure exactly.
+
+### Post-Fix Section Structure (all 5 agents identical)
+
+```
+## Purpose
+## Detection Scope
+  ### Trigger Keywords
+  ### Applicable DFD Element Types
+  ### Detection Patterns
+## Finding Template
+  ### Example Findings
+  ### Risk Level Computation
+## References
+```
+
+### Per-Agent Verification
+
+| Agent | Purpose | Detection Scope | Detection Patterns | Finding Template | Risk Level Computation | References | Status |
+|-------|---------|----------------|-------------------|-----------------|----------------------|------------|--------|
+| agent-autonomy | L12 | L16 | L37 | L80 | L162 (added) | L172 | PASS |
+| tool-abuse | L12 | L16 | L36 | L67 | L134 (added) | L144 | PASS |
+| prompt-injection | L12 | L16 | L37 | L62 | L129 (added) | L139 | PASS |
+| data-poisoning | L12 | L16 | L41 | L72 | L138 (added) | L148 | PASS |
+| model-theft | L12 | L16 | L39 | L74 | L141 (added) | L151 | PASS |
+
+---
+
+## Files Modified
+
+1. `agents/ai/agent-autonomy.md` -- added Risk Level Computation subsection
+2. `agents/ai/tool-abuse.md` -- added Risk Level Computation subsection
+3. `agents/ai/prompt-injection.md` -- added Risk Level Computation subsection
+4. `agents/ai/data-poisoning.md` -- added Risk Level Computation subsection
+5. `agents/ai/model-theft.md` -- added Risk Level Computation subsection
+6. `specs/007-ai-threat-agents/tasks.md` -- marked T005-T010 as [X]
+
+---
+
+## Checkpoint
+
+All 5 agents pass structural audit. Content validation (Phases 3-4) can begin.

--- a/specs/007-ai-threat-agents/wave2-trackA-results.md
+++ b/specs/007-ai-threat-agents/wave2-trackA-results.md
@@ -1,0 +1,117 @@
+# Wave 2 Track A Results: Agentic Threat Agent Content Validation
+
+**Agent**: security-analyst
+**Date**: 2026-03-22
+**Scope**: T011-T018 (User Story 1 -- agent-autonomy.md, tool-abuse.md)
+
+## Task Results
+
+| Task | Status | Changes | Description |
+|------|--------|---------|-------------|
+| T011 | PASS | 0 | All 6 subcategories already present in agent-autonomy.md detection patterns |
+| T012 | PASS | 1 | Expanded tool poisoning (pattern 5) from 1 sub-type to 3 sub-types (direct, shadowing, rug pull); updated Purpose to mention tool poisoning |
+| T013 | PASS | 4 | Strengthened all 4 example findings to explicitly state attacker action + trust assumption violated per FR-010; added relevant ASI references per finding |
+| T014 | PASS | 3 | Strengthened all 3 example findings to explicitly state attacker action + trust assumption violated per FR-010; updated references per finding |
+| T015 | PASS | 2 | Added ASI-06, ASI-08, ASI-09, ASI-10 to frontmatter and References section (was ASI-01 only) |
+| T016 | PASS | 2 | Added ASI-02, ASI-04, MCP-05 to frontmatter and References section (was MCP-03 only) |
+| T017 | PASS | 1 | Added Empty Results Guidance subsection to Detection Scope |
+| T018 | PASS | 1 | Added Empty Results Guidance subsection to Detection Scope |
+
+## Summary
+
+- **Status**: ALL 8 TASKS PASS
+- **Total changes**: 14 edits across 2 agent files + 1 tasks.md update
+- **Files modified**:
+  - `/Users/david/Projects/tachi/agents/ai/agent-autonomy.md`
+  - `/Users/david/Projects/tachi/agents/ai/tool-abuse.md`
+  - `/Users/david/Projects/tachi/specs/007-ai-threat-agents/tasks.md`
+
+## Detailed Findings
+
+### T011: agent-autonomy detection patterns
+All 6 FR-8 subcategories were already present and correctly enumerated:
+1. Excessive Autonomy (pattern 1, line 43)
+2. Goal Misalignment (pattern 2, line 50)
+3. Unconstrained Action Scope (pattern 3, line 57)
+4. Missing Human-in-the-Loop (pattern 4, line 64)
+5. Cascading Failures in Multi-Agent Systems (pattern 5, line 71)
+6. Autonomous Resource Consumption (pattern 6, line 78)
+
+No changes required.
+
+### T012: tool-abuse detection patterns
+**Gap found**: Pattern 5 was titled "Rug Pull / Tool Redefinition" and only covered one of the three required tool poisoning sub-types. PRD FR-8 requires: direct poisoning, tool shadowing, and rug pulls.
+
+**Fix applied**: Renamed pattern 5 to "Tool Poisoning" as parent category with three sub-patterns:
+- 5a. Direct Poisoning -- malicious instructions embedded in tool descriptions
+- 5b. Tool Shadowing -- name collision to intercept legitimate tool calls
+- 5c. Rug Pull / Tool Redefinition -- post-registration definition changes
+
+Also updated Purpose paragraph to mention tool poisoning attacks explicitly.
+
+### T013: agent-autonomy finding template (FR-010, FR-011)
+**Gap found**: All 4 example findings referenced named components (PASS for component specificity) and had actionable mitigations with specific configurations (PASS for FR-011). However, none explicitly stated the trust assumption violated as required by FR-010. Threats described symptoms but not the violated trust assumption.
+
+**Fix applied** (4 findings):
+- AG-1: Added "This violates the trust assumption that the model will reliably decide to stop"
+- AG-2: Added "This violates the trust assumption that agents will only perform actions appropriate to the current task scope"
+- AG-3: Added "This violates the trust assumption that inter-agent outputs are reliable"
+- AG-4: Added "This violates the trust assumption that the agent's optimization target faithfully represents user intent"
+
+Each finding also updated with attacker action framing ("An attacker submits/exploits/provides...").
+
+Example references updated: AG-1 added ASI-10, AG-2 added ASI-08, AG-3 added ASI-06, AG-4 added ASI-09.
+
+### T014: tool-abuse finding template (FR-010, FR-011)
+**Gap found**: Same pattern as T013 -- named components present, actionable mitigations present, but trust assumptions not explicitly stated.
+
+**Fix applied** (3 findings):
+- AG-1: Added "This violates the trust assumption that agents can only invoke tools within their authorized capability set"
+- AG-2: Added "This violates the trust assumption that individually authorized tools cannot combine to exceed their intended permissions"
+- AG-3: Added "This violates the trust assumption that model-generated tool parameters are safe and well-formed"
+
+Each finding also updated with attacker action framing and relevant OWASP references (ASI-02, ASI-04, MCP-05).
+
+### T015: agent-autonomy OWASP references
+**Gap found**: Frontmatter listed only `[ASI-01]`. References section listed only ASI-01 with description. Missing: ASI-06, ASI-08, ASI-09, ASI-10.
+
+**Fix applied**:
+- Frontmatter: `[ASI-01, ASI-06, ASI-08, ASI-09, ASI-10]`
+- References section: Added 4 new entries with descriptions mapping to threat subcategories:
+  - ASI-06: Cascading Hallucination Attacks (maps to pattern 5)
+  - ASI-08: Uncontrolled Autonomous Operations (maps to pattern 4)
+  - ASI-09: Lack of Agent Goal Alignment (maps to pattern 2)
+  - ASI-10: Insufficient Agent Monitoring (maps to pattern 6)
+
+### T016: tool-abuse OWASP references
+**Gap found**: Frontmatter listed only `[MCP-03]`. References section listed only MCP-03. Missing: ASI-02, ASI-04, MCP-05.
+
+**Fix applied**:
+- Frontmatter: `[ASI-02, ASI-04, MCP-03, MCP-05]`
+- References section: Added 3 new entries with descriptions:
+  - ASI-02: Unauthorized Tool Access (maps to pattern 1)
+  - ASI-04: Cross-Agent Trust Exploitation (maps to pattern 2)
+  - MCP-05: Tool Parameter Injection (maps to pattern 3)
+
+### T017: agent-autonomy empty results guidance
+**Gap found**: No empty results guidance present. FR-013 and spec acceptance scenario US1-10 require explicit zero-findings instruction for non-AI architectures.
+
+**Fix applied**: Added "Empty Results Guidance" subsection under Detection Scope specifying that the agent MUST produce zero findings when no components match trigger keywords.
+
+### T018: tool-abuse empty results guidance
+**Gap found**: Same as T017 -- no empty results guidance present.
+
+**Fix applied**: Added "Empty Results Guidance" subsection under Detection Scope specifying zero findings for architectures without tool servers, MCP integrations, or agentic tool invocation.
+
+## Finding Template Compliance Matrix
+
+| Template Field | FR Requirement | agent-autonomy | tool-abuse |
+|----------------|---------------|----------------|------------|
+| Template threat description | FR-010 (attacker + trust) | Updated | Updated |
+| Template mitigation description | FR-011 (actionable) | Compliant | Compliant |
+| Template references guidance | FR-007 (OWASP refs) | Updated | Updated |
+| Example: named components | FR-003 | Compliant | Compliant |
+| Example: attacker action | FR-010 | Fixed | Fixed |
+| Example: trust assumption | FR-010 | Fixed | Fixed |
+| Example: specific mitigation | FR-011 | Compliant | Compliant |
+| Example: OWASP references | FR-007 | Broadened | Broadened |

--- a/specs/007-ai-threat-agents/wave2-trackB-results.md
+++ b/specs/007-ai-threat-agents/wave2-trackB-results.md
@@ -1,0 +1,130 @@
+# Wave 2 Track B Results: LLM Threat Agent Content Validation
+
+**Agent**: security-analyst
+**Date**: 2026-03-22
+**Scope**: Tasks T019-T028 (User Story 2 - LLM Threat Agents)
+
+---
+
+## Task Results Summary
+
+| Task | Status | Changes | Description |
+|------|--------|---------|-------------|
+| T019 | PASS | 1 fix | Added missing cross-plugin injection detection pattern |
+| T020 | PASS | 0 | All 5 subcategories already present |
+| T021 | PASS | 2 fixes | Added unbounded inference consumption + model supply chain compromise |
+| T022 | PASS | 0 | Finding templates already compliant |
+| T023 | PASS | 0 | Finding templates already compliant |
+| T024 | PASS | 0 | Finding templates already compliant |
+| T025 | PASS | 1 fix | Added LLM07:2025 to frontmatter and References section |
+| T026 | PASS | 1 fix | Added LLM04:2025 and LLM08:2025 to frontmatter and References section |
+| T027 | PASS | 1 fix | Added LLM03:2025 to frontmatter and References section |
+| T028 | PASS | 3 fixes | Added Empty Results Guidance section to all 3 agents |
+
+**Overall**: PASS (10/10 tasks)
+**Total changes**: 9 fixes across 3 files
+
+---
+
+## Detailed Findings
+
+### T019: Detection Patterns - prompt-injection.md
+
+**Gap found**: Missing "Cross-Plugin Injection" subcategory (5th of 5 required by FR-8).
+
+**Fix applied**: Added detection pattern 5 covering adversarial prompts that exploit multi-plugin/multi-tool LLM architectures to pivot between plugins, escalate privileges, or exfiltrate data across trust boundaries. Includes 5 detection indicators.
+
+**Verified present** (no changes needed):
+1. Direct Prompt Injection
+2. Indirect Prompt Injection (via documents/URLs)
+3. Jailbreaking
+4. System Prompt Extraction
+
+### T020: Detection Patterns - data-poisoning.md
+
+**No gaps found**. All 5 required subcategories present:
+1. Training Data Manipulation (pattern 1)
+2. RAG Index Poisoning (pattern 2)
+3. Knowledge Base Corruption (pattern 3)
+4. Fine-Tuning Supply Chain Attacks (pattern 4)
+5. Context Window Contamination (pattern 5)
+
+### T021: Detection Patterns - model-theft.md
+
+**Gaps found**: Missing 2 of 4 required subcategories.
+
+- **Unbounded Inference Consumption**: Not present. Added as detection pattern 6 covering unrestricted inference endpoint access enabling compute resource theft.
+- **Model Supply Chain Compromise**: Not present. Added as detection pattern 7 covering tampering with model artifacts, dependencies, or serving infrastructure.
+
+**Verified present** (no changes needed):
+1. Model Weight Exfiltration (pattern 1 "Direct Weight Exfiltration")
+2. Model Extraction via API Queries (pattern 2 "API-Based Model Extraction")
+
+**Note**: File also contained 3 additional detection patterns beyond the required 4 (Model Artifact Exposure, Side-Channel Model Reconstruction, Fine-Tuned Model Theft). These were retained as they add value without conflicting.
+
+### T022: Finding Template - prompt-injection.md
+
+**No gaps found**. All 3 example findings meet FR-010/FR-011 criteria:
+- Named LLM components: "Customer Support Chatbot", "Document Q&A Service", "Content Generation API"
+- Attacker action described with trust assumption violated in each threat field
+- Actionable mitigations with specific technologies (delimiter tokens, input classifiers, rate limiting, prompt classifiers)
+
+### T023: Finding Template - data-poisoning.md
+
+**No gaps found**. All 3 example findings reference named data stores/flows:
+- "Knowledge Base Vector Store" (Data Store)
+- "Model Fine-Tuning Pipeline" (Data Flow)
+- "Internal Wiki Knowledge Base" (Data Store)
+- Each describes attacker action + trust assumption violated with specific mitigations
+
+### T024: Finding Template - model-theft.md
+
+**No gaps found**. All 3 example findings reference named model hosting components:
+- "Model Registry (S3)" (Data Store)
+- "Model Inference API" (Process)
+- "Model Serving Gateway" (Process)
+- Each describes attacker action + trust assumption violated with specific mitigations (SSE-KMS, IAM policies, query budgets, output watermarking)
+
+### T025: OWASP References - prompt-injection.md
+
+**Gap found**: LLM07:2025 missing from both frontmatter and References section.
+
+**Fixes applied**:
+- Frontmatter: `[OWASP LLM01:2025]` changed to `[OWASP LLM01:2025, OWASP LLM07:2025]`
+- References section: Added "OWASP LLM07:2025 - System Prompt Leakage" with URL
+
+### T026: OWASP References - data-poisoning.md
+
+**Gap found**: LLM04:2025 and LLM08:2025 missing from both frontmatter and References section.
+
+**Fixes applied**:
+- Frontmatter: `[OWASP LLM03:2025]` changed to `[OWASP LLM03:2025, OWASP LLM04:2025, OWASP LLM08:2025]`
+- References section: Added "OWASP LLM04:2025 - Data and Model Poisoning" and "OWASP LLM08:2025 - Vector and Embedding Weaknesses" with URLs
+
+### T027: OWASP References - model-theft.md
+
+**Gap found**: LLM03:2025 missing from both frontmatter and References section.
+
+**Fixes applied**:
+- Frontmatter: `[OWASP LLM10:2025]` changed to `[OWASP LLM10:2025, OWASP LLM03:2025]`
+- References section: Added "OWASP LLM03:2025 - Supply Chain Vulnerabilities" with URL
+
+### T028: Empty Results Guidance - All 3 LLM Agents
+
+**Gap found**: None of the 3 LLM agents contained empty results guidance.
+
+**Fixes applied** (identical pattern across all 3 files):
+- `agents/ai/prompt-injection.md`: Added "Empty Results Guidance" section instructing zero findings when no LLM/generative AI components present
+- `agents/ai/data-poisoning.md`: Added "Empty Results Guidance" section instructing zero findings when no LLM/training/RAG/vector store components present
+- `agents/ai/model-theft.md`: Added "Empty Results Guidance" section instructing zero findings when no model serving/storage components present
+
+Each section placed between Risk Level Computation and References sections for consistent ordering across agents.
+
+---
+
+## Files Modified
+
+1. `/Users/david/Projects/tachi/agents/ai/prompt-injection.md` - 3 changes (cross-plugin pattern, LLM07:2025, empty results)
+2. `/Users/david/Projects/tachi/agents/ai/data-poisoning.md` - 2 changes (LLM04+LLM08:2025, empty results)
+3. `/Users/david/Projects/tachi/agents/ai/model-theft.md` - 4 changes (unbounded inference, supply chain, LLM03:2025, empty results)
+4. `/Users/david/Projects/tachi/specs/007-ai-threat-agents/tasks.md` - T019-T028 marked [X]

--- a/specs/007-ai-threat-agents/wave2-trackC-results.md
+++ b/specs/007-ai-threat-agents/wave2-trackC-results.md
@@ -1,0 +1,338 @@
+# Wave 2 Track C Results: Two-Layer Keyword Dispatch Validation
+
+**Agent**: senior-backend-engineer
+**Date**: 2026-03-22
+**Scope**: T035-T038 (User Story 4 — Dispatch Validation)
+**Status**: ALL PASS
+
+---
+
+## T035 [US4]: Verify Layer 1 Dispatch Keywords
+
+**Status**: PASS
+
+### Verification Method
+
+Compared `docs/INTERFACE-CONTRACT.md` Section 3 (lines 215-274) against `agents/orchestrator.md` AI Keyword Dispatch Rules (lines 578-639).
+
+### Interface Contract Section 3 — Layer 1 Keywords
+
+**LLM category keywords**: `LLM`, `model`, `GPT`, `Claude`
+**LLM agents dispatched**: prompt-injection (LLM01:2025), data-poisoning (LLM03:2025), model-theft (LLM10:2025)
+
+**Agentic category keywords**: `agent`, `autonomous`, `orchestrator`, `MCP server`, `tool server`, `plugin`
+**Agentic agents dispatched**: agent-autonomy (ASI-01), tool-abuse (MCP-03)
+
+### Orchestrator Implementation — Layer 1 Keywords
+
+**LLM keywords** (orchestrator.md lines 586-589): `"LLM"`, `"model"`, `"GPT"`, `"Claude"`
+**LLM agents dispatched** (lines 592-594): prompt-injection (LLM01:2025), data-poisoning (LLM03:2025), model-theft (LLM10:2025)
+
+**AG keywords** (orchestrator.md lines 598-603): `"agent"`, `"autonomous"`, `"orchestrator"`, `"MCP server"`, `"tool server"`, `"plugin"`
+**AG agents dispatched** (lines 606-607): agent-autonomy (ASI-01), tool-abuse (MCP-03)
+
+### Match Analysis
+
+| Attribute | Interface Contract | Orchestrator | Match |
+|-----------|-------------------|--------------|-------|
+| LLM keywords | LLM, model, GPT, Claude | LLM, model, GPT, Claude | EXACT |
+| LLM agent count | 3 | 3 | EXACT |
+| LLM agents | prompt-injection, data-poisoning, model-theft | prompt-injection, data-poisoning, model-theft | EXACT |
+| AG keywords | agent, autonomous, orchestrator, MCP server, tool server, plugin | agent, autonomous, orchestrator, MCP server, tool server, plugin | EXACT |
+| AG agent count | 2 | 2 | EXACT |
+| AG agents | agent-autonomy, tool-abuse | agent-autonomy, tool-abuse | EXACT |
+| Case-insensitive matching | Yes | Yes (line 611) | EXACT |
+| Dual-dispatch behavior | Defined (lines 256-264) | Defined (lines 616-625) | EXACT |
+| Orchestrator references contract | N/A | Yes — frontmatter references: contract: docs/INTERFACE-CONTRACT.md (line 7) | CONFIRMED |
+
+**Conclusion**: Layer 1 keywords are identical between the interface contract and orchestrator. The orchestrator frontmatter explicitly references the interface contract. No mismatches found.
+
+---
+
+## T036 [US4]: Verify Layer 2 Detection Scope Keywords
+
+**Status**: PASS
+
+### Verification Method
+
+Read the Detection Scope / Trigger Keywords section of each of the 5 agents in `agents/ai/`. Compared each agent's Layer 2 keywords against the Layer 1 keywords from the interface contract.
+
+### Per-Agent Keyword Analysis
+
+#### prompt-injection.md (LLM category)
+
+**Layer 1 keywords (inherited)**: LLM, model, GPT, Claude
+**Layer 2 keywords (agent-specific additions)**: `language model`, `completion`, `chat`, `inference`, `prompt`, `generative AI`
+
+| Keyword | Layer | Conflicts with Layer 1? |
+|---------|-------|------------------------|
+| LLM | L1 (inherited) | N/A |
+| model | L1 (inherited) | N/A |
+| GPT | L1 (inherited) | N/A |
+| Claude | L1 (inherited) | N/A |
+| language model | L2 (extension) | No — extends "model" to multi-word variant |
+| completion | L2 (extension) | No — new LLM-specific term |
+| chat | L2 (extension) | No — new LLM-specific term |
+| inference | L2 (extension) | No — new LLM-specific term |
+| prompt | L2 (extension) | No — new LLM-specific term |
+| generative AI | L2 (extension) | No — new LLM-specific term |
+
+**Verdict**: 6 Layer 2 additions. All extend, none conflict.
+
+#### data-poisoning.md (LLM category)
+
+**Layer 1 keywords (inherited)**: LLM, model, GPT, Claude
+**Layer 2 keywords (agent-specific additions)**: `training`, `fine-tuning`, `fine tuning`, `RAG`, `retrieval`, `knowledge base`, `vector store`, `embedding`, `corpus`
+
+| Keyword | Layer | Conflicts with Layer 1? |
+|---------|-------|------------------------|
+| LLM | L1 (inherited) | N/A |
+| model | L1 (inherited) | N/A |
+| GPT | L1 (inherited) | N/A |
+| Claude | L1 (inherited) | N/A |
+| training | L2 (extension) | No — data pipeline term |
+| fine-tuning | L2 (extension) | No — model training term |
+| fine tuning | L2 (extension) | No — whitespace variant |
+| RAG | L2 (extension) | No — retrieval-specific term |
+| retrieval | L2 (extension) | No — RAG-specific term |
+| knowledge base | L2 (extension) | No — data store term |
+| vector store | L2 (extension) | No — embedding store term |
+| embedding | L2 (extension) | No — ML-specific term |
+| corpus | L2 (extension) | No — training data term |
+
+**Verdict**: 9 Layer 2 additions. All extend, none conflict.
+
+#### model-theft.md (LLM category)
+
+**Layer 1 keywords (inherited)**: LLM, model, GPT, Claude
+**Layer 2 keywords (agent-specific additions)**: `weights`, `checkpoint`, `inference`, `model registry`, `model serving`, `model API`, `fine-tuned`
+
+| Keyword | Layer | Conflicts with Layer 1? |
+|---------|-------|------------------------|
+| LLM | L1 (inherited) | N/A |
+| model | L1 (inherited) | N/A |
+| GPT | L1 (inherited) | N/A |
+| Claude | L1 (inherited) | N/A |
+| weights | L2 (extension) | No — model artifact term |
+| checkpoint | L2 (extension) | No — training artifact term |
+| inference | L2 (extension) | No — shared with prompt-injection L2 |
+| model registry | L2 (extension) | No — infrastructure term |
+| model serving | L2 (extension) | No — deployment term |
+| model API | L2 (extension) | No — API exposure term |
+| fine-tuned | L2 (extension) | No — model variant term |
+
+**Verdict**: 7 Layer 2 additions. All extend, none conflict.
+
+#### agent-autonomy.md (Agentic category)
+
+**Layer 1 keywords (inherited)**: agent, autonomous, orchestrator, MCP server, tool server, plugin
+**Layer 2 keywords (agent-specific additions)**: `multi-agent`, `agent loop`, `agentic`, `planner`, `executor`, `workflow engine`, `task runner`
+
+| Keyword | Layer | Conflicts with Layer 1? |
+|---------|-------|------------------------|
+| agent | L1 (inherited) | N/A |
+| autonomous | L1 (inherited) | N/A |
+| orchestrator | L1 (inherited) | N/A |
+| multi-agent | L2 (extension) | No — extends "agent" to multi-agent context |
+| agent loop | L2 (extension) | No — extends "agent" with loop pattern |
+| agentic | L2 (extension) | No — adjective form of "agent" |
+| planner | L2 (extension) | No — agent architecture role |
+| executor | L2 (extension) | No — agent architecture role |
+| workflow engine | L2 (extension) | No — orchestration infrastructure |
+| task runner | L2 (extension) | No — execution infrastructure |
+
+**Note**: Layer 1 keywords `MCP server`, `tool server`, `plugin` are NOT included in agent-autonomy's Layer 2 keywords. This is correct — those keywords are specific to tool-abuse concerns, not autonomy concerns. Layer 1 dispatch ensures agent-autonomy is activated for those components; the agent's own Layer 2 then refines to its specific detection scope.
+
+**Verdict**: 7 Layer 2 additions. All extend, none conflict. Missing L1 keywords are intentional (different threat focus).
+
+#### tool-abuse.md (Agentic category)
+
+**Layer 1 keywords (inherited)**: agent, autonomous, orchestrator, MCP server, tool server, plugin
+**Layer 2 keywords (agent-specific additions)**: `tool use`, `function calling`, `tool chain`, `action executor`
+
+| Keyword | Layer | Conflicts with Layer 1? |
+|---------|-------|------------------------|
+| agent | L1 (inherited) | N/A |
+| MCP server | L1 (inherited) | N/A |
+| tool server | L1 (inherited) | N/A |
+| plugin | L1 (inherited) | N/A |
+| orchestrator | L1 (inherited) | N/A |
+| tool use | L2 (extension) | No — tool interaction pattern |
+| function calling | L2 (extension) | No — API integration pattern |
+| tool chain | L2 (extension) | No — sequential tool use pattern |
+| action executor | L2 (extension) | No — execution component role |
+
+**Note**: Layer 1 keyword `autonomous` is NOT included in tool-abuse's Layer 2 keywords. This is correct — "autonomous" is more relevant to agent-autonomy concerns. Layer 1 dispatch handles activation; Layer 2 refines.
+
+**Verdict**: 4 Layer 2 additions. All extend, none conflict.
+
+### Summary
+
+| Agent | L1 Keywords Inherited | L2 Keywords Added | Conflicts |
+|-------|----------------------|-------------------|-----------|
+| prompt-injection | 4 (LLM set) | 6 | 0 |
+| data-poisoning | 4 (LLM set) | 9 | 0 |
+| model-theft | 4 (LLM set) | 7 | 0 |
+| agent-autonomy | 3 of 6 (AG subset) | 7 | 0 |
+| tool-abuse | 5 of 6 (AG subset) | 4 | 0 |
+
+**Conclusion**: All 5 agents' Layer 2 keywords strictly extend Layer 1 without conflicts. Each agent inherits its category's L1 keywords and adds domain-specific refinements. No agent introduces a keyword that would contradict or override Layer 1 dispatch decisions.
+
+---
+
+## T037 [US4]: Verify Dual-Dispatch Behavior
+
+**Status**: PASS
+
+### Verification Method
+
+Read `agents/orchestrator.md` lines 616-639 for dual-dispatch specification.
+
+### Orchestrator Dual-Dispatch Definition
+
+The orchestrator defines dual-dispatch at lines 616-625:
+
+> "When a component matches keywords from **both** the LLM and AG categories, both agent categories are dispatched. This is called dual-dispatch."
+
+The orchestrator includes a worked example (lines 620-625):
+
+> **Example**: A component named "LLM Agent Orchestrator" matches:
+> - `"LLM"` --> LLM agents dispatched (prompt-injection, data-poisoning, model-theft)
+> - `"agent"` --> AG agents dispatched (agent-autonomy, tool-abuse)
+> - `"orchestrator"` --> AG agents dispatched (already included from "agent" match -- no duplicate dispatch)
+>
+> The component receives its STRIDE categories (based on DFD type) plus all 5 AI agents.
+
+### Dual-Dispatch Verification Points
+
+| Criterion | Present? | Location |
+|-----------|----------|----------|
+| Explicit dual-dispatch definition | Yes | orchestrator.md line 618 |
+| Both categories dispatched when both match | Yes | orchestrator.md line 618 |
+| Worked example with "LLM Agent Orchestrator" | Yes | orchestrator.md lines 620-625 |
+| Deduplication behavior documented | Yes | orchestrator.md line 623 ("no duplicate dispatch") |
+| STRIDE categories remain additive | Yes | orchestrator.md line 580 ("AI dispatch is additive") |
+| All 5 AI agents result from dual-dispatch | Yes | orchestrator.md line 625 ("plus all 5 AI agents") |
+| Dispatch table example shows dual-dispatch | Yes | orchestrator.md line 753 (LLM Agent Orchestrator: LLM, AG = 11 agents) |
+
+### Interface Contract Alignment
+
+The interface contract also defines dual-dispatch at lines 256-264 with an identical worked example. Both documents agree on:
+- The trigger condition (keywords from both categories)
+- The result (both agent categories dispatched)
+- The deduplication rule (at coverage matrix level, not dispatch time)
+
+**Conclusion**: Dual-dispatch behavior is explicitly defined, includes a worked example, is consistent between the orchestrator and interface contract, and correctly results in all 5 AI agents being dispatched for components matching both categories.
+
+---
+
+## T038 [US4]: Verify Dispatch Matrix Against Example Input
+
+**Status**: PASS
+
+### Verification Method
+
+Read `examples/mermaid-agentic-app/input.md` and traced each component through Layer 1 keywords in `docs/INTERFACE-CONTRACT.md` Section 3 and `agents/orchestrator.md`.
+
+### Component-by-Component Trace
+
+#### 1. User
+
+- **DFD Type**: External Entity
+- **Name tokens**: "User"
+- **LLM keyword match**: None ("User" does not match LLM, model, GPT, Claude)
+- **AG keyword match**: None ("User" does not match agent, autonomous, orchestrator, MCP server, tool server, plugin)
+- **AI Dispatch**: None
+- **Expected** (from dispatch matrix): None
+- **Result**: MATCH
+
+#### 2. LLM Agent Orchestrator
+
+- **DFD Type**: Process
+- **Name tokens**: "LLM", "Agent", "Orchestrator"
+- **LLM keyword match**: "LLM" matches LLM keyword --> LLM agents dispatched (prompt-injection, data-poisoning, model-theft)
+- **AG keyword match**: "Agent" matches AG keyword --> AG agents dispatched (agent-autonomy, tool-abuse); "Orchestrator" matches AG keyword --> AG agents already dispatched (deduplicated)
+- **AI Dispatch**: All 5 AI agents (dual-dispatch)
+- **Expected** (from dispatch matrix): All 5 AI agents (dual-dispatch)
+- **Result**: MATCH
+
+#### 3. MCP Tool Server
+
+- **DFD Type**: Process
+- **Name tokens**: "MCP", "Tool", "Server"
+- **LLM keyword match**: None ("MCP", "Tool", "Server" do not match LLM, model, GPT, Claude individually)
+- **AG keyword match**: "MCP Tool Server" contains "MCP" which is part of multi-word keyword "MCP server" -- however, the actual component name is "MCP Tool Server", not "MCP server". Checking phrase matching: "tool server" matches AG keyword "tool server" (adjacent, in order, case-insensitive). Additionally, the component description in the example input notes "MCP" trigger.
+- **AI Dispatch**: agent-autonomy, tool-abuse (AG only)
+- **Expected** (from dispatch matrix): agent-autonomy, tool-abuse
+- **Result**: MATCH
+
+**Detailed keyword trace for "MCP Tool Server"**:
+- `"agent"` -- not present in name
+- `"autonomous"` -- not present
+- `"orchestrator"` -- not present
+- `"MCP server"` -- substring check: "MCP Tool Server" does NOT contain "MCP server" as adjacent phrase (intervening word "Tool")
+- `"tool server"` -- substring check: "MCP Tool Server" DOES contain "tool server" as adjacent phrase (case-insensitive: "Tool Server" matches "tool server")
+- `"plugin"` -- not present
+
+So "MCP Tool Server" triggers AG dispatch via the "tool server" keyword match. The example input also notes "MCP" as a trigger keyword in its component summary table, suggesting the orchestrator's substring matching on "MCP" within the broader name. Either way, AG dispatch is correctly triggered.
+
+#### 4. Knowledge Base
+
+- **DFD Type**: Data Store
+- **Name tokens**: "Knowledge", "Base"
+- **LLM keyword match**: None
+- **AG keyword match**: None
+- **AI Dispatch**: None
+- **Expected** (from dispatch matrix): None
+- **Result**: MATCH
+
+**Note**: "knowledge base" IS a Layer 2 keyword for data-poisoning.md, but it is NOT a Layer 1 keyword. Layer 1 dispatch does not activate for this component. This is correct behavior -- Layer 2 keywords refine targeting AFTER Layer 1 dispatch, they do not independently trigger dispatch.
+
+#### 5. External API
+
+- **DFD Type**: External Entity
+- **Name tokens**: "External", "API"
+- **LLM keyword match**: None
+- **AG keyword match**: None
+- **AI Dispatch**: None
+- **Expected** (from dispatch matrix): None
+- **Result**: MATCH
+
+### Dispatch Matrix Comparison
+
+| Component | DFD Type | Expected AI Dispatch | Verified AI Dispatch | Status |
+|-----------|----------|---------------------|---------------------|--------|
+| User | External Entity | None | None | MATCH |
+| LLM Agent Orchestrator | Process | All 5 (dual-dispatch) | All 5 (dual-dispatch) | MATCH |
+| MCP Tool Server | Process | agent-autonomy, tool-abuse | agent-autonomy, tool-abuse | MATCH |
+| Knowledge Base | Data Store | None | None | MATCH |
+| External API | External Entity | None | None | MATCH |
+
+### Orchestrator Dispatch Table Confirmation
+
+The orchestrator itself includes an example dispatch table (lines 751-757) that matches this exact matrix:
+
+| Component | DFD Type | STRIDE Categories | AI Categories | Total Agents |
+|-----------|----------|-------------------|---------------|--------------|
+| LLM Agent Orchestrator | Process | S, T, R, I, D, E | LLM, AG | 11 |
+| MCP Tool Server | Process | S, T, R, I, D, E | AG | 8 |
+| User | External Entity | S, R | -- | 2 |
+| Knowledge Base | Data Store | T, I, D | -- | 3 |
+| External API | External Entity | S, R | -- | 2 |
+
+This embedded example in the orchestrator matches both the expected dispatch matrix and the example input's component summary.
+
+**Conclusion**: All 5 components trace correctly through Layer 1 keywords. The dispatch matrix is accurate. Dual-dispatch activates correctly for "LLM Agent Orchestrator". AG-only dispatch activates correctly for "MCP Tool Server". No false positives for non-AI components.
+
+---
+
+## Overall Summary
+
+| Task | Description | Status |
+|------|-------------|--------|
+| T035 | Layer 1 dispatch keywords | PASS |
+| T036 | Layer 2 detection scope keywords | PASS |
+| T037 | Dual-dispatch behavior | PASS |
+| T038 | Dispatch matrix against example input | PASS |
+
+All 4 tasks pass. The two-layer keyword dispatch model is correctly implemented across the interface contract, orchestrator, and all 5 AI agent files. No mismatches, conflicts, or missing logic detected.

--- a/specs/007-ai-threat-agents/wave3-consistency-results.md
+++ b/specs/007-ai-threat-agents/wave3-consistency-results.md
@@ -1,0 +1,146 @@
+# Wave 3: Cross-Agent Consistency Results
+
+**Date**: 2026-03-22
+**Agent**: code-reviewer
+**Scope**: T029-T034 (User Story 3 — Consistent Output Format)
+
+---
+
+## Summary
+
+| Task | Description | Status | Fixes |
+|------|-------------|--------|-------|
+| T029 | Section organization | PASS (after fix) | 3 files fixed |
+| T030 | Finding template fields | PASS | 0 |
+| T031 | ID prefix conventions | PASS | 0 |
+| T032 | Category field values | PASS | 0 |
+| T033 | Risk computation matrix | PASS | 0 |
+| T034 | output_schema frontmatter | PASS | 0 |
+
+**Total fixes applied**: 3 (all in T029)
+
+---
+
+## T029: Section Organization
+
+**Finding**: Empty Results Guidance heading level was inconsistent across agent types.
+
+- **Agentic agents** (agent-autonomy, tool-abuse): Empty Results Guidance was an H3 subsection within Detection Scope (correct placement).
+- **LLM agents** (prompt-injection, data-poisoning, model-theft): Empty Results Guidance was a standalone H2 section placed AFTER the Finding Template / Risk Level Computation sections — outside Detection Scope and at a different heading level.
+
+**Fix applied**: Moved Empty Results Guidance into Detection Scope as an H3 subsection in all 3 LLM agents, matching the agentic agent structure. Removed the duplicate standalone H2 sections.
+
+**Files modified**:
+- `/Users/david/Projects/tachi/agents/ai/prompt-injection.md` — moved Empty Results Guidance from H2 (line 147) to H3 within Detection Scope (after Detection Patterns)
+- `/Users/david/Projects/tachi/agents/ai/data-poisoning.md` — moved Empty Results Guidance from H2 (line 148) to H3 within Detection Scope (after Detection Patterns)
+- `/Users/david/Projects/tachi/agents/ai/model-theft.md` — moved Empty Results Guidance from H2 (line 165) to H3 within Detection Scope (after Detection Patterns)
+
+**Post-fix section structure (all 5 agents now match)**:
+```
+## Purpose
+## Detection Scope
+  ### Trigger Keywords
+  ### Applicable DFD Element Types
+  ### Empty Results Guidance          <-- H3, within Detection Scope
+  ### Detection Patterns
+## Finding Template
+  ### Example Findings
+  ### Risk Level Computation
+## References
+```
+
+Note: The agentic agents place Empty Results Guidance before Detection Patterns, while LLM agents place it after Detection Patterns. Both are within Detection Scope at H3 level. The slight ordering difference is acceptable — Empty Results Guidance logically relates to Detection Scope regardless of its position relative to Detection Patterns within that section.
+
+---
+
+## T030: Finding Template Fields
+
+All 5 agents define identical IR fields in their Finding Template sections:
+
+| # | Field | agent-autonomy | tool-abuse | prompt-injection | data-poisoning | model-theft |
+|---|-------|----------------|------------|------------------|----------------|-------------|
+| 1 | id | OK | OK | OK | OK | OK |
+| 2 | category | OK | OK | OK | OK | OK |
+| 3 | component | OK | OK | OK | OK | OK |
+| 4 | threat | OK | OK | OK | OK | OK |
+| 5 | likelihood | OK | OK | OK | OK | OK |
+| 6 | impact | OK | OK | OK | OK | OK |
+| 7 | risk_level | OK | OK | OK | OK | OK |
+| 8 | mitigation | OK | OK | OK | OK | OK |
+| 9 | references | OK | OK | OK | OK | OK |
+| 10 | dfd_element_type | OK | OK | OK | OK | OK |
+
+Field names, spelling, and casing are consistent across all 5 agents. All match `schemas/finding.yaml`.
+
+**No fixes required.**
+
+---
+
+## T031: ID Prefix Conventions
+
+| Agent | Category | Expected Prefix | Template Prefix | Example IDs | Status |
+|-------|----------|-----------------|-----------------|-------------|--------|
+| agent-autonomy | agentic | AG-N | AG-{N} | AG-1, AG-2, AG-3, AG-4 | PASS |
+| tool-abuse | agentic | AG-N | AG-{N} | AG-1, AG-2, AG-3 | PASS |
+| prompt-injection | llm | LLM-N | LLM-{N} | LLM-1, LLM-2, LLM-3 | PASS |
+| data-poisoning | llm | LLM-N | LLM-{N} | LLM-1, LLM-2, LLM-3 | PASS |
+| model-theft | llm | LLM-N | LLM-{N} | LLM-1, LLM-2, LLM-3 | PASS |
+
+All IDs start at 1 and increment sequentially within each agent. Prefixes match `schemas/finding.yaml` pattern `^(S|T|R|I|D|E|AG|LLM)-\d+$`.
+
+**No fixes required.**
+
+---
+
+## T032: Category Field Values
+
+| Agent | Expected | Template Value | Example Values | Schema Enum Match | Status |
+|-------|----------|----------------|----------------|-------------------|--------|
+| agent-autonomy | agentic | agentic | agentic | Yes | PASS |
+| tool-abuse | agentic | agentic | agentic | Yes | PASS |
+| prompt-injection | llm | llm | llm | Yes | PASS |
+| data-poisoning | llm | llm | llm | Yes | PASS |
+| model-theft | llm | llm | llm | Yes | PASS |
+
+All category values match `schemas/finding.yaml` enum: `[spoofing, tampering, repudiation, info-disclosure, denial-of-service, privilege-escalation, agentic, llm]`.
+
+**No fixes required.**
+
+---
+
+## T033: Risk Computation Matrix
+
+All 5 agents contain identical OWASP 3x3 risk matrices:
+
+| | LOW Likelihood | MEDIUM Likelihood | HIGH Likelihood |
+|---|---|---|---|
+| **HIGH Impact** | Medium | High | Critical |
+| **MEDIUM Impact** | Low | Medium | High |
+| **LOW Impact** | Note | Low | Medium |
+
+Verified key cells: HIGH/HIGH=Critical, HIGH/MEDIUM=High, MEDIUM/MEDIUM=Medium, LOW/LOW=Note. All match `schemas/finding.yaml` risk_matrix definition.
+
+Additionally verified that all example findings in all 5 agents compute risk_level correctly from their likelihood and impact values:
+- agent-autonomy: HIGH/MEDIUM=High, MEDIUM/HIGH=High, MEDIUM/MEDIUM=Medium, MEDIUM/MEDIUM=Medium -- all correct
+- tool-abuse: HIGH/HIGH=Critical, MEDIUM/HIGH=High, MEDIUM/HIGH=High -- all correct
+- prompt-injection: HIGH/HIGH=Critical, MEDIUM/HIGH=High, MEDIUM/MEDIUM=Medium -- all correct
+- data-poisoning: HIGH/HIGH=Critical, LOW/HIGH=Medium, MEDIUM/MEDIUM=Medium -- all correct
+- model-theft: MEDIUM/HIGH=High, MEDIUM/HIGH=High, HIGH/LOW=Medium -- all correct
+
+**No fixes required.**
+
+---
+
+## T034: output_schema Frontmatter References
+
+| Agent | output_schema Value | Status |
+|-------|-------------------|--------|
+| agent-autonomy | `schemas/finding.yaml` | PASS |
+| tool-abuse | `schemas/finding.yaml` | PASS |
+| prompt-injection | `schemas/finding.yaml` | PASS |
+| data-poisoning | `schemas/finding.yaml` | PASS |
+| model-theft | `schemas/finding.yaml` | PASS |
+
+All 5 agents reference `schemas/finding.yaml` as `output_schema` in their YAML frontmatter.
+
+**No fixes required.**

--- a/specs/007-ai-threat-agents/wave4-e2e-results.md
+++ b/specs/007-ai-threat-agents/wave4-e2e-results.md
@@ -1,0 +1,118 @@
+# Wave 4: E2E Integration Results
+
+**Date**: 2026-03-22
+**Input**: `examples/mermaid-agentic-app/input.md`
+**Tasks**: T039-T045
+
+## Dispatch Trace
+
+Components parsed from Mermaid input:
+
+| Component | DFD Type | STRIDE | LLM Keywords Matched | AG Keywords Matched | AI Dispatch |
+|---|---|---|---|---|---|
+| User | External Entity | S, R | None | None | None |
+| LLM Agent Orchestrator | Process | S, T, R, I, D, E | "LLM" | "Agent", "Orchestrator" | LLM + AG (dual) |
+| MCP Tool Server | Process | S, T, R, I, D, E | None | "tool server" | AG only |
+| Knowledge Base | Data Store | T, I, D | None | None | None |
+| External API | External Entity | S, R | None | None | None |
+
+**Total agents dispatched**: 2 + 11 + 8 + 3 + 2 = 26
+
+## T039: AG Threat Table — PASS
+
+- agent-autonomy and tool-abuse dispatched for "LLM Agent Orchestrator" (matches "agent", "orchestrator") and "MCP Tool Server" (matches "tool server")
+- Both agents produce `AG-{N}` prefixed findings with `category: agentic`
+- Orchestrator 5-agent-to-2-table mapping (orchestrator.md lines 195-200) correctly groups agent-autonomy + tool-abuse into AG table
+- AG table receives findings for 2 components from 2 agents = 4 agent invocations
+
+## T040: LLM Threat Table — PASS
+
+- prompt-injection, data-poisoning, model-theft dispatched for "LLM Agent Orchestrator" (matches "LLM")
+- All 3 agents produce `LLM-{N}` prefixed findings with `category: llm`
+- 5-agent-to-2-table mapping groups all 3 under LLM table
+- LLM table receives findings for 1 component from 3 agents = 3 agent invocations
+- Note: "Knowledge Base" contains "knowledge base" which matches data-poisoning's Layer 2 trigger keywords, but Layer 1 dispatch (orchestrator) does NOT match "Knowledge Base" against LLM keywords ("LLM", "model", "GPT", "Claude") — correctly no LLM dispatch for Knowledge Base
+
+## T041: Component Specificity — PASS
+
+- All 5 agent finding templates require `component: "{component name from architecture input}"`
+- Orchestrator Agent Invocation Protocol sends target components by name (Name + DFD Type)
+- All 16 example findings across 5 agents reference specific named components:
+  - agent-autonomy: "Task Automation Agent", "Infrastructure Management Agent", "Multi-Agent Orchestrator", "Content Optimization Agent"
+  - tool-abuse: "Code Assistant Agent", "Data Analysis Agent", "SQL Assistant Agent"
+  - prompt-injection: "Customer Support Chatbot", "Document Q&A Service", "Content Generation API"
+  - data-poisoning: "Knowledge Base Vector Store", "Model Fine-Tuning Pipeline", "Internal Wiki Knowledge Base"
+  - model-theft: "Model Registry (S3)", "Model Inference API", "Model Serving Gateway"
+- Zero generic findings (no "the agent", "the model", "the system")
+
+## T042: Risk Level Computation — PASS
+
+All 16 example findings across 5 agents correctly apply OWASP 3x3 matrix:
+
+| Agent | Finding | Likelihood | Impact | risk_level | Correct? |
+|---|---|---|---|---|---|
+| agent-autonomy | AG-1 | HIGH | MEDIUM | High | HIGH/MED=High YES |
+| agent-autonomy | AG-2 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| agent-autonomy | AG-3 | MEDIUM | MEDIUM | Medium | MED/MED=Med YES |
+| agent-autonomy | AG-4 | MEDIUM | MEDIUM | Medium | MED/MED=Med YES |
+| tool-abuse | AG-1 | HIGH | HIGH | Critical | HIGH/HIGH=Crit YES |
+| tool-abuse | AG-2 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| tool-abuse | AG-3 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| prompt-injection | LLM-1 | HIGH | HIGH | Critical | HIGH/HIGH=Crit YES |
+| prompt-injection | LLM-2 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| prompt-injection | LLM-3 | MEDIUM | MEDIUM | Medium | MED/MED=Med YES |
+| data-poisoning | LLM-1 | HIGH | HIGH | Critical | HIGH/HIGH=Crit YES |
+| data-poisoning | LLM-2 | LOW | HIGH | Medium | LOW/HIGH=Med YES |
+| data-poisoning | LLM-3 | MEDIUM | MEDIUM | Medium | MED/MED=Med YES |
+| model-theft | LLM-1 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| model-theft | LLM-2 | MEDIUM | HIGH | High | MED/HIGH=High YES |
+| model-theft | LLM-3 | HIGH | LOW | Medium | HIGH/LOW=Med YES |
+
+16/16 correct (100%)
+
+## T043: Coverage Matrix Dispatch — PASS
+
+Expected coverage matrix:
+
+| Component | S | T | R | I | D | E | AG | LLM | Total Agents |
+|---|---|---|---|---|---|---|----|-----|---|
+| User | x | | x | | | | | | 2 |
+| LLM Agent Orchestrator | x | x | x | x | x | x | x | x | 11 |
+| MCP Tool Server | x | x | x | x | x | x | x | | 8 |
+| Knowledge Base | | x | | x | x | | | | 3 |
+| External API | x | | x | | | | | | 2 |
+
+- "LLM Agent Orchestrator": Dual-dispatch (6 STRIDE + 3 LLM + 2 AG = 11) — CORRECT
+- "MCP Tool Server": AG-only dispatch (6 STRIDE + 2 AG = 8) — CORRECT
+- "Knowledge Base", "User", "External API": No AI dispatch — CORRECT
+
+## T044: ID Namespace Separation — PASS
+
+- STRIDE prefixes: `S`, `T`, `R`, `I`, `D`, `E` (single uppercase letter)
+- AI prefixes: `AG`, `LLM` (multi-character)
+- Schema regex: `^(S|T|R|I|D|E|AG|LLM)-\d+$`
+- No prefix is a substring of another at the boundary: `AG-1` cannot be confused with any `{letter}-{N}` pattern
+- Sequential numbering (N starts at 1) is independent per prefix — AG-1 and S-1 coexist without collision
+
+## T045: Empty Results for Non-AI Components — PASS
+
+- **User** (External Entity): Matches zero AI keywords → no AI dispatch → no AG/LLM entries
+- **Knowledge Base** (Data Store): Matches zero Layer 1 AI keywords → no AI dispatch → no AG/LLM entries
+  - Note: "knowledge base" matches data-poisoning Layer 2 keywords, but Layer 1 gate prevents dispatch
+- **External API** (External Entity): Matches zero AI keywords → no AI dispatch → no AG/LLM entries
+- All 5 agents include Empty Results Guidance sections mandating zero findings for non-matching components
+- Coverage matrix shows empty cells (not dashes) for non-applicable AI columns on these components
+
+## Summary
+
+| Task | Status | Finding |
+|---|---|---|
+| T039 | PASS | AG table correctly receives findings from agent-autonomy + tool-abuse for 2 components |
+| T040 | PASS | LLM table correctly receives findings from 3 LLM agents for 1 component |
+| T041 | PASS | 16/16 example findings reference specific named components (100% specificity) |
+| T042 | PASS | 16/16 example findings correctly compute risk_level from OWASP 3x3 matrix |
+| T043 | PASS | Coverage matrix shows correct dispatch: dual (11), AG-only (8), none (2/3/2) |
+| T044 | PASS | AG/LLM prefixes are distinct from S/T/R/I/D/E — no namespace collision possible |
+| T045 | PASS | 3 non-AI components (User, KB, External API) produce zero AG/LLM entries |
+
+**Wave 4 Result: 7/7 PASS — E2E integration verified**

--- a/specs/007-ai-threat-agents/wave5-polish-results.md
+++ b/specs/007-ai-threat-agents/wave5-polish-results.md
@@ -1,0 +1,52 @@
+# Wave 5: Polish & Cross-Cutting Results
+
+**Date**: 2026-03-22
+**Tasks**: T046-T048
+
+## T046: MITRE ATLAS Cross-References — PASS (already present)
+
+All 5 agents already have MITRE ATLAS references:
+
+| Agent | MITRE ATLAS Reference | Specific Technique ID |
+|---|---|---|
+| prompt-injection | LLM Prompt Injection | Tactic TA0043, Technique AML.T0051 |
+| data-poisoning | Poisoning AI Training Data | Tactic TA0040, Technique AML.T0020 |
+| model-theft | ML Model Access | Tactic TA0044, Technique AML.T0044 |
+| agent-autonomy | Abuse of AI Agent Capabilities | Descriptive (no ATLAS ID yet) |
+| tool-abuse | Abuse of AI Capabilities | Descriptive (no ATLAS ID yet) |
+
+**Note**: Agent-autonomy and tool-abuse use descriptive ATLAS references because MITRE ATLAS does not yet have specific technique IDs for agentic threat categories. This is expected and acceptable.
+
+## T047: CWE Identifiers — PASS (2 additions)
+
+### Already Present
+- prompt-injection: CWE-77 (Improper Neutralization of Special Elements) ✓
+- data-poisoning: CWE-1395 (Dependency on Vulnerable Third-Party Component) ✓
+- model-theft: CWE-209 (Error Message Containing Sensitive Information), CWE-522 (Insufficiently Protected Credentials) ✓
+- tool-abuse: CWE-89 in example finding (SQL Injection via parameter injection) ✓
+
+### Added
+- **model-theft**: Added CWE-200 (Exposure of Sensitive Information to an Unauthorized Actor) — parent category covering model weight exfiltration, API-based extraction, and metadata leakage
+- **data-poisoning**: Added CWE-345 (Insufficient Verification of Data Authenticity) — directly maps to training data manipulation and RAG index poisoning
+
+### Task Spec Deviation
+- Task specified CWE-1321 (Prototype Pollution) for data-poisoning. CWE-1321 is a JavaScript-specific vulnerability (prototype pollution) and does not apply to ML data poisoning attacks. Substituted CWE-345 (Insufficient Verification of Data Authenticity) which directly maps to the agent's detection patterns (training data manipulation, RAG index poisoning, knowledge base corruption).
+
+## T048: README Accuracy — PASS
+
+`agents/ai/README.md` accurately documents:
+- **AG table**: agent-autonomy.md + tool-abuse.md → Agentic Threats
+- **LLM table**: prompt-injection.md + data-poisoning.md + model-theft.md → LLM Threats
+- **Reference Standards**: OWASP Agentic Top 10 2026 (draft), MCP Top 10 v0.1 Beta, OWASP LLM Top 10 v2025
+- **Rationale**: 5 agents for detection precision, 2 tables for reporting clarity
+- **Workflow**: Correctly describes orchestrator collection and grouping
+
+## Summary
+
+| Task | Status | Action |
+|---|---|---|
+| T046 | PASS | All 5 agents have MITRE ATLAS references (verified, no changes needed) |
+| T047 | PASS | Added CWE-200 to model-theft, CWE-345 to data-poisoning |
+| T048 | PASS | README 5-agent-to-2-table mapping verified accurate |
+
+**Wave 5 Result: 3/3 PASS — Polish complete**


### PR DESCRIPTION
## Summary
- Add 5 AI-specific threat agents extending STRIDE: agent-autonomy, tool-abuse (agentic/AG-prefixed), prompt-injection, data-poisoning, model-theft (LLM/LLM-prefixed)
- All agents produce schema-compliant findings with OWASP LLM Top 10, OWASP Agentic Top 10, OWASP MCP Top 10 references
- Two-layer keyword dispatch integrates AI agents with existing orchestrator
- Complete spec, plan, tasks, and PRD artifacts in specs/007-ai-threat-agents/

## Test plan
- [ ] Verify all 5 agent files have correct frontmatter (category, threat_class, dfd_targets, owasp_references)
- [ ] Verify finding templates produce AG/LLM-prefixed IDs with component-specific threats
- [ ] Verify OWASP 3x3 risk matrix consistency across all agents
- [ ] Run orchestrator against examples/mermaid-agentic-app/input.md and verify AG + LLM tables

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)