### PR TITLE
docs(007): update CHANGELOG for AI Threat Agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Feature 007 — AI Threat Agents
+
+**Added**
+- AI threat agent prompts for 5 agentic threat categories: prompt injection, data poisoning, tool abuse, model theft, agent autonomy (`eaa0439`)
+
+**Changed**
+- Closed Feature 007 — updated product docs, archived specs, regenerated backlog (`2ca4a19`, `71206e8`)
+
 ### Feature 003 — Orchestrator Agent
 
 **Added**


### PR DESCRIPTION
## Summary
- Add Feature 007 (AI Threat Agents) entries to CHANGELOG under [Unreleased]
- Generated via `/aod.document` post-delivery review

## Test plan
- [x] CHANGELOG format follows Keep a Changelog standard
- [x] Commit SHAs match actual Feature 007 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)