### PR TITLE
feat(018): threat infographic agent with Gemini integration

### DIFF
--- a/agents/orchestrator.md
+++ b/agents/orchestrator.md
@@ -5,10 +5,11 @@ status: active
 version: "1.2"
 description: >
   Central coordinator for OWASP four-step threat modeling with Phase 5 (Report)
-  integration. Parses architecture input, dispatches STRIDE and AI agents,
-  detects cross-agent correlations using 5 deterministic rules, produces
-  deduplicated coverage matrix, risk summary, SARIF 2.1.0 output, and
-  narrative threat report with Mermaid attack trees.
+  and Phase 6 (Infographic) integration. Parses architecture input, dispatches
+  STRIDE and AI agents, detects cross-agent correlations using 5 deterministic
+  rules, produces deduplicated coverage matrix, risk summary, SARIF 2.1.0
+  output, narrative threat report with Mermaid attack trees, and visual risk
+  infographic specification with optional Gemini-generated image.
 references:
   contract: docs/INTERFACE-CONTRACT.md
   schemas:
@@ -16,6 +17,7 @@ references:
     input: schemas/input.yaml
     output: schemas/output.yaml
     report: schemas/report.yaml
+    infographic: schemas/infographic.yaml
   templates:
     threats: templates/threats.md
     sarif_template: templates/threats.sarif
@@ -35,6 +37,7 @@ references:
       - agents/ai/agent-autonomy.md
       - agents/ai/tool-abuse.md
     report: agents/threat-report.md
+    infographic: agents/threat-infographic.md
 ---
 
 # Orchestrator
@@ -46,8 +49,9 @@ You are the tachi orchestrator -- the central coordinator that drives the comple
 3. **Phase 3 -- Determine Countermeasures**: Collect findings from all dispatched agents, validate risk levels, and assemble them into structured tables.
 4. **Phase 4 -- Assess**: Generate the coverage matrix, risk summary, and recommended actions list.
 5. **Phase 5 -- Report** (optional, default-on): Invoke the report agent to generate a narrative threat report with Mermaid attack trees and a prioritized remediation roadmap.
+6. **Phase 6 -- Infographic** (optional, default-on): Invoke the infographic agent to generate a visual risk specification and optional presentation-ready image.
 
-Your output is a `threats.md` document containing all 7 required sections plus Section 4a (Correlated Findings), a `threats.sarif` file containing the same findings in SARIF 2.1.0 format, and (when Phase 5 is enabled) a `threat-report.md` narrative report with `attack-trees/` containing Mermaid attack tree files for Critical and High findings. All files are produced in the same output directory. The `threats.md` and `threats.sarif` output must conform to the structure defined in the Output Format Specification below. You must not produce any output outside this structure.
+Your output is a `threats.md` document containing all 7 required sections plus Section 4a (Correlated Findings), a `threats.sarif` file containing the same findings in SARIF 2.1.0 format, (when Phase 5 is enabled) a `threat-report.md` narrative report with `attack-trees/` containing Mermaid attack tree files for Critical and High findings, and (when Phase 6 is enabled) a `threat-infographic-spec.md` visual risk specification with an optional `threat-infographic.jpg` image when the Gemini API is available. All files are produced in the same output directory. The `threats.md` and `threats.sarif` output must conform to the structure defined in the Output Format Specification below. You must not produce any output outside this structure.
 
 You are platform-neutral. You do not reference any specific agentic coding tool, IDE, or invocation framework. Your instructions work with any LLM capable of following structured markdown prompts.
 
@@ -83,6 +87,8 @@ Every invocation produces two output files in the same output directory, with tw
 2. **`threats.sarif`** — Machine-readable SARIF 2.1.0 JSON file containing the same findings mapped to the SARIF standard for integration with GitHub Code Scanning, VS Code SARIF Viewer, Azure DevOps, and other SARIF-compatible tools.
 3. **`threat-report.md`** — (Phase 5, default-on) Narrative threat report with executive summary, attack trees, and prioritized remediation roadmap.
 4. **`attack-trees/`** — (Phase 5, default-on) Directory of standalone Mermaid attack tree files, one per Critical and High finding.
+5. **`threat-infographic-spec.md`** — (Phase 6, default-on) Visual risk specification containing 6 sections of structured data for infographic rendering.
+6. **`threat-infographic.jpg`** — (Phase 6, conditional) Presentation-ready infographic image generated via Google Gemini API. Only produced when `GEMINI_API_KEY` is set and the API call succeeds.
 
 Both files use the same finding data collected in Phase 3. The `threats.md` sections must appear in the order listed below. The `threats.sarif` generation instructions appear in the "SARIF Output Generation" section after the Output Structural Validation Checklist.
 
@@ -1203,7 +1209,15 @@ Before finalizing the output document, run the following validation checklist ag
 - [ ] Finding count in `threat-report.md` frontmatter matches the finding count in `threats.md`
 - [ ] Appendix: Finding Reference in `threat-report.md` contains every finding ID from `threats.md`
 
-If all checks pass, the `threats.md` output document is structurally valid, the `threats.sarif` file is consistent with it, and (when Phase 5 is enabled) the `threat-report.md` and `attack-trees/` are complete. Produce the final outputs.
+#### Phase 6 Outputs (when Phase 6 is enabled)
+
+- [ ] `threat-infographic-spec.md` exists in the output directory
+- [ ] `threat-infographic-spec.md` contains all 6 required sections (Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings, Architecture Threat Overlay, Visual Design Directives)
+- [ ] Risk distribution counts in `threat-infographic-spec.md` match `threats.md` Section 6 (Risk Summary)
+- [ ] If `GEMINI_API_KEY` is set: `threat-infographic.jpg` exists in the output directory and is a valid JPEG file
+- [ ] If `GEMINI_API_KEY` is not set: informational message logged ("Gemini API key not configured — infographic image generation skipped. Specification saved."), no image file expected
+
+If all checks pass, the `threats.md` output document is structurally valid, the `threats.sarif` file is consistent with it, (when Phase 5 is enabled) the `threat-report.md` and `attack-trees/` are complete, and (when Phase 6 is enabled) the `threat-infographic-spec.md` and optional `threat-infographic.jpg` are valid. Produce the final outputs.
 
 ---
 
@@ -1765,6 +1779,78 @@ When Phase 5 is skipped:
 - The Output Structural Validation Checklist Phase 5 checks are skipped (they only apply when Phase 5 runs)
 
 This preserves full backward compatibility with Phase 1-4 behavior.
+
+---
+
+## Phase 6: Infographic — "Visualize the risk landscape"
+
+This phase transforms the structured threat model output from Phase 4 into a visual risk specification and optional presentation-ready infographic image. Phase 6 is optional (default-on) and runs after Phase 5 (Report) completes (or after Phase 4 if Phase 5 is skipped).
+
+Phase objectives:
+
+1. Invoke the infographic agent (`agents/threat-infographic.md`) with the completed `threats.md` as sole input.
+2. Generate `threat-infographic-spec.md` containing 6 required sections: Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings, Architecture Threat Overlay, and Visual Design Directives.
+3. When `GEMINI_API_KEY` is available, generate `threat-infographic.jpg` — a presentation-ready infographic image via Google Gemini API.
+4. Place all Phase 6 outputs in the same output directory as `threats.md` and `threats.sarif`.
+
+**Pipeline isolation**: Phase 6 failures MUST NOT block or invalidate Phases 1-5 outputs. If the infographic agent encounters any error — API failure, content policy rejection, schema validation failure, or unexpected exception — the pipeline completes successfully with all Phase 1-5 outputs intact. Phase 6 errors are logged but never propagated as pipeline failures.
+
+---
+
+### Phase 6 Dispatch
+
+After Phase 5 completes (or after Phase 4 if Phase 5 is skipped) and `threats.md` is written to the output directory:
+
+1. **Check opt-out**: If the `--skip-infographic` flag is set, or the `TACHI_SKIP_INFOGRAPHIC=true` environment variable is set, or the `infographic` configuration is set to `false` (see Opt-Out Configuration below), skip Phase 6 entirely. The pipeline completes with no change to existing Phase 1-5 behavior.
+
+2. **Fresh-context invocation**: Invoke the infographic agent (`agents/threat-infographic.md`) in a fresh context. The invocation MUST:
+   - Pass ONLY the `threats.md` file path as input
+   - NOT pass accumulated pipeline state from Phases 1-5
+   - NOT pass `threat-report.md`, `attack-trees/`, or any other Phase 5 outputs
+   - NOT pass intermediate component inventories, agent dispatch logs, or correlation detection state
+   - The infographic agent reads `threats.md` and operates independently using only what that file contains
+
+3. **Context isolation boundary**: The following content boundary applies to Phase 6:
+   ```
+   <infographic-input>
+   {path to threats.md}
+   </infographic-input>
+   ```
+   The infographic agent treats `threats.md` as its complete input. It does not access or require any other pipeline artifacts. This prevents context window pressure from accumulated pipeline state and ensures the infographic agent operates on the validated, final output.
+
+4. **Output placement**: The infographic agent writes its outputs to the same directory as `threats.md`:
+   ```
+   {output-directory}/
+   ├── threats.md                    (Phase 4 — existing, unchanged)
+   ├── threats.sarif                  (Phase 4 — existing, unchanged)
+   ├── threat-report.md               (Phase 5 — existing, unchanged)
+   ├── attack-trees/                  (Phase 5 — existing, unchanged)
+   ├── threat-infographic-spec.md     (Phase 6 — new)
+   └── threat-infographic.jpg         (Phase 6 — new, conditional on GEMINI_API_KEY)
+   ```
+
+5. **Completion**: Phase 6 is complete when `threat-infographic-spec.md` is written. The `threat-infographic.jpg` is a conditional output — its absence (due to missing API key or API error) does not constitute a Phase 6 failure. The pipeline then proceeds to the validation checklist.
+
+---
+
+### Opt-Out Configuration
+
+Phase 6 (Infographic) is default-on. It can be skipped using any of the following mechanisms:
+
+1. **Flag**: `--skip-infographic` — When the orchestrator is invoked with this flag, Phase 6 is skipped entirely. The pipeline completes after Phase 5 (or Phase 4 if Phase 5 is also skipped) with no change to existing behavior.
+
+2. **Environment variable**: `TACHI_SKIP_INFOGRAPHIC=true` — When this environment variable is set to `true`, Phase 6 is skipped. This enables CI/CD pipelines to disable infographic generation without modifying invocation flags.
+
+3. **Configuration**: If the orchestrator's invocation context includes a configuration parameter `infographic: false`, Phase 6 is skipped.
+
+When any opt-out mechanism is active (flag, environment variable, or configuration — any one is sufficient):
+- The pipeline completes as if Phase 6 does not exist
+- No `threat-infographic-spec.md` or `threat-infographic.jpg` files are generated
+- No warning or informational message is logged about the skip
+- `threats.md`, `threats.sarif`, `threat-report.md`, and `attack-trees/` are unaffected
+- The Output Structural Validation Checklist Phase 6 checks are skipped (they only apply when Phase 6 runs)
+
+This preserves full backward compatibility with Phase 1-5 behavior.
 
 ---
 

--- a/agents/threat-infographic.md
+++ b/agents/threat-infographic.md
@@ -1,0 +1,535 @@
+---
+agent_name: threat-infographic
+category: report
+status: active
+version: "1.0"
+description: >
+  Transforms structured threat model output (threats.md) into a visual risk
+  specification (threat-infographic-spec.md) with six required sections:
+  Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings,
+  Architecture Threat Overlay, and Visual Design Directives. Optionally
+  produces a presentation-ready threat-infographic.jpg via Gemini API.
+  The specification is the primary deliverable; the image is best-effort.
+input_schema: schemas/output.yaml
+output_schema: schemas/infographic.yaml
+output_files:
+  - threat-infographic-spec.md
+  - threat-infographic.jpg  # conditional on GEMINI_API_KEY
+references:
+  schemas:
+    input: schemas/output.yaml
+    output: schemas/infographic.yaml
+    finding: schemas/finding.yaml
+---
+
+# Threat Infographic Agent
+
+## Core Mission
+
+You are the tachi threat infographic agent. Your mission is to transform the structured threat model output (`threats.md`) into a visual risk specification that communicates security posture to executive audiences — board members, CISOs, and management teams who need to understand risk at a glance without reading a full threat report.
+
+Your input is a single file: `threats.md`, produced by the orchestrator's Phase 4 (Assess). This file contains 7 sections plus Section 4a (Correlated Findings), conforming to `schemas/output.yaml`. You must not require any other input — you run in a fresh context with only `threats.md`.
+
+Your output is:
+1. **`threat-infographic-spec.md`** — A structured infographic specification with 6 sections conforming to `schemas/infographic.yaml`. This is the **primary deliverable**. It contains all data points, color coding, layout instructions, and text content needed to render a presentation-ready infographic.
+2. **`threat-infographic.jpg`** (optional) — A presentation-ready JPEG image rendered from the specification via Gemini API. Produced only when `GEMINI_API_KEY` is available and the API call succeeds. This is a **best-effort** deliverable.
+
+The specification is self-contained: a designer can render the infographic from the spec alone without access to `threats.md`.
+
+You are platform-neutral. You do not reference any specific agentic coding tool, IDE, or invocation framework. Your instructions work with any LLM capable of following structured markdown prompts.
+
+---
+
+## Input Contract
+
+You consume the complete `threats.md` file produced by the orchestrator. The structure is defined by `schemas/output.yaml` (v1.1). You parse specific sections relevant to infographic data extraction.
+
+**Critical constraint**: You do NOT consume `threat-report.md` or any other pipeline output. You run in a fresh context with only `threats.md` as input (context isolation per ADR-002, ADR-010).
+
+### Required Input Sections
+
+| Section | Content | Infographic Agent Usage |
+|---------|---------|------------------------|
+| YAML Frontmatter | `date`, `schema_version`, `classification` | Metadata (Section 1 of spec) |
+| Section 1: System Overview | Components, data flows, technologies | Architecture Threat Overlay (Section 5) |
+| Section 3: STRIDE Tables | 6 category tables with findings | Risk Distribution, Heat Map, Top Findings |
+| Section 4: AI Threat Tables | 2 category tables (AG, LLM) with findings | Risk Distribution, Heat Map, Top Findings |
+| Section 4a: Correlated Findings | Cross-agent correlation groups | Counted in risk totals, not double-counted |
+| Section 5: Coverage Matrix | Component x category analysis coverage | Heat Map cross-validation |
+| Section 6: Risk Summary | Aggregate counts by risk level | Risk Distribution (authoritative source) |
+| Section 7: Recommended Actions | Prioritized finding list with mitigations | Top Critical Findings (Section 4) |
+
+### Finding IR Fields Consumed
+
+Each finding in the STRIDE and AI tables provides these fields (from `schemas/finding.yaml` v1.0):
+
+| Field | Type | Infographic Usage |
+|-------|------|-------------------|
+| `id` | string (`{CATEGORY}-{N}`) | Top Critical Findings entry reference |
+| `component` | string | Heat Map rows, Architecture Overlay annotations |
+| `threat` | string | Top Critical Findings one-sentence summary |
+| `risk_level` | enum (Critical/High/Medium/Low/Note) | Risk Distribution counts, Heat Map columns, finding selection |
+
+### Input Validation
+
+Before generating the specification, validate:
+1. `threats.md` contains YAML frontmatter with `schema_version` field
+2. At least Sections 3 or 4 are present with findings
+3. If Section 6 (Risk Summary) is missing, compute severity counts directly from individual findings in Sections 3 and 4
+
+---
+
+## Data Extraction Methodology
+
+Extract data from `threats.md` in 5 steps. Each step feeds one or more specification sections.
+
+### Step 1: Parse Frontmatter for Metadata
+
+Extract from YAML frontmatter:
+- `date` → scan_date in Metadata
+- `schema_version` → referenced in spec frontmatter
+- `classification` → referenced in Metadata
+
+Extract from Section 1 (System Overview):
+- Count of unique components → agent_count proxy (number of analysis agents = number of STRIDE categories + AI categories that produced findings)
+- Project name from section narrative or first component context
+
+### Step 2: Extract Section 6 for Risk Distribution
+
+Section 6 (Risk Summary) is the **authoritative source** for aggregate severity counts.
+
+Extract:
+- Critical count
+- High count
+- Medium count
+- Low count
+- Total finding count
+
+Compute percentages: `(count / total) * 100`, rounded to one decimal place.
+
+**Note severity**: Findings with `risk_level` = Note are informational observations, not actionable threats. They are excluded from the visual risk distribution and heat map to maintain executive clarity. If Section 6 includes a Note count, it is omitted from the infographic severity breakdown. The total finding count in Metadata reflects all findings including Notes, but the Risk Distribution table shows only Critical, High, Medium, and Low.
+
+**Fallback**: If Section 6 is absent, iterate all finding tables in Sections 3, 4, and 4a. Count unique finding IDs per `risk_level`. Do not double-count findings that appear in both individual tables and correlation groups.
+
+### Step 3: Cross-Tabulate Component x Risk Level for Heat Map
+
+For each finding in Sections 3, 4, and 4a:
+1. Extract `component` and `risk_level`
+2. Build a matrix: rows = unique components, columns = Critical, High, Medium, Low
+3. For each cell: count of findings matching that component + severity
+4. Compute row totals
+5. Sort rows by total finding count descending
+6. If more than 8 components: keep top 8, aggregate remaining into "Other" row with summed counts
+
+Component names must match `threats.md` exactly — no renaming, abbreviation, or normalization.
+
+### Step 4: Select Top 5 Findings for Critical Findings Section
+
+From Section 7 (Recommended Actions) or individual finding tables:
+1. Filter findings with `risk_level` = Critical
+2. If fewer than 5 Critical, supplement with High findings
+3. For each selected finding, extract:
+   - `id` (finding ID)
+   - `component`
+   - `threat` (condense to one sentence if needed)
+   - `risk_level`
+4. Cap at 5 entries total
+
+**Edge case**: If no Critical or High findings exist, select top 5 Medium findings and note "No Critical or High findings identified" in the section.
+
+### Step 5: Aggregate Per-Component Risk for Architecture Overlay
+
+For each unique component:
+1. Sum weighted risk: Critical=4, High=3, Medium=2, Low=1
+2. Compute total weighted score
+3. Classify component risk weight:
+   - `high`: any Critical finding OR weighted score >= 10
+   - `medium`: weighted score >= 5
+   - `low`: weighted score < 5
+4. Write annotation describing the component's risk profile and dominant threat categories
+
+---
+
+## Infographic Specification Format
+
+The output `threat-infographic-spec.md` contains YAML frontmatter and 6 required sections. All sections must be present and non-empty.
+
+### YAML Frontmatter
+
+```yaml
+---
+schema_version: "1.0"
+date: "{YYYY-MM-DD from threats.md}"
+source_file: "threats.md"
+finding_count: {total from Section 6}
+image_generated: {true|false}
+---
+```
+
+### Section 1: Metadata
+
+```markdown
+## 1. Metadata
+
+| Field | Value |
+|-------|-------|
+| Project Name | {extracted from threats.md} |
+| Scan Date | {date from frontmatter} |
+| Analysis Agents | {count of agent categories with findings} |
+| Total Findings | {total from Section 6} |
+| Risk Posture | {one-sentence summary: e.g., "Elevated risk — 3 Critical and 9 High findings across 5 components require immediate attention."} |
+```
+
+### Section 2: Risk Distribution
+
+```markdown
+## 2. Risk Distribution
+
+| Severity | Count | Percentage | Color |
+|----------|-------|------------|-------|
+| Critical | {N} | {N.N}% | #DC2626 |
+| High | {N} | {N.N}% | #F97316 |
+| Medium | {N} | {N.N}% | #EAB308 |
+| Low | {N} | {N.N}% | #4169E1 |
+| **Total** | **{N}** | **100%** | — |
+
+**Chart Format**: Suitable for donut chart (proportional segments) or horizontal bar chart (comparative lengths).
+```
+
+**Accuracy rule**: Counts MUST exactly match `threats.md` Section 6. Zero discrepancy.
+
+### Section 3: Coverage Heat Map
+
+```markdown
+## 3. Coverage Heat Map
+
+| Component | Critical | High | Medium | Low | Total |
+|-----------|----------|------|--------|-----|-------|
+| {component_1} | {N} | {N} | {N} | {N} | {N} |
+| {component_2} | {N} | {N} | {N} | {N} | {N} |
+| ... | | | | | |
+| Other | {N} | {N} | {N} | {N} | {N} |
+```
+
+- Rows ordered by Total descending
+- Maximum 8 named component rows + optional "Other" aggregation row
+- Component names match `threats.md` exactly
+- Cell values are integer counts
+
+### Section 4: Top Critical Findings
+
+```markdown
+## 4. Top Critical Findings
+
+| # | Finding ID | Component | Threat | Risk Level |
+|---|-----------|-----------|--------|------------|
+| 1 | {id} | {component} | {one-sentence summary} | Critical |
+| 2 | {id} | {component} | {one-sentence summary} | Critical |
+| ... | | | | |
+```
+
+- Maximum 5 entries
+- Selection priority: Critical first, then High
+- Each threat summary is one sentence, business-oriented language
+- If no Critical or High findings: "No Critical or High findings identified. Top Medium findings shown."
+
+### Section 5: Architecture Threat Overlay
+
+```markdown
+## 5. Architecture Threat Overlay
+
+| Component | Risk Weight | Finding Count | Annotation |
+|-----------|-------------|---------------|------------|
+| {component} | High | {N} | {Description of risk profile and dominant threat categories} |
+| {component} | Medium | {N} | {Description} |
+| {component} | Low | {N} | {Description} |
+```
+
+**Visual Guidance**: Components with `High` risk weight should be rendered with the largest visual emphasis (bold borders, larger icons, red highlight). `Medium` components receive moderate emphasis (orange highlight). `Low` components receive minimal emphasis (standard rendering).
+
+### Section 6: Visual Design Directives
+
+```markdown
+## 6. Visual Design Directives
+
+### Color Palette (CVSS Severity)
+
+| Severity | Hex Code | Usage |
+|----------|----------|-------|
+| Critical | #DC2626 | Highest severity indicators, urgent findings |
+| High | #F97316 | High severity indicators, priority findings |
+| Medium | #EAB308 | Medium severity indicators, planned remediation |
+| Low | #4169E1 | Low severity indicators, accepted risk |
+| Informational | #6B7280 | Neutral elements, labels, secondary text |
+
+### Layout Structure
+
+- **Aspect Ratio**: 16:9 landscape (1920x1080 minimum)
+- **Three-Zone Layout**:
+  1. **Header Zone** (top ~20%): Project name, scan date, total findings, risk posture summary, overall risk score
+  2. **Distribution Zone** (middle ~40%): Risk distribution chart (donut or bar) on the left, coverage heat map on the right
+  3. **Findings Zone** (bottom ~40%): Top critical findings list on the left, architecture threat overlay on the right
+
+### Typography
+
+- **Title**: Bold, 28-32pt equivalent
+- **Section Headers**: Semi-bold, 18-22pt equivalent
+- **Data Labels**: Regular, 12-14pt equivalent
+- **Data Values**: Bold, 14-16pt equivalent
+
+### Background
+
+- Dark theme: Navy (#1E293B) with white text
+- Light theme: White (#FFFFFF) with dark text
+- Either theme is acceptable; dark theme preferred for presentation impact
+```
+
+---
+
+## Quality Standards
+
+### Output Structural Validation Checklist
+
+Before finalizing the specification, run the following checklist. Every check must pass.
+
+#### Section Completeness
+
+- [ ] All 6 specification sections are present with non-empty content
+- [ ] YAML frontmatter contains all 5 required fields (schema_version, date, source_file, finding_count, image_generated)
+- [ ] Section headings match `schemas/infographic.yaml` exactly (## 1. Metadata through ## 6. Visual Design Directives)
+
+#### Data Accuracy
+
+- [ ] Risk distribution counts (Critical, High, Medium, Low) match `threats.md` Section 6 exactly — zero discrepancy
+- [ ] Percentages sum to 100% (within rounding tolerance of +/- 1%)
+- [ ] Total finding count matches sum of severity counts
+
+#### Component Integrity
+
+- [ ] Component names in Coverage Heat Map match `threats.md` exactly — no renaming, abbreviation, or normalization
+- [ ] Heat map rows ordered by total finding count descending
+- [ ] If more than 8 components: top 8 shown with "Other" aggregation row
+
+#### Finding Selection
+
+- [ ] Top Critical Findings contains maximum 5 entries
+- [ ] Selection priority: Critical first, then High (if fewer than 5 Critical)
+- [ ] Each entry has: finding ID, component, one-sentence threat summary, risk level
+
+#### Visual Design
+
+- [ ] CVSS hex codes correct: Critical=#DC2626, High=#F97316, Medium=#EAB308, Low=#4169E1, Info=#6B7280
+- [ ] Layout specifies 16:9 landscape aspect ratio
+- [ ] Three-zone layout defined (header, distribution, findings)
+
+### Edge Cases
+
+- **Empty threat model** (zero findings): Produce specification with zero-count risk distribution, empty heat map, empty findings list, and a note in Metadata risk posture: "No threats identified in this threat model."
+- **No Critical or High findings**: Top Critical Findings section states "No Critical or High findings identified" and lists top 5 Medium findings instead.
+- **Large threat model (>30 findings)**: All findings counted in Risk Distribution and Heat Map. Top Critical Findings remains capped at 5 entries.
+- **More than 8 components**: Coverage Heat Map shows top 8 by total count; remaining aggregated as "Other" row.
+- **Single component**: Heat Map shows one row. Architecture Overlay notes concentration risk.
+- **Missing Section 6 in threats.md**: Compute severity counts directly from individual findings in Sections 3, 4, and 4a. Document the fallback in spec frontmatter or Metadata.
+
+---
+
+## Gemini API Prompt Construction
+
+After generating the infographic specification (`threat-infographic-spec.md`), construct a Gemini image generation prompt from the 6 specification sections. The prompt is a **narrative scene description**, not a keyword list or bullet dump.
+
+### Prompt Framing
+
+Frame the entire prompt as a business document visualization request. Use language such as "risk assessment summary," "security posture overview," and "organizational risk dashboard." Do NOT use attack-specific terminology (e.g., "exploit," "vulnerability chain," "attack vector," "privilege escalation") in the image prompt — this minimizes content policy rejection risk from the Gemini API.
+
+### Narrative Scene Construction
+
+Build the prompt as a single cohesive scene description that walks through the infographic from top to bottom, drawing data from each specification section:
+
+1. **From Section 1 (Metadata)**: Open with the project name, scan date, and total finding count. Frame as: "A professional risk assessment summary dashboard for {project_name}, dated {scan_date}, analyzing {total_findings} security findings across {agent_count} analysis categories."
+
+2. **From Section 2 (Risk Distribution)**: Describe the severity breakdown using exact counts and percentages. Include explicit hex color codes inline: "A donut chart with {critical_count} critical findings in #DC2626 red ({critical_pct}%), {high_count} high-priority findings in #F97316 orange ({high_pct}%), {medium_count} moderate findings in #EAB308 yellow ({medium_pct}%), and {low_count} low-priority findings in #4169E1 blue ({low_pct}%)."
+
+3. **From Section 3 (Coverage Heat Map)**: Describe the component density matrix. Name the top 3-4 components by finding count: "A heat map grid showing finding density across {component_count} system components, with {top_component} having the highest concentration at {top_count} findings."
+
+4. **From Section 4 (Top Critical Findings)**: Summarize the highest-severity entries using business language: "A prioritized list of the {n} most urgent findings, led by {finding_1_component} requiring immediate attention."
+
+5. **From Section 5 (Architecture Threat Overlay)**: Describe component risk weights: "Component risk indicators showing {high_risk_components} at elevated risk and {low_risk_components} at baseline risk levels."
+
+6. **From Section 6 (Visual Design Directives)**: Incorporate layout, color, and typography instructions directly into the scene description.
+
+### Spatial Zone Instructions
+
+Structure the prompt using explicit spatial placement. Use directional language that guides the image model's composition:
+
+- "The top third of the image contains the dashboard header: project name in bold white text on a dark navy (#1E293B) background, scan date, total finding count, and a one-sentence risk posture summary."
+- "The middle band shows two side-by-side panels: on the left, a donut chart of risk distribution with color-coded severity segments using #DC2626, #F97316, #EAB308, and #4169E1; on the right, a heat map grid with component names along the left edge and severity columns color-coded by the same palette."
+- "The bottom section displays two panels: on the left, a numbered list of the top critical findings with finding IDs and one-line descriptions; on the right, a component risk summary with visual weight indicators."
+
+### Text Label Budget
+
+Cap distinct text labels at **15-20 per infographic**. This includes:
+- Project name (1 label)
+- Scan date (1 label)
+- Total finding count (1 label)
+- Risk posture summary (1 label)
+- Severity level names with counts (4 labels: "Critical: N", "High: N", "Medium: N", "Low: N")
+- Top component names in heat map (3-4 labels)
+- Top finding summaries (3-5 labels, condensed to 2-4 words each)
+
+Each text label should be **2-4 words** to ensure legibility in the generated image. Longer descriptions are conveyed through layout and color, not text.
+
+### Color Specification
+
+Include hex codes directly in the prompt text — do not rely on the image model interpreting color names consistently:
+- Critical severity: `#DC2626` (red)
+- High severity: `#F97316` (orange)
+- Medium severity: `#EAB308` (yellow)
+- Low severity: `#4169E1` (blue)
+- Informational/neutral: `#6B7280` (gray)
+- Background: `#1E293B` (dark navy) for dark theme
+- Text: `#FFFFFF` (white) on dark background
+
+---
+
+## Gemini API Integration
+
+### Configuration
+
+The Gemini API configuration is defined here in the agent prompt, not in the output schema. This keeps model-specific settings with the agent that uses them.
+
+```yaml
+gemini_config:
+  default_model: "gemini-3-pro-image-preview"
+  resolution: "2K"
+  fallback_model: "gemini-3.1-flash-image-preview"
+```
+
+- **default_model**: The primary Gemini model for image generation. Configurable — do not hardcode. If the default model is unavailable, fall back to `fallback_model`.
+- **resolution**: Target output resolution. "2K" produces images at approximately 1920x1080 for 16:9 aspect ratio.
+- **fallback_model**: Secondary model to attempt if the default model returns a model-not-found error.
+
+### API Key Check
+
+Before attempting image generation:
+
+1. Check for the `GEMINI_API_KEY` environment variable.
+2. If the variable is **not set or empty**: skip image generation entirely. Save the infographic specification as a standalone deliverable. Log an informational message: "Gemini API key not configured — infographic image generation skipped. Specification saved as standalone deliverable." Set `image_generated: false` in the specification frontmatter. Continue the pipeline.
+3. If the variable **is set**: proceed with the API call.
+
+### API Request
+
+Submit the constructed narrative prompt to the Gemini image generation endpoint:
+
+**Endpoint**:
+```
+POST https://generativelanguage.googleapis.com/v1beta/models/{model_id}:generateContent
+```
+
+Where `{model_id}` is the configured model (default: `gemini-3-pro-image-preview`).
+
+**Request Headers**:
+```
+Content-Type: application/json
+x-goog-api-key: {GEMINI_API_KEY}
+```
+
+**Request Body**:
+```json
+{
+  "contents": [
+    {
+      "parts": [
+        {
+          "text": "{constructed_narrative_prompt}"
+        }
+      ]
+    }
+  ],
+  "generationConfig": {
+    "responseModalities": ["TEXT", "IMAGE"],
+    "aspectRatio": "16:9",
+    "imageSize": "2K"
+  }
+}
+```
+
+### Response Parsing
+
+Parse the API response to extract the generated image:
+
+1. Check that the response contains a `candidates` array with at least one entry.
+2. Iterate through `candidates[0].content.parts[]`.
+3. Find the part where `inline_data` is present and `inline_data.mime_type` starts with `image/` (e.g., `image/jpeg`, `image/png`).
+4. Extract the `inline_data.data` field (base64-encoded image data).
+5. Decode the base64 data.
+6. Save the decoded bytes as `threat-infographic.jpg` in the output directory alongside the specification.
+7. Set `image_generated: true` in the specification frontmatter.
+
+If no `inline_data` part with an image MIME type is found in the response, treat this as an API error (see Error Handling below).
+
+### Fallback Model Attempt
+
+If the default model returns an HTTP error indicating model unavailability (404 or model-specific error), attempt one retry with the `fallback_model` (`gemini-3.1-flash-image-preview`). If the fallback also fails, proceed to error handling.
+
+---
+
+## Error Handling & Graceful Degradation
+
+The infographic agent handles six specific error conditions. In every case, the infographic specification is preserved as a standalone deliverable. The pipeline is never blocked.
+
+### Condition 1: Missing GEMINI_API_KEY
+
+- **Trigger**: `GEMINI_API_KEY` environment variable is not set or is empty.
+- **Action**: Log an informational message: "GEMINI_API_KEY not configured. Infographic specification saved as standalone deliverable. To generate an image, set the GEMINI_API_KEY environment variable."
+- **Result**: Specification saved with `image_generated: false`. No API call attempted. Pipeline continues.
+
+### Condition 2: API Rate Limit (HTTP 429)
+
+- **Trigger**: Gemini API returns HTTP 429 (Too Many Requests).
+- **Action**: Log a warning: "Gemini API rate limit exceeded (HTTP 429). Infographic image generation skipped. Specification saved as standalone deliverable."
+- **Result**: Specification saved with `image_generated: false`. No retry attempted. Pipeline continues.
+- **Rationale**: Single-attempt design per scope boundaries. Retry logic is out of scope for MVP.
+
+### Condition 3: API Timeout
+
+- **Trigger**: Gemini API call does not return within 60 seconds.
+- **Action**: Log an error: "Gemini API request timed out after 60 seconds. Infographic image generation skipped. Specification saved as standalone deliverable."
+- **Result**: Specification saved with `image_generated: false`. Pipeline continues.
+
+### Condition 4: Content Policy Rejection
+
+- **Trigger**: Gemini API returns a response indicating content policy violation (typically a `SAFETY` finish reason or blocked prompt).
+- **Action**: Log a warning with the specific rejection reason: "Gemini API content policy rejection: {reason}. Infographic image generation skipped. Specification saved as standalone deliverable."
+- **Result**: Specification saved with `image_generated: false`. Pipeline continues.
+- **Mitigation**: The prompt construction section is designed to use business-oriented language specifically to minimize this condition. If rejections occur frequently, review the prompt for inadvertent attack-specific terminology.
+
+### Condition 5: Missing Section 6 in threats.md
+
+- **Trigger**: `threats.md` does not contain a Section 6 (Risk Summary) with aggregate severity counts.
+- **Action**: Compute severity counts directly from individual findings in Sections 3, 4, and 4a using the fallback methodology defined in Data Extraction Methodology (Step 2). Log an informational message: "Section 6 (Risk Summary) not found in threats.md. Severity counts computed from individual findings."
+- **Result**: Specification generated with computed counts. Data accuracy is maintained through direct finding enumeration. Add a note to the specification Metadata: "Risk counts derived from individual findings (Section 6 absent in source)."
+- **Cross-reference**: See Data Extraction Methodology, Step 2, "Fallback" for the deduplication procedure that prevents double-counting findings appearing in both individual tables and correlation groups (Section 4a).
+
+### Condition 6: Empty Threat Model (Zero Findings)
+
+- **Trigger**: `threats.md` contains no findings in Sections 3, 4, or 4a (all tables empty or absent).
+- **Action**: Produce a complete specification with zero-count values across all sections.
+- **Result**: Specification contains:
+  - Metadata: `Total Findings: 0`, Risk Posture: "No threats identified in this threat model."
+  - Risk Distribution: All severity counts = 0, all percentages = 0%.
+  - Coverage Heat Map: Empty table with column headers only.
+  - Top Critical Findings: "No findings to display."
+  - Architecture Threat Overlay: Components listed with `Low` risk weight and annotation "No findings identified."
+  - Visual Design Directives: Standard directives (unchanged — layout is data-independent).
+  - `image_generated: false` — no Gemini API call attempted for empty threat models.
+
+### Degradation Summary
+
+| Condition | Spec Saved | Image Generated | Pipeline Blocked | Log Level |
+|-----------|-----------|----------------|-----------------|-----------|
+| Missing API key | Yes | No | No | Info |
+| Rate limit (429) | Yes | No | No | Warning |
+| API timeout | Yes | No | No | Error |
+| Content policy rejection | Yes | No | No | Warning |
+| Missing Section 6 | Yes (computed) | Attempted | No | Info |
+| Empty threat model | Yes (zero-count) | No | No | Info |

--- a/docs/architecture/01_system_design/README.md
+++ b/docs/architecture/01_system_design/README.md
@@ -695,3 +695,54 @@ flowchart TD
 | Output Schema | YAML | Matches existing schema patterns |
 | Attack Trees | Mermaid `flowchart TD` | Standard, GitHub-renderable |
 | Template | Markdown | Same format as `templates/threats.md` |
+
+---
+
+### Feature 018: Threat Infographic Agent
+
+## Components
+
+### Component 1: Infographic Agent Prompt (`agents/threat-infographic.md`)
+
+**Purpose**: Markdown prompt file that defines the infographic agent's data extraction methodology, specification format, Gemini API prompt construction, and graceful fallback behavior. When invoked by the orchestrator or standalone, the LLM follows these instructions to transform `threats.md` into a visual risk specification.
+
+**Follows Existing Pattern**: 8-section YAML+Markdown structure matching `agents/threat-report.md` (F-015).
+
+### Component 2: Infographic Output Schema (`schemas/infographic.yaml`)
+
+**Purpose**: Defines the structural validation contract for `threat-infographic-spec.md`, enabling automated completeness checks. Covers 6 required sections: Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings, Architecture Threat Overlay, and Visual Design Directives.
+
+### Component 3: Orchestrator Integration
+
+**Purpose**: Update `agents/orchestrator.md` to dispatch Phase 6 (Infographic) after Phase 5 (Report) completes. Follows identical structural pattern to Phase 5: optional default-on, fresh-context invocation with only `threats.md`, pipeline isolation (Phase 6 failures never block Phases 1-5).
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    TM["threats.md<br/>(Phase 4 Output)"] --> IA["Infographic Agent<br/>(agents/threat-infographic.md)"]
+    IA --> IS["threat-infographic-spec.md<br/>(6 Sections)"]
+    IA -->|"GEMINI_API_KEY set"| IMG["threat-infographic.jpg<br/>(Optional)"]
+    IA -->|"No API key or error"| SKIP["Spec saved as<br/>standalone deliverable"]
+
+    subgraph Infographic Agent Processing
+        Parse["Parse threats.md<br/>Sections 1-7 + 4a"] --> Meta["1. Metadata<br/>(Project, Date, Counts)"]
+        Parse --> Risk["2. Risk Distribution<br/>(Severity Counts + %)"]
+        Parse --> Heat["3. Coverage Heat Map<br/>(Component × Severity)"]
+        Parse --> Top["4. Top Critical Findings<br/>(Up to 5)"]
+        Parse --> Arch["5. Architecture<br/>Threat Overlay"]
+        Meta & Risk & Heat & Top & Arch --> Design["6. Visual Design<br/>Directives"]
+        Design --> Prompt["Gemini API<br/>Prompt Construction"]
+    end
+
+    IA --> Val["Validation<br/>(schemas/infographic.yaml)"]
+```
+
+## Tech Stack
+
+| Component | Technology | Rationale |
+|-----------|-----------|-----------|
+| Infographic Agent | Markdown prompt file | Consistent with tachi agent architecture |
+| Output Schema | YAML | Matches existing schema patterns |
+| Image Generation | Google Gemini API (`gemini-3-pro-image-preview`) | Best-in-class text rendering for data-dense infographics |
+| Specification Format | Markdown (6 sections) | Human-readable, designer-consumable, Gemini-promptable |

--- a/docs/product/02_PRD/018-threat-infographic-agent-2026-03-23.md
+++ b/docs/product/02_PRD/018-threat-infographic-agent-2026-03-23.md
@@ -1,0 +1,468 @@
+---
+prd:
+  number: "018"
+  topic: threat-infographic-agent
+  created: 2026-03-23
+  status: Approved
+  type: feature
+triad:
+  pm_signoff: {agent: product-manager, date: 2026-03-23, status: approved, notes: "PRD drafted by PM via ~aod-define skill with GitHub Issue #18 user stories, consumer guide F-008, and OWASP/CVSS research as primary inputs"}
+  architect_signoff: {agent: architect, date: 2026-03-23, status: approved_with_concerns, notes: "14 findings (0 critical, 1 high, 7 medium, 5 low). High: Gemini image quality for data-dense infographics is unreliable — reframe spec as primary deliverable, image as best-effort. Medium: missing schemas/infographic.yaml, Phase 6 fresh-context isolation, opt-out flag naming. All resolvable in spec phase."}
+  techlead_signoff: {agent: team-lead, date: 2026-03-23, status: approved_with_concerns, notes: "Feasible in 1 sprint (75% confidence, 2.0-3.5h). L/L/S sizing correct. 5-wave execution. Recommend elevating FR-7 to P0 and resolving open questions 1 and 3 before task breakdown."}
+source:
+  idea_id: 18
+  story_id: null
+---
+
+# Threat Infographic Agent - Product Requirements Document
+
+**Status**: Approved
+**Created**: 2026-03-23
+**Author**: product-manager
+**Reviewers**: architect, team-lead
+**Phase**: Phase 2 (Reporting & Integration)
+**Priority**: P1 (High)
+
+---
+
+## Executive Summary
+
+### The One-Liner
+Build an infographic agent that transforms threat model data into a visual risk specification and produces a presentation-ready infographic image via Gemini API.
+
+### Problem Statement
+Developers using tachi now have a structured `threats.md` and a narrative `threat-report.md` (delivered in F-015). While the report serves CISOs and security engineers with text-based analysis, three communication gaps remain:
+
+1. **Board presentations and stakeholder briefings** demand visual artifacts — charts, heat maps, and graphical summaries — not multi-page markdown documents. Executives scanning a deck allocate 3-5 seconds per slide; a text-heavy threat report cannot compete with a single infographic that communicates risk posture at a glance.
+
+2. **Security dashboards and documentation portals** increasingly embed images rather than rendered markdown. Teams using Confluence, Notion, or slide decks need a `.jpg` or `.png` they can drag-and-drop, not a Mermaid diagram that requires a renderer.
+
+3. **Cross-team communication** — sharing threat model results with product managers, QA leads, and external auditors — is friction-heavy when the deliverable is a 50+ section markdown file. A single infographic summarizing risk distribution, coverage heat map, and top critical findings is the artifact that actually gets shared.
+
+Without a visual output layer, tachi's reporting pipeline produces comprehensive text that is underutilized outside the security team.
+
+### Proposed Solution
+Add an infographic agent (`agents/threat-infographic.md`) that operates as a new Phase 6 (Infographic) in the orchestrator pipeline, after Phase 5 (Report). The agent performs two steps:
+
+1. **Infographic specification generation** — Reads `threats.md` (and optionally `threat-report.md`) and produces a detailed infographic specification (`threat-infographic-spec.md`) describing the layout, data points, color coding, text content, and visual hierarchy. This spec is a structured markdown document that serves as both a human-readable design brief and a machine-readable prompt for image generation.
+
+2. **Image generation via Gemini API** — Feeds the infographic specification to Google's Gemini image generation API to produce `threat-infographic.jpg`. The specification is designed to produce a clean, professional, presentation-ready visual.
+
+The infographic agent is a **markdown prompt file**, consistent with tachi's architecture where all agents are prompt files, not application code. Image generation is **optional and configurable** — projects without Gemini API access receive the infographic specification as a standalone deliverable for manual rendering.
+
+### Success Criteria
+- Infographic agent produces a structured `threat-infographic-spec.md` from `threats.md` in the example project
+- The spec includes: risk distribution chart data, coverage heat map data, top critical findings summary, and architecture threat overlay description
+- When Gemini API is available, the agent produces a `threat-infographic.jpg` that is presentation-ready
+- When Gemini API is unavailable, the spec is saved as a standalone markdown document usable for manual rendering
+- All tachi features remain fully functional without Gemini API access — infographic generation is additive, not required
+- The infographic accurately reflects the data in `threats.md` — no misrepresentation of risk levels or finding counts
+
+### Timeline
+Phase 2 delivery — estimated 1 sprint
+
+---
+
+## Strategic Alignment
+
+### Product Vision Alignment
+**Reference**: `docs/product/01_Product_Vision/product-vision.md`
+
+The infographic agent extends tachi's mission as "the default threat modeling toolkit for any team building agentic AI applications" by adding the visual communication layer that executives and cross-functional teams expect. Text-based reports serve security engineers; visual artifacts serve the broader organization. This positions tachi as a complete threat intelligence platform — from structured analysis (F-005, F-007) through narrative reporting (F-015) to visual communication (F-018).
+
+### Roadmap Fit
+**Phase**: Phase 2 (Reporting & Integration)
+**Dependencies**: F-001, F-003, F-005, F-007, F-010, F-015 (all delivered) — provides the complete `threats.md` and `threat-report.md` that the infographic agent consumes
+**Blocks**: Future dashboard or CI/CD integration features that consume visual artifacts
+
+---
+
+## Target Users & Personas
+
+### Primary Persona: Executive / CISO
+- **Role**: Security leadership, board reporting, investment decisions
+- **Experience**: Understands risk concepts but does not read multi-page threat reports end-to-end
+- **Goals**: Communicate risk posture in board presentations and stakeholder briefings using a single visual artifact
+- **Pain Points**: Must manually create slides from text-based reports; visual artifacts require design tools and security interpretation skills
+
+**Why This Matters**: Executives make budget and priority decisions based on what they can quickly comprehend. A presentation-ready infographic removes the translation step between threat analysis and executive action.
+
+### Secondary Persona: Developer / DevSecOps Engineer
+- **Role**: Builds and operates the threat modeling pipeline
+- **Experience**: Technical, comfortable with APIs and configuration
+- **Goals**: Automate visual output generation as part of the threat modeling pipeline without manual design work
+- **Pain Points**: Creating visual summaries requires switching to design tools; Gemini integration requires structured prompts that are hard to craft manually
+
+### Tertiary Persona: Project Manager / Auditor
+- **Role**: Cross-team coordination, compliance documentation
+- **Experience**: Manages stakeholder communication, not security-specialized
+- **Goals**: Share threat model results with non-technical stakeholders via a shareable image artifact
+- **Pain Points**: Cannot embed markdown reports in slide decks, Confluence pages, or audit documentation without screenshots
+
+---
+
+## User Stories
+
+### US-1: Visual Threat Infographic for Executive Communication
+**When**: I have a completed threat model and need to present risk posture to management or a board,
+**I want to**: a visual threat infographic showing risk distribution, coverage heat map, and top critical findings,
+**So I can**: quickly communicate the security landscape without requiring the audience to read a full report.
+
+**Acceptance Criteria**:
+- **Given** a completed `threats.md` with findings from STRIDE and AI agents, **when** the infographic agent runs, **then** it produces `threat-infographic-spec.md` containing layout, data points, color coding, and text content for the infographic
+- **Given** the infographic specification, **when** it describes risk distribution, **then** it includes finding counts per risk level (Critical, High, Medium, Low) using CVSS severity color conventions (Critical=red, High=orange, Medium=yellow, Low=blue per research §10)
+- **Given** the infographic specification, **when** it describes the coverage heat map, **then** it shows which architecture components have the most findings and their severity distribution
+- **Given** the infographic specification, **when** it describes the architecture threat overlay, **then** it annotates which components carry the most risk with visual weight proportional to finding severity and count
+- **Given** the generated infographic (spec or image), **when** viewed by an executive, **then** the risk posture is comprehensible within 10 seconds without reading accompanying text
+
+**Priority**: P0
+**Effort**: L
+
+### US-2: Structured Infographic Specification for Gemini Image Generation
+**When**: I want the infographic agent to produce a visual automatically from threat data,
+**I want to**: the agent to generate a detailed infographic specification and feed it to Gemini image generation API,
+**So I can**: get a presentation-ready `threat-infographic.jpg` without manual design work.
+
+**Acceptance Criteria**:
+- **Given** a completed `threats.md`, **when** the infographic agent runs with Gemini API access configured, **then** it produces both `threat-infographic-spec.md` (the specification) and `threat-infographic.jpg` (the rendered image)
+- **Given** the infographic specification, **when** fed to Gemini image generation API, **then** the resulting image is clean, professional, and suitable for presentation slides (minimum 1920x1080 resolution)
+- **Given** the infographic specification, **when** saved as markdown, **then** it is detailed enough for a designer to manually render the infographic if Gemini is unavailable
+- **Given** the Gemini API returns an error or is unavailable, **when** the agent detects the failure, **then** it saves the specification as a standalone deliverable and logs a warning — it does NOT fail the pipeline
+
+**Priority**: P0
+**Effort**: L
+
+### US-3: Optional and Configurable Infographic Generation
+**When**: my project does not have Gemini API access or I want to skip infographic generation,
+**I want to**: infographic generation to be optional and configurable,
+**So I can**: use all other tachi features without requiring a Gemini API key.
+
+**Acceptance Criteria**:
+- **Given** a project without a `GEMINI_API_KEY` environment variable set, **when** the orchestrator runs, **then** infographic image generation is skipped gracefully with an informational message — the spec is still generated but no image is produced
+- **Given** the orchestrator configuration, **when** infographic generation is disabled (opt-out flag), **then** Phase 6 is skipped entirely — no spec, no image
+- **Given** a project with all features enabled, **when** the orchestrator runs the full pipeline, **then** Phases 1-5 complete regardless of whether Phase 6 succeeds or fails — infographic generation never blocks the core pipeline
+
+**Priority**: P0
+**Effort**: S
+
+---
+
+## Functional Requirements
+
+### FR-1: Infographic Agent Prompt Definition
+
+**Description**: Create `agents/threat-infographic.md` as a markdown prompt file defining the infographic agent's analysis methodology, specification format, and image generation instructions.
+
+**Agent Responsibilities**:
+- Parse `threats.md` for risk data: finding counts per severity, component-level finding distribution, top critical/high findings
+- Optionally parse `threat-report.md` for cross-cutting themes and remediation priorities
+- Generate a structured infographic specification with layout, data points, colors, and text
+- Interface with Gemini API for image generation when available
+- Gracefully handle missing API access
+
+**Agent Prompt Structure** (follows existing agent pattern from F-015):
+- YAML header with agent metadata, input contract, output contract
+- Data extraction methodology
+- Infographic specification format
+- Gemini API prompt construction guidelines
+- Fallback behavior for no-API scenarios
+
+### FR-2: Infographic Specification Format
+
+**Description**: Define the `threat-infographic-spec.md` output structure.
+
+**Required Specification Sections**:
+
+| Section | Content | Source |
+|---------|---------|--------|
+| **Metadata** | Project name, scan date, agent count, total findings | `threats.md` YAML frontmatter and Section 6 |
+| **Risk Distribution** | Finding counts per severity level with percentages | Computed from Section 3-4 finding tables |
+| **Coverage Heat Map** | Component × severity matrix showing finding density | Computed from component field across all findings |
+| **Top Critical Findings** | Summary of up to 5 most severe findings with component and threat | Filtered from Critical/High findings |
+| **Architecture Threat Overlay** | Description of which components carry highest risk and why | Derived from component-level aggregation |
+| **Visual Design Directives** | Color palette, layout structure, font hierarchy, spacing | CVSS severity colors (§10) + clean professional style |
+| **Gemini Prompt** | The exact prompt to send to Gemini API for image generation | Constructed from all above sections |
+
+### FR-3: CVSS Severity Color Coding
+
+**Description**: Use standardized CVSS severity color conventions throughout the infographic specification.
+
+**Color Mapping** (from research §10):
+
+| Severity | Color | Hex | Usage |
+|----------|-------|-----|-------|
+| Critical | Red | `#FF0000` | Chart segments, heat map cells, finding badges |
+| High | Orange | `#FFA500` | Chart segments, heat map cells, finding badges |
+| Medium | Yellow | `#FFD700` | Chart segments, heat map cells, finding badges |
+| Low | Blue | `#4169E1` | Chart segments, heat map cells, finding badges |
+| Informational | Gray | `#808080` | Background elements, de-emphasized items |
+
+### FR-4: Risk Distribution Chart Data
+
+**Description**: Extract and format finding counts for a risk distribution visualization.
+
+**Data Structure**:
+- Count of findings per severity level (Critical, High, Medium, Low)
+- Percentage of total findings per severity level
+- Total finding count
+- Formatted for both pie chart and bar chart representation
+
+**Source**: Aggregate from `threats.md` Sections 3 (STRIDE Findings) and 4 (AI Agent Findings), using the `risk_level` field from each finding.
+
+### FR-5: Coverage Heat Map Data
+
+**Description**: Generate a component × severity matrix for heat map visualization.
+
+**Data Structure**:
+- Rows: Architecture components (from `component` field in findings)
+- Columns: Severity levels (Critical, High, Medium, Low)
+- Cells: Finding count for each component-severity combination
+- Row ordering: By total finding count (most findings first)
+
+**Source**: Cross-tabulate `component` and `risk_level` fields across all findings in `threats.md`.
+
+### FR-6: Gemini API Integration
+
+**Description**: Interface with Google Gemini API for image generation from the infographic specification.
+
+**Integration Flow**:
+1. Check for `GEMINI_API_KEY` environment variable
+2. If present: construct Gemini prompt from `threat-infographic-spec.md`, call Gemini image generation API, save result as `threat-infographic.jpg`
+3. If absent: log informational message, save spec as standalone deliverable, continue pipeline
+
+**API Requirements**:
+- Use Gemini's image generation endpoint
+- Request minimum 1920x1080 resolution
+- Request professional, clean design style suitable for business presentations
+- Include error handling for API rate limits, timeouts, and content policy rejections
+
+**Fallback Behavior**:
+- API unavailable → save spec only, log warning, continue pipeline
+- API error → save spec only, log error with details, continue pipeline
+- API content policy rejection → save spec only, log rejection reason, continue pipeline
+
+### FR-7: Orchestrator Integration
+
+**Description**: Integrate the infographic agent into the orchestrator pipeline as Phase 6 (Infographic).
+
+**Integration Points**:
+- Phase 6 runs after Phase 5 (Report) completes
+- Infographic agent receives `threats.md` as primary input and `threat-report.md` as optional secondary input
+- Output is written to the same output directory as other pipeline outputs
+- Phase 6 is optional — configurable via orchestrator settings or command-line flag
+
+**Output Directory Structure** (after Phase 6):
+```
+YYYY-MM-DD-{phase}/
+├── threats.md              # Phase 4 output (existing)
+├── threats.sarif            # Phase 4 output (existing, F-012)
+├── threat-report.md         # Phase 5 output (existing, F-015)
+├── attack-trees/            # Phase 5 output (existing, F-015)
+├── threat-infographic-spec.md  # Phase 6 output (new)
+└── threat-infographic.jpg      # Phase 6 output (new, conditional on Gemini API)
+```
+
+### FR-8: Opt-Out Configuration
+
+**Description**: Allow users to disable infographic generation entirely.
+
+**Configuration Options**:
+- Command-line flag: `--no-infographic` on orchestrator invocation to skip Phase 6 entirely
+- Environment variable: `TACHI_SKIP_INFOGRAPHIC=true` as persistent configuration
+- When opted out: Phase 6 is not invoked, no spec or image is generated, no warning is logged
+
+---
+
+## Non-Functional Requirements
+
+### Data Accuracy
+- Risk distribution counts MUST exactly match the finding counts in `threats.md` — no rounding errors, no omitted findings
+- Component names in the heat map MUST match the component names in `threats.md` exactly
+- Severity colors MUST follow the CVSS convention defined in FR-3 — no ad-hoc color choices
+
+### Pipeline Resilience
+- Phase 6 failures MUST NOT block or invalidate Phases 1-5 outputs
+- Gemini API failures MUST be handled gracefully — the spec is always saved regardless of API availability
+- Phase 6 MUST complete within 60 seconds (excluding Gemini API call time)
+
+### Portability
+- The infographic specification MUST be self-contained — a designer can render the infographic from the spec alone without access to `threats.md`
+- The specification MUST be valid markdown readable by any markdown renderer
+- The generated image MUST be a standard JPEG — no proprietary formats
+
+### Configurability
+- All three infographic sections (risk distribution, heat map, top findings) MUST be present in every specification
+- Gemini API integration MUST be opt-in via environment variable presence, not a required configuration step
+- The opt-out flag MUST completely skip Phase 6 with no residual side effects
+
+---
+
+## Success Metrics
+
+### Primary Metrics
+
+**Infographic Specification Quality**: Spec contains all required sections with accurate data
+- **Baseline**: N/A (no visual output exists)
+- **Target**: Every generated spec includes risk distribution, coverage heat map, top findings, architecture overlay, and Gemini prompt
+- **Timeline**: At delivery
+
+**Data Accuracy**: 100% match between spec data and `threats.md` finding counts
+- **Baseline**: N/A
+- **Target**: Zero discrepancy between risk distribution counts in spec and actual finding counts in `threats.md`
+- **Timeline**: At delivery
+
+**Pipeline Resilience**: Phase 6 never blocks pipeline completion
+- **Baseline**: N/A
+- **Target**: Zero pipeline failures caused by infographic agent errors or Gemini API failures
+- **Timeline**: At delivery
+
+**Gemini Integration**: Image generated successfully when API is available
+- **Baseline**: N/A
+- **Target**: `threat-infographic.jpg` produced with presentation-ready quality when `GEMINI_API_KEY` is set
+- **Timeline**: At delivery
+
+---
+
+## Scope & Boundaries
+
+### In Scope (MVP)
+
+**Must Have (P0)**:
+- Infographic agent prompt file (`agents/threat-infographic.md`)
+- Infographic specification generation (`threat-infographic-spec.md`) with risk distribution, coverage heat map, top critical findings, and architecture threat overlay
+- CVSS severity color coding per research §10
+- Gemini API integration for image generation (when API key is available)
+- Graceful fallback when Gemini API is unavailable (spec saved as standalone deliverable)
+- Pipeline isolation — Phase 6 failures never block Phases 1-5
+
+**Should Have (P1)**:
+- Orchestrator integration as Phase 6 (Infographic)
+- Opt-out configuration (`--no-infographic` flag and `TACHI_SKIP_INFOGRAPHIC` environment variable)
+- Architecture threat overlay in specification
+
+### Out of Scope
+
+**Won't Have**:
+- Interactive or animated infographic visualization
+- Multiple image output formats (PNG, SVG, PDF) — JPEG only for MVP
+- Custom infographic templates or branding options
+- Alternative image generation APIs (DALL-E, Midjourney, Stable Diffusion) — Gemini only for MVP
+- Real-time infographic updates when `threats.md` changes
+- Infographic comparison across multiple threat model runs
+- Embedding infographic in `threat-report.md` (separate file output)
+
+### Assumptions
+- Gemini API supports image generation with sufficient quality for business presentations
+- The infographic specification format is detailed enough for Gemini to produce useful output
+- `threats.md` structure (finding IR schema) remains stable from F-010/F-012
+- A single infographic image is sufficient — no multi-page or multi-image output needed
+- JPEG format meets presentation needs (no transparency required)
+
+### Constraints
+- **No application code**: Infographic agent is a prompt file, consistent with tachi's architecture
+- **Gemini API dependency**: Image generation requires external API access — this is an optional enhancement, not a core capability
+- **Single image format**: JPEG only for MVP to limit scope
+- **Pipeline dependency**: Requires `threats.md` from Phase 4 — cannot run independently
+
+---
+
+## Risks & Dependencies
+
+### Technical Risks
+
+**Risk 1**: Gemini image generation quality for data-rich infographics
+- **Likelihood**: Medium
+- **Impact**: High
+- **Mitigation**: Design the infographic specification to be as explicit as possible — exact text, exact colors, exact layout positions. Include example infographic descriptions in the agent prompt.
+- **Contingency**: If Gemini produces low-quality images, the specification serves as the primary deliverable — users render manually or use design tools. Image generation becomes a "nice to have" rather than a core feature.
+
+**Risk 2**: Gemini API content policy rejection for security-related content
+- **Likelihood**: Low
+- **Impact**: Medium
+- **Mitigation**: Frame the infographic as a "risk assessment summary" or "security posture overview" using business language, not attack-specific terminology. Avoid words that might trigger content filters (e.g., "exploit", "attack" in the image prompt).
+- **Contingency**: Specification-only output if content policy consistently rejects security infographic prompts.
+
+**Risk 3**: Infographic specification too complex for consistent Gemini output
+- **Likelihood**: Medium
+- **Impact**: Medium
+- **Mitigation**: Use a structured prompt format with clear sections — Gemini performs better with well-organized prompts. Include layout grid coordinates and precise color hex codes.
+- **Contingency**: Simplify the infographic to 2-3 core visualizations (risk distribution + top findings) rather than attempting all four sections.
+
+**Risk 4**: Data accuracy in visual representation
+- **Likelihood**: Low
+- **Impact**: High
+- **Mitigation**: The infographic specification includes exact numeric data — finding counts, percentages, component names. The spec is verifiable against `threats.md` before image generation. Include a data verification section in the spec.
+- **Contingency**: Add a "Data Source: threats.md" watermark or footnote to the infographic so viewers know to verify against the source document.
+
+### Dependencies
+
+**Internal Dependencies**:
+- **F-003 (Orchestrator)**: Delivered — pipeline where Phase 6 is added
+- **F-005 (STRIDE Agents)**: Delivered — produces STRIDE findings
+- **F-007 (AI Agents)**: Delivered — produces AI findings
+- **F-010 (Deduplication & Risk Rating)**: Delivered — provides calibrated risk levels
+- **F-015 (Threat Report Agent)**: Delivered — Phase 5 output; infographic agent runs after report
+- **`schemas/finding.yaml`**: Defines finding IR parsed by the infographic agent
+- **`schemas/output.yaml`**: Defines `threats.md` structure consumed by the infographic agent
+
+**External Dependencies**:
+- **Google Gemini API**: Image generation capability — optional dependency, feature works without it
+- **`GEMINI_API_KEY` environment variable**: Required for image generation, not for specification generation
+
+**Dependency Graph**:
+```
+F-018 (Threat Infographic Agent)
+  ├── Depends on: F-003 (Orchestrator) ✅ Delivered
+  ├── Depends on: F-005 (STRIDE Agents) ✅ Delivered
+  ├── Depends on: F-007 (AI Agents) ✅ Delivered
+  ├── Depends on: F-010 (Dedup & Risk) ✅ Delivered
+  ├── Depends on: F-015 (Threat Report Agent) ✅ Delivered
+  ├── Optional: Google Gemini API (image generation)
+  └── Blocks: Future dashboard/CI integration features
+```
+
+---
+
+## Open Questions
+
+- [ ] What Gemini model and endpoint should be used for image generation? (e.g., `gemini-2.0-flash-exp` with `generateImage`) — architect — Decide in spec phase
+- [ ] Should the infographic specification include an SVG fallback description for environments where Gemini is unavailable long-term? — PM — Deferred to future feature
+- [ ] What is the maximum number of components to display in the coverage heat map before truncating to "top N"? — architect — Decide in spec phase
+- [ ] Should the agent support multiple infographic layouts (landscape vs. portrait) or standardize on one? — PM — Standardize on landscape (16:9) for MVP
+
+---
+
+## References
+
+### Product Documentation
+- Product Vision: `docs/product/01_Product_Vision/product-vision.md`
+- Consumer Guide: `docs/guides/CONSUMER_GUIDE_TACHI.md` § F-008
+- Threat Report PRD: `docs/product/02_PRD/015-threat-report-agent-attack-trees-2026-03-23.md`
+
+### Technical Documentation
+- Output Schema: `schemas/output.yaml` (defines `threats.md` structure)
+- Finding Schema: `schemas/finding.yaml` (finding IR)
+- Orchestrator: `agents/orchestrator.md` (pipeline phases)
+- Example Output: `examples/mermaid-agentic-app/threats.md` (sample threat model)
+
+### Research References
+- §8 — Risk Rating Matrices (OWASP risk levels and severity scales for visual risk distribution charts)
+- §10 — CVSS (severity color conventions — Critical=red, High=orange, Medium=yellow, Low=blue)
+
+---
+
+## Approval & Sign-Off
+
+| Role | Name | Status | Date | Comments |
+|------|------|--------|------|----------|
+| Product Manager | product-manager | ✅ Approved | 2026-03-23 | PRD drafted with GitHub Issue #18 stories, consumer guide F-008, and CVSS/OWASP research |
+| Architect | architect | ⚠ Approved with Concerns | 2026-03-23 | 1 high (Gemini quality), 7 medium, 5 low — all resolvable in spec phase |
+| Engineering Lead | team-lead | ⚠ Approved with Concerns | 2026-03-23 | 1 sprint feasible (75% confidence, 2.0-3.5h). Elevate FR-7 to P0; resolve open questions before tasks |
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-23 | product-manager | Initial PRD |

--- a/docs/product/02_PRD/INDEX.md
+++ b/docs/product/02_PRD/INDEX.md
@@ -5,6 +5,7 @@
 
 | # | Feature | PM | Architect | Team-Lead | Status | Date |
 |---|---------|----|-----------|-----------| -------|------|
+| 018 | [Threat Infographic Agent](018-threat-infographic-agent-2026-03-23.md) | ✓ | ⚠ | ⚠ | Approved | 2026-03-23 |
 | 015 | [Threat Report Agent & Attack Trees](015-threat-report-agent-attack-trees-2026-03-23.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-23 |
 | 012 | [SARIF Output Generation](012-sarif-output-generation-2026-03-22.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-22 |
 | 010 | [Deduplication & Risk Rating](010-deduplication-risk-rating-2026-03-22.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-22 |

--- a/docs/product/_backlog/BACKLOG.md
+++ b/docs/product/_backlog/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-> Auto-generated from GitHub Issues on 2026-03-23T13:17:00Z.
+> Auto-generated from GitHub Issues on 2026-03-23T15:00:23Z.
 > Source of truth: GitHub Issues with `stage:*` labels.
 > Regenerate: `/aod.status` or `.aod/scripts/bash/backlog-regenerate.sh`
 
@@ -40,6 +40,7 @@
 
 | # | Title | State | Updated |
 |---|-------|-------|---------|
+| #18 | Feature: Threat Infographic Agent | OPEN | 2026-03-23 |
 | #15 | Feature 007: Threat Report Agent & Attack Trees | CLOSED | 2026-03-23 |
 | #12 | Feature 006: SARIF Output Generation | CLOSED | 2026-03-23 |
 | #10 | Feature 008: Deduplication & Risk Rating | CLOSED | 2026-03-22 |

--- a/examples/mermaid-agentic-app/threat-infographic-spec.md
+++ b/examples/mermaid-agentic-app/threat-infographic-spec.md
@@ -1,0 +1,94 @@
+---
+schema_version: "1.0"
+date: "2026-03-21"
+source_file: "threats.md"
+finding_count: 19
+image_generated: false
+---
+
+## 1. Metadata
+
+| Field | Value |
+|-------|-------|
+| Project Name | Agentic AI Application (Mermaid Architecture) |
+| Scan Date | 2026-03-21 |
+| Analysis Agents | 8 |
+| Total Findings | 19 |
+| Risk Posture | Elevated risk — 3 Critical and 9 High findings across 5 components require immediate attention. |
+
+## 2. Risk Distribution
+
+| Severity | Count | Percentage | Color |
+|----------|-------|------------|-------|
+| Critical | 3 | 15.8% | #DC2626 |
+| High | 9 | 47.4% | #F97316 |
+| Medium | 7 | 36.8% | #EAB308 |
+| Low | 0 | 0.0% | #4169E1 |
+| **Total** | **19** | **100%** | — |
+
+**Chart Format**: Suitable for donut chart (proportional segments) or horizontal bar chart (comparative lengths).
+
+## 3. Coverage Heat Map
+
+| Component | Critical | High | Medium | Low | Total |
+|-----------|----------|------|--------|-----|-------|
+| LLM Agent Orchestrator | 2 | 4 | 4 | 0 | 10 |
+| Knowledge Base | 0 | 3 | 1 | 0 | 4 |
+| MCP Tool Server | 1 | 1 | 0 | 0 | 2 |
+| User | 0 | 1 | 1 | 0 | 2 |
+| External API | 0 | 0 | 1 | 0 | 1 |
+
+## 4. Top Critical Findings
+
+| # | Finding ID | Component | Threat | Risk Level |
+|---|-----------|-----------|--------|------------|
+| 1 | AG-1 | LLM Agent Orchestrator | Autonomous execution of consequential tool calls without human approval for irreversible actions | Critical |
+| 2 | AG-2 | MCP Tool Server | Unrestricted tool access without per-session capability scoping enables out-of-scope invocations | Critical |
+| 3 | LLM-1 | LLM Agent Orchestrator | Direct prompt injection causing data exfiltration via crafted tool call parameters | Critical |
+| 4 | S-1 | User | Authentication credential replay or forgery enabling unauthorized user impersonation | High |
+| 5 | T-2 | Knowledge Base | Unauthorized document modification corrupting RAG retrieval results | High |
+
+## 5. Architecture Threat Overlay
+
+| Component | Risk Weight | Finding Count | Annotation |
+|-----------|-------------|---------------|------------|
+| LLM Agent Orchestrator | High | 10 | Highest-risk component with 2 Critical and 4 High findings spanning privilege escalation, prompt injection, information disclosure, and denial of service. Central attack surface due to orchestration role. |
+| Knowledge Base | High | 4 | Elevated risk with 3 High findings covering data integrity, unauthorized access, and knowledge poisoning. Primary data store targeted for indirect attacks on downstream LLM context. |
+| MCP Tool Server | Medium | 2 | Moderate risk with 1 Critical finding on unrestricted tool access and 1 High finding on unsanitized parameter forwarding. Attack surface concentrated on tool invocation controls. |
+| User | Medium | 2 | Moderate risk with 1 High finding on authentication bypass and 1 Medium finding on action repudiation. External entry point requiring identity verification controls. |
+| External API | Low | 1 | Low risk with 1 Medium finding on connection spoofing. Attack surface limited to outbound API communication channel. |
+
+**Visual Guidance**: Components with `High` risk weight should be rendered with the largest visual emphasis (bold borders, larger icons, red highlight). `Medium` components receive moderate emphasis (orange highlight). `Low` components receive minimal emphasis (standard rendering).
+
+## 6. Visual Design Directives
+
+### Color Palette (CVSS Severity)
+
+| Severity | Hex Code | Usage |
+|----------|----------|-------|
+| Critical | #DC2626 | Highest severity indicators, urgent findings |
+| High | #F97316 | High severity indicators, priority findings |
+| Medium | #EAB308 | Medium severity indicators, planned remediation |
+| Low | #4169E1 | Low severity indicators, accepted risk |
+| Informational | #6B7280 | Neutral elements, labels, secondary text |
+
+### Layout Structure
+
+- **Aspect Ratio**: 16:9 landscape (1920x1080 minimum)
+- **Three-Zone Layout**:
+  1. **Header Zone** (top ~20%): Project name, scan date, total findings, risk posture summary, overall risk score
+  2. **Distribution Zone** (middle ~40%): Risk distribution chart (donut or bar) on the left, coverage heat map on the right
+  3. **Findings Zone** (bottom ~40%): Top critical findings list on the left, architecture threat overlay on the right
+
+### Typography
+
+- **Title**: Bold, 28-32pt equivalent
+- **Section Headers**: Semi-bold, 18-22pt equivalent
+- **Data Labels**: Regular, 12-14pt equivalent
+- **Data Values**: Bold, 14-16pt equivalent
+
+### Background
+
+- Dark theme: Navy (#1E293B) with white text
+- Light theme: White (#FFFFFF) with dark text
+- Either theme is acceptable; dark theme preferred for presentation impact

--- a/schemas/infographic.yaml
+++ b/schemas/infographic.yaml
@@ -1,0 +1,125 @@
+# Infographic Output Schema
+#
+# Defines the complete structure of a threat infographic specification
+# (threat-infographic-spec.md). Validates that generated specifications
+# contain all required sections with correct structure.
+#
+# Producers: Infographic agent (agents/threat-infographic.md)
+# Consumers: Validation phase, orchestrator output checks, designers
+#
+# Version: 1.0
+
+schema_version: "1.0"
+
+infographic:
+  output_file: threat-infographic-spec.md
+  optional_output_file: threat-infographic.jpg
+
+  frontmatter:
+    required: true
+    fields:
+      schema_version:
+        type: string
+        value: "1.0"
+      date:
+        type: string
+        format: "YYYY-MM-DD"
+      source_file:
+        type: string
+        description: >
+          Path to input threats.md used as the basis for
+          this infographic specification.
+      finding_count:
+        type: integer
+        description: >
+          Total findings from input threats.md (sum across
+          all STRIDE and AI agent categories).
+      image_generated:
+        type: boolean
+        description: >
+          Whether threat-infographic.jpg was successfully
+          produced via Gemini API.
+
+  required_sections:
+    - name: "Metadata"
+      heading: "## 1. Metadata"
+      required_fields:
+        - project_name
+        - scan_date
+        - agent_count
+        - finding_count
+        - risk_posture
+
+    - name: "Risk Distribution"
+      heading: "## 2. Risk Distribution"
+      required_fields:
+        - severity_counts
+        - percentages
+        - chart_format
+      accuracy_rule: >
+        Counts must match threats.md Section 6 exactly —
+        zero discrepancy.
+
+    - name: "Coverage Heat Map"
+      heading: "## 3. Coverage Heat Map"
+      required_fields:
+        - component_severity_matrix
+        - row_ordering
+      max_rows: 8
+      overflow_rule: >
+        Aggregate remaining components as "Other" row
+        with combined counts.
+
+    - name: "Top Critical Findings"
+      heading: "## 4. Top Critical Findings"
+      required_fields:
+        - finding_id
+        - component
+        - threat_summary
+        - risk_level
+      max_entries: 5
+      selection_rule: "Critical first, then High"
+
+    - name: "Architecture Threat Overlay"
+      heading: "## 5. Architecture Threat Overlay"
+      required_fields:
+        - component_risk_annotations
+        - visual_weight_guidance
+
+    - name: "Visual Design Directives"
+      heading: "## 6. Visual Design Directives"
+      required_fields:
+        - color_palette
+        - layout_structure
+        - aspect_ratio
+        - font_hierarchy
+
+  color_palette:
+    critical: "#DC2626"
+    high: "#F97316"
+    medium: "#EAB308"
+    low: "#4169E1"
+    info: "#6B7280"
+
+  layout:
+    aspect_ratio: "16:9"
+    orientation: landscape
+    zones:
+      - header
+      - distribution
+      - findings
+
+  attack_tree_naming:
+    description: >
+      Attack tree references in Top Critical Findings use
+      the finding ID format from schemas/finding.yaml
+      (e.g., "AG-1", "S-3").
+
+  # Completeness Rule
+  #
+  # Risk distribution counts in the specification must exactly
+  # match the aggregate counts in threats.md Section 6 (Risk
+  # Summary). Component names must match threats.md verbatim.
+  completeness_rule: >
+    Risk distribution counts must match threats.md Section 6.
+    Component names must match threats.md exactly.

--- a/specs/018-threat-infographic-agent/NEXT-SESSION.md
+++ b/specs/018-threat-infographic-agent/NEXT-SESSION.md
@@ -1,0 +1,48 @@
+# Session Continuation: Threat Infographic Agent (F-018)
+
+**Generated**: 2026-03-23
+**Branch**: 018-threat-infographic-agent
+**Last Commit**: eaea020 docs(015): update CHANGELOG (#17)
+
+## Completed This Session
+
+- **Wave 1** (T001): Created `schemas/infographic.yaml` — infographic output schema following `report.yaml` structural pattern
+- **Wave 2** (T002-T007): Created `agents/threat-infographic.md` — Core Mission, Input Contract, Data Extraction Methodology, Infographic Specification Format, Quality Standards sections
+- **P0 Checkpoint**: Architect review — APPROVED_WITH_CONCERNS (2 low, 1 info). LOW-01 (Note severity handling) addressed inline.
+- **Wave 3 Track A** (T008-T010): Added Gemini API Prompt Construction, Gemini API Integration, Error Handling & Graceful Degradation sections to `agents/threat-infographic.md`
+- **Wave 3 Track B** (T011-T015): Updated `agents/orchestrator.md` — Phase 6 frontmatter, pipeline description, dispatch section, opt-out config (`--skip-infographic`), output validation checks
+
+## Current State
+
+- **Phase**: implement (Wave 4 remaining)
+- **Uncommitted**: 8 files (2 new agent/schema files, 1 modified orchestrator, spec artifacts, backlog)
+- **Tasks**: 15/18 complete (83%)
+- **Remaining Tasks** (Wave 4 — Validation & Polish):
+  - T016: Create sample `threat-infographic-spec.md` from `examples/mermaid-agentic-app/threats.md`
+  - T017: Validate data accuracy of sample output (counts, component names, hex codes)
+  - T018: Validate `quickstart.md` consistency with implemented changes
+
+## Next Actions
+
+1. Run `/aod.build` — will auto-resume at Wave 4 (T016-T018)
+2. Wave 4 executes: generate sample output, validate data accuracy, validate quickstart
+3. P1 Checkpoint: Architect + Code Reviewer + Security Analyst final validation
+4. Security scan (Step 6)
+5. Completion report → `/aod.deliver`
+
+## Context Files
+
+- `specs/018-threat-infographic-agent/spec.md` — Feature specification (PM approved)
+- `specs/018-threat-infographic-agent/plan.md` — Implementation plan (PM + Architect approved)
+- `specs/018-threat-infographic-agent/tasks.md` — Task breakdown (Triple sign-off)
+- `specs/018-threat-infographic-agent/agent-assignments.md` — Wave/agent assignments
+- `agents/threat-infographic.md` — NEW: Infographic agent prompt (all sections complete)
+- `schemas/infographic.yaml` — NEW: Infographic output schema
+- `agents/orchestrator.md` — MODIFIED: Phase 6 integration
+- `.aod/results/architect-p0.md` — P0 checkpoint review results
+
+## Resume Command
+
+```bash
+claude "Resume Threat Infographic Agent implementation (branch: 018-threat-infographic-agent). Waves 1-3 complete (15/18 tasks). Run /aod.build to continue with Wave 4 (Validation & Polish)."
+```

--- a/specs/018-threat-infographic-agent/agent-assignments.md
+++ b/specs/018-threat-infographic-agent/agent-assignments.md
@@ -1,0 +1,111 @@
+# Agent Assignments: Threat Infographic Agent (F-018)
+
+**Generated**: 2026-03-23
+**Total Tasks**: 18
+**Estimated Duration**: 2.3–3.0 hours (with parallelism)
+
+## Agent Assignment Matrix
+
+| Task | Agent | Rationale |
+|------|-------|-----------|
+| T001 | `senior-backend-engineer` | Schema authoring (YAML) |
+| T002 | `senior-backend-engineer` | Agent prompt file creation (markdown) |
+| T003 | `senior-backend-engineer` | Agent prompt section authoring |
+| T004 | `senior-backend-engineer` | Agent prompt section authoring |
+| T005 | `senior-backend-engineer` | Agent prompt section authoring |
+| T006 | `senior-backend-engineer` | Agent prompt section authoring |
+| T007 | `senior-backend-engineer` | Agent prompt section authoring |
+| T008 | `senior-backend-engineer` | Agent prompt section authoring (Gemini) |
+| T009 | `senior-backend-engineer` | Agent prompt section authoring (API) |
+| T010 | `senior-backend-engineer` | Agent prompt section authoring (error handling) |
+| T011 | `senior-backend-engineer` | Orchestrator modification (frontmatter) |
+| T012 | `senior-backend-engineer` | Orchestrator modification (pipeline description) |
+| T013 | `senior-backend-engineer` | Orchestrator modification (Phase 6 dispatch) |
+| T014 | `senior-backend-engineer` | Orchestrator modification (opt-out config) |
+| T015 | `senior-backend-engineer` | Orchestrator modification (validation checks) |
+| T016 | `senior-backend-engineer` | Sample output generation |
+| T017 | `code-reviewer` | Data accuracy validation |
+| T018 | `code-reviewer` | Quickstart consistency validation |
+
+## Parallel Execution Waves
+
+### Wave 1: Schema Foundation
+**Duration**: ~15 min | **Agents**: 1
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| T001 | `senior-backend-engineer` (A) | Create `schemas/infographic.yaml` |
+
+**Quality Gate**: Schema file exists and follows `report.yaml` structural pattern.
+
+---
+
+### Wave 2: Core Agent Prompt (US-1)
+**Duration**: ~55–80 min | **Agents**: 1
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| T002 | `senior-backend-engineer` (A) | Create agent file with YAML frontmatter |
+| T003 | `senior-backend-engineer` (A) | Core Mission section |
+| T004 | `senior-backend-engineer` (A) | Input Contract section |
+| T005 | `senior-backend-engineer` (A) | Data Extraction Methodology |
+| T006 | `senior-backend-engineer` (A) | Infographic Specification Format |
+| T007 | `senior-backend-engineer` (A) | Quality Standards / Validation Checklist |
+
+**Quality Gate**: Agent can produce `threat-infographic-spec.md` with correct 6-section structure. US-1 MVP testable.
+
+---
+
+### Wave 3: Gemini + Orchestrator (US-2 || US-4)
+**Duration**: ~37–60 min | **Agents**: 2 (parallel)
+
+**Track A — Gemini API (US-2)**:
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| T008 | `senior-backend-engineer` (A) | Gemini prompt construction |
+| T009 | `senior-backend-engineer` (A) | Gemini API integration |
+| T010 | `senior-backend-engineer` (A) | Error handling & graceful degradation |
+
+**Track B — Orchestrator Integration (US-4)**:
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| T011 | `senior-backend-engineer` (B) | Update orchestrator frontmatter |
+| T012 | `senior-backend-engineer` (B) | Update pipeline description |
+| T013 | `senior-backend-engineer` (B) | Add Phase 6 dispatch section |
+| T014 | `senior-backend-engineer` (B) | Add opt-out configuration |
+| T015 | `senior-backend-engineer` (B) | Add output validation checks |
+
+**Quality Gate**: Agent handles Gemini API with graceful fallback. Orchestrator dispatches Phase 6. US-2 and US-4 independently testable.
+
+---
+
+### Wave 4: Validation & Polish
+**Duration**: ~30–45 min | **Agents**: 2 (parallel)
+
+| Task | Agent | Description |
+|------|-------|-------------|
+| T016 | `senior-backend-engineer` (A) | Generate sample infographic spec |
+| T017 | `code-reviewer` (C) | Validate data accuracy |
+| T018 | `code-reviewer` (C) | Validate quickstart consistency |
+
+**Quality Gate**: Sample output passes data accuracy checks. Quickstart documentation consistent. Feature ready for delivery.
+
+---
+
+## Time Estimates
+
+| Scenario | Duration | Notes |
+|----------|----------|-------|
+| Optimistic (2 agents, parallel) | 2.3 hours | Waves 3 tracks run in parallel |
+| Realistic (2 agents, parallel) | 3.0 hours | Account for context loading and review |
+| Pessimistic (2 agents, parallel) | 4.1 hours | Account for Gemini API issues |
+| Sequential (1 agent) | 3.25–4.75 hours | All tasks serial |
+
+## Notes
+
+- All tasks are markdown/YAML authoring — `senior-backend-engineer` is the correct agent for file creation/editing
+- Wave 3 is the key parallelization opportunity: two agents working on different files simultaneously
+- `code-reviewer` validates output quality in Wave 4 — separate from authoring agent for independence
+- Single-file bottleneck in Wave 2 (T002-T007 all target same file) is a structural constraint, not mitigable

--- a/specs/018-threat-infographic-agent/checklists/requirements.md
+++ b/specs/018-threat-infographic-agent/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Threat Infographic Agent
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-03-23
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs as implementation choices)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+- Gemini API model ID (`gemini-3-pro-image-preview`) is referenced as a configurable default, not an implementation choice — it specifies WHAT model capability is needed
+- CVSS color hex codes are specification-level data (design directives), not implementation details
+- All PRD open questions resolved: Gemini model (configurable default), heat map truncation (top 8), layout (16:9 landscape), SVG fallback (deferred)
+- Architect concerns addressed: spec-as-primary-deliverable framing, schemas/infographic.yaml required, fresh-context isolation, opt-out naming
+- Team Lead condition addressed: FR-7 (orchestrator integration) elevated to P0 as US-4

--- a/specs/018-threat-infographic-agent/data-model.md
+++ b/specs/018-threat-infographic-agent/data-model.md
@@ -1,0 +1,83 @@
+# Data Model: Threat Infographic Agent
+
+## Input Schema: `threats.md` (read-only)
+
+The infographic agent consumes `threats.md` as defined by `schemas/output.yaml` (v1.1). No modifications to this schema are needed.
+
+**Key sections consumed**:
+
+| Section | Data Extracted | Used In |
+|---------|---------------|---------|
+| YAML Frontmatter | `date`, `schema_version`, `classification` | Metadata |
+| Section 1: Architecture | Component names, trust boundaries | Architecture Threat Overlay |
+| Section 3: STRIDE Findings | Per-finding `component`, `risk_level` | Risk Distribution, Heat Map |
+| Section 4: AI Findings | Per-finding `component`, `risk_level` | Risk Distribution, Heat Map |
+| Section 4a: Correlated Findings | Correlation groups | Counted in totals |
+| Section 5: Coverage Matrix | Component × category counts | Heat Map cross-validation |
+| Section 6: Risk Summary | Aggregate severity counts | Risk Distribution (authoritative source) |
+| Section 7: Recommended Actions | Top findings by severity | Top Critical Findings |
+
+## Output Schema: `threat-infographic-spec.md`
+
+Defined by `schemas/infographic.yaml` (v1.0). New schema created for this feature.
+
+### Section Structure
+
+```
+threat-infographic-spec.md
+├── YAML Frontmatter
+│   ├── schema_version: "1.0"
+│   ├── date: "YYYY-MM-DD"
+│   ├── source_file: "threats.md"
+│   ├── finding_count: N
+│   └── image_generated: true|false
+├── ## 1. Metadata
+│   ├── project_name: string
+│   ├── scan_date: date
+│   ├── agent_count: integer
+│   ├── finding_count: integer
+│   └── risk_posture: string (one sentence)
+├── ## 2. Risk Distribution
+│   ├── severity_counts: {Critical: N, High: N, Medium: N, Low: N}
+│   ├── percentages: {Critical: N%, High: N%, Medium: N%, Low: N%}
+│   └── total: integer
+├── ## 3. Coverage Heat Map
+│   ├── rows[]: (max 8 + optional "Other")
+│   │   ├── component: string (exact match to threats.md)
+│   │   ├── critical: integer
+│   │   ├── high: integer
+│   │   ├── medium: integer
+│   │   ├── low: integer
+│   │   └── total: integer
+│   └── ordering: by total descending
+├── ## 4. Top Critical Findings
+│   ├── entries[]: (max 5)
+│   │   ├── finding_id: string (e.g., "AG-1")
+│   │   ├── component: string
+│   │   ├── threat_summary: string (one sentence)
+│   │   └── risk_level: Critical|High
+│   └── selection: Critical first, then High
+├── ## 5. Architecture Threat Overlay
+│   ├── component_annotations[]:
+│   │   ├── component: string
+│   │   ├── risk_weight: high|medium|low
+│   │   └── annotation: string
+│   └── visual_guidance: string
+└── ## 6. Visual Design Directives
+    ├── color_palette: {Critical: "#DC2626", High: "#F97316", Medium: "#EAB308", Low: "#4169E1", Info: "#6B7280"}
+    ├── layout: three-zone (header, distribution, findings)
+    ├── aspect_ratio: "16:9"
+    ├── orientation: landscape
+    ├── font_hierarchy: title > section > label > data
+    └── background: dark navy (#1E293B) or white (#FFFFFF)
+```
+
+## Data Accuracy Constraints
+
+| Constraint | Enforcement |
+|-----------|-------------|
+| Risk distribution counts = threats.md Section 6 | Agent validates before writing spec |
+| Component names match threats.md exactly | Verbatim extraction, no renaming |
+| Severity colors match CVSS hex codes | Hardcoded in schema, validated in checklist |
+| Heat map row ordering | Sorted by total finding count descending |
+| Top findings selection | Critical first, then High, max 5 |

--- a/specs/018-threat-infographic-agent/plan.md
+++ b/specs/018-threat-infographic-agent/plan.md
@@ -1,0 +1,314 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-23
+    status: APPROVED
+    notes: "All 15 FRs addressed. All 4 user stories traceable to deliverables. All 8 success criteria achievable. Zero scope creep. 2 non-blocking concerns: PRD Risk 3 contingency documentation, opt-out flag naming consistency."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-23
+    status: APPROVED_WITH_CONCERNS
+    notes: "Architecture sound, follows F-015 patterns. 4 medium concerns resolvable during implementation: (1) agent frontmatter missing standard fields, (2) opt-out flag naming inconsistency (--no vs --skip), (3) schema structure should match report.yaml pattern, (4) move gemini_config from schema to agent prompt. No blocking issues."
+  techlead_signoff: null
+---
+
+# Implementation Plan: Threat Infographic Agent
+
+**Branch**: `018-threat-infographic-agent` | **Date**: 2026-03-23 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/018-threat-infographic-agent/spec.md`
+
+## Summary
+
+Add an infographic agent (`agents/threat-infographic.md`) that transforms the structured `threats.md` output into a visual risk specification (`threat-infographic-spec.md`) and optionally produces a presentation-ready JPEG image via Google Gemini API. Integrate as Phase 6 (Infographic) in the orchestrator pipeline, running in fresh context with only `threats.md` as input. The specification is the primary deliverable; the image is best-effort.
+
+All deliverables are markdown prompt files and YAML schemas — consistent with tachi's architecture where agents are prompts, not application code.
+
+## Technical Context
+
+**Language/Version**: Markdown + YAML (prompt engineering, no application code)
+**Primary Dependencies**: Existing `schemas/finding.yaml` (v1.0), `schemas/output.yaml` (v1.1), `agents/orchestrator.md`, Google Gemini API (optional external)
+**Storage**: Filesystem — markdown files in `agents/`, `schemas/`
+**Testing**: Manual validation against `examples/mermaid-agentic-app/threats.md` (19 findings: 3 Critical, 9 High, 7 Medium)
+**Target Platform**: Any LLM-based agent runtime (Claude, GPT-4, etc.) with optional Gemini API access for image generation
+**Project Type**: Content-as-code (prompt files + schemas)
+**Performance Goals**: Specification generation completes within single LLM context window; Gemini API call ≤60s timeout
+**Constraints**: Fresh context isolation for Phase 6 — only `threats.md` as input; Gemini API is optional; Phase 6 failures never block Phases 1–5
+**Scale/Scope**: 3 new files, 1 modified file, 0 application code
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. General-Purpose Architecture | PASS | Infographic agent is domain-agnostic — transforms any `threats.md` following the schema, not tied to specific threat models |
+| II. API-First Design | N/A | No API endpoints — this is a prompt file, not a service. Gemini API is an external dependency described in prompt instructions |
+| III. Backward Compatibility | PASS | Phase 6 is opt-out (default-on); existing Phase 1–5 behavior unchanged; no breaking changes |
+| IV. Concurrency & Data Integrity | N/A | No shared state — infographic agent reads `threats.md` (immutable input), writes new files |
+| V. Privacy & Data Isolation | PASS | Infographic agent processes threat model output, not user PII; output stays in same directory |
+| VI. Testing Excellence | PASS | Validated against sample `threats.md`; completeness verified via data accuracy checks |
+| VII. Definition of Done | PASS | Three-step validation: pushed + tested + user validated |
+| VIII. Observability | N/A | No runtime services to monitor |
+| IX. Git Workflow | PASS | Feature branch `018-threat-infographic-agent` |
+| X. Product-Spec Alignment | PASS | PM approved spec (with concerns); all 15 FRs trace to PRD requirements |
+| XI. SDLC Triad Collaboration | PASS | PRD Triad-approved; spec PM-approved; plan under dual review |
+
+**Gate Result**: PASS — no violations. Proceeding to Phase 0.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/018-threat-infographic-agent/
+├── plan.md              # This file
+├── research.md          # Research phase output (completed during spec)
+├── data-model.md        # Schema design for infographic output
+├── quickstart.md        # Integration quickstart guide
+└── tasks.md             # Task breakdown (/aod.tasks output)
+```
+
+### Source Files (repository root)
+
+```
+agents/
+├── threat-infographic.md    # NEW — Infographic agent prompt file (FR-001)
+└── orchestrator.md          # MODIFIED — Add Phase 6 dispatch (FR-012, FR-013, FR-014)
+
+schemas/
+├── finding.yaml             # EXISTING — Input schema (no changes)
+├── output.yaml              # EXISTING — threats.md schema (no changes)
+└── infographic.yaml         # NEW — Infographic output validation schema (FR-015)
+
+examples/mermaid-agentic-app/
+├── threats.md               # EXISTING — Sample input for validation
+└── threat-infographic-spec.md  # NEW — Sample output for validation
+```
+
+**Structure Decision**: Content-as-code pattern — no `src/`, `tests/`, or application directories. All deliverables are markdown/YAML files consistent with tachi's prompt-file architecture. Follows identical pattern to F-015.
+
+## Components
+
+### Component 1: Infographic Agent Prompt (`agents/threat-infographic.md`)
+
+**Purpose**: Markdown prompt file that defines the infographic agent's data extraction methodology, specification format, Gemini API prompt construction, and graceful fallback behavior. When invoked by the orchestrator or standalone, the LLM follows these instructions to transform `threats.md` into a visual risk specification.
+
+**Follows Existing Pattern**: 8-section YAML+Markdown structure matching `agents/threat-report.md` (F-015).
+
+**YAML Frontmatter**:
+```yaml
+---
+agent_name: threat-infographic
+category: report
+input_schema: schemas/output.yaml
+output_schema: schemas/infographic.yaml
+output_files:
+  - threat-infographic-spec.md
+  - threat-infographic.jpg  # conditional on GEMINI_API_KEY
+---
+```
+
+**Sections**:
+1. **Core Mission**: Transform structured threat findings into a visual risk specification with optional Gemini API image generation. The specification is the primary deliverable; the image is best-effort.
+2. **Input Contract**: Consumes complete `threats.md` (Sections 1–7 + 4a). References `schemas/output.yaml` for structure validation. Does NOT consume `threat-report.md` (fresh context isolation).
+3. **Data Extraction Methodology**:
+   - Parse `threats.md` YAML frontmatter for project metadata (date, schema version, classification)
+   - Extract Section 6 (Risk Summary) for aggregate finding counts per severity level
+   - Cross-tabulate `component` and `risk_level` fields from all findings in Sections 3, 4, and 4a for coverage heat map
+   - Select top 5 findings from Section 7 (Recommended Actions) filtered by severity (Critical first, then High)
+   - Aggregate per-component risk scores for architecture threat overlay
+4. **Infographic Specification Format** (6 required sections):
+   - **Metadata**: Project name, scan date, total agent count, total finding count, risk posture summary
+   - **Risk Distribution**: Severity counts with percentages, formatted for donut/bar chart. Data structure: `{severity: count, percentage}` for each level
+   - **Coverage Heat Map**: Component × severity matrix, rows ordered by total finding count descending, capped at 8 components with "Other" aggregation
+   - **Top Critical Findings**: Up to 5 entries: finding ID, component, one-sentence threat, risk level
+   - **Architecture Threat Overlay**: Component risk annotations with visual weight guidance
+   - **Visual Design Directives**: Color palette (CVSS hex codes), three-zone layout (header/distribution/findings), 16:9 landscape, font hierarchy, spacing
+5. **Gemini API Prompt Construction**:
+   - Construct a narrative scene description (not keyword list) from the 6 specification sections
+   - Use spatial zone instructions: "The top third contains..., the middle band shows..., the bottom section displays..."
+   - Include explicit hex codes for severity colors in prompt text
+   - Cap distinct text labels at 15-20 per infographic
+   - Use business-oriented framing: "risk assessment summary," "security posture overview"
+   - Avoid attack-specific terminology to minimize content policy rejection
+6. **Gemini API Integration**:
+   - Check `GEMINI_API_KEY` environment variable
+   - If present: call `POST https://generativelanguage.googleapis.com/v1beta/models/{model_id}:generateContent` with `responseModalities: ["TEXT", "IMAGE"]`, `aspectRatio: "16:9"`, `imageSize: "2K"`
+   - Default model: `gemini-3-pro-image-preview` (configurable — do not hardcode)
+   - Parse response: iterate `parts[]`, find `inline_data` with image MIME type, decode base64, save as `threat-infographic.jpg`
+   - If absent or API error: save specification only, log condition, continue
+7. **Error Handling & Graceful Degradation**:
+   - Missing `GEMINI_API_KEY`: log informational message, save spec, continue
+   - API rate limit (429): log warning, save spec, continue — no retry
+   - API timeout: log error with timeout duration, save spec, continue
+   - Content policy rejection: log rejection reason, save spec, continue
+   - Missing Section 6 in `threats.md`: compute severity counts directly from individual findings
+   - Empty threat model (0 findings): produce spec with zero-count distribution and note
+8. **Quality Standards / Validation Checklist**:
+   - All 6 specification sections present and non-empty
+   - Risk distribution counts match `threats.md` Section 6 exactly
+   - Component names in heat map match `threats.md` exactly
+   - Heat map rows ordered by total finding count descending
+   - Top findings selected from highest severity first
+   - CVSS hex codes match specification (Critical=#DC2626, High=#F97316, Medium=#EAB308, Low=#4169E1, Info=#6B7280)
+   - Gemini prompt uses business language, no attack terminology
+   - If image generated: file is valid JPEG with 16:9 aspect ratio
+
+### Component 2: Infographic Output Schema (`schemas/infographic.yaml`)
+
+**Purpose**: Defines the structural validation contract for `threat-infographic-spec.md`, enabling automated completeness checks.
+
+**Schema Structure**:
+```yaml
+schema_version: "1.0"
+output_file: threat-infographic-spec.md
+optional_output_file: threat-infographic.jpg
+required_sections:
+  - name: "Metadata"
+    heading: "## 1. Metadata"
+    required_fields: [project_name, scan_date, agent_count, finding_count, risk_posture]
+  - name: "Risk Distribution"
+    heading: "## 2. Risk Distribution"
+    required_fields: [severity_counts, percentages, chart_format]
+    accuracy_rule: "Counts must match threats.md Section 6 exactly"
+  - name: "Coverage Heat Map"
+    heading: "## 3. Coverage Heat Map"
+    required_fields: [component_severity_matrix, row_ordering]
+    max_rows: 8
+    overflow_rule: "Aggregate remaining components as 'Other'"
+  - name: "Top Critical Findings"
+    heading: "## 4. Top Critical Findings"
+    required_fields: [finding_id, component, threat_summary, risk_level]
+    max_entries: 5
+    selection_rule: "Critical first, then High"
+  - name: "Architecture Threat Overlay"
+    heading: "## 5. Architecture Threat Overlay"
+    required_fields: [component_risk_annotations, visual_weight_guidance]
+  - name: "Visual Design Directives"
+    heading: "## 6. Visual Design Directives"
+    required_fields: [color_palette, layout_structure, aspect_ratio, font_hierarchy]
+color_palette:
+  critical: "#DC2626"
+  high: "#F97316"
+  medium: "#EAB308"
+  low: "#4169E1"
+  info: "#6B7280"
+layout:
+  aspect_ratio: "16:9"
+  orientation: landscape
+  zones: [header, distribution, findings]
+gemini_config:
+  default_model: "gemini-3-pro-image-preview"
+  resolution: "2K"
+  fallback_model: "gemini-3.1-flash-image-preview"
+completeness_rule: "Risk distribution counts must match threats.md Section 6"
+```
+
+### Component 3: Orchestrator Integration
+
+**Purpose**: Update `agents/orchestrator.md` to dispatch Phase 6 (Infographic) after Phase 5 (Report) completes.
+
+**Changes to orchestrator.md**:
+
+1. **YAML frontmatter update**:
+   - Add `infographic: agents/threat-infographic.md` to `references.agents`
+   - Add `infographic: schemas/infographic.yaml` to `references.schemas`
+   - Update `description` to mention Phase 6
+
+2. **Pipeline description update** (line ~48):
+   - Add: `6. **Phase 6 -- Infographic** (optional, default-on): Invoke the infographic agent to generate a visual risk specification and optional presentation-ready image.`
+
+3. **Output Format Specification update** (line ~80):
+   - Add `threat-infographic-spec.md` and `threat-infographic.jpg` to the output file list
+   - Add conditional note: "(Phase 6, default-on) when Phase 6 is enabled"
+
+4. **Output Structural Validation Checklist update** (after Phase 5 section, ~line 1204):
+   - Add Phase 6 validation checks:
+     ```
+     #### Phase 6 Outputs (when Phase 6 is enabled)
+     - [ ] `threat-infographic-spec.md` exists in the output directory
+     - [ ] `threat-infographic-spec.md` contains all 6 required sections
+     - [ ] Risk distribution counts match `threats.md` Section 6
+     - [ ] If `GEMINI_API_KEY` is set: `threat-infographic.jpg` exists and is valid JPEG
+     - [ ] If `GEMINI_API_KEY` is not set: informational message logged, no image file expected
+     ```
+
+5. **New Phase 6 section** (after Phase 5 section, ~line 1767):
+   - Phase 6 dispatch following identical structure to Phase 5:
+     - Check opt-out (`--no-infographic` flag or `TACHI_SKIP_INFOGRAPHIC=true` env var or `infographic: false` config)
+     - Fresh-context invocation with only `threats.md` path
+     - Context isolation boundary using `<infographic-input>` tags
+     - Output placement in same directory
+     - Completion criteria
+   - Opt-out configuration section matching Phase 5 pattern
+   - **Pipeline isolation**: explicit statement that Phase 6 failures do NOT invalidate Phase 1–5 outputs
+
+**Minimal diff approach**: Add Phase 6 as a new section following Phase 5, using identical structural patterns. Do not restructure existing phases.
+
+## Data Flow
+
+```mermaid
+flowchart TD
+    TM["threats.md<br/>(Phase 4 Output)"] --> IA["Infographic Agent<br/>(agents/threat-infographic.md)"]
+    IA --> IS["threat-infographic-spec.md<br/>(6 Sections)"]
+    IA -->|"GEMINI_API_KEY set"| IMG["threat-infographic.jpg<br/>(Optional)"]
+    IA -->|"No API key or error"| SKIP["Spec saved as<br/>standalone deliverable"]
+
+    subgraph Infographic Agent Processing
+        Parse["Parse threats.md<br/>Sections 1-7 + 4a"] --> Meta["1. Metadata<br/>(Project, Date, Counts)"]
+        Parse --> Risk["2. Risk Distribution<br/>(Severity Counts + %)"]
+        Parse --> Heat["3. Coverage Heat Map<br/>(Component × Severity)"]
+        Parse --> Top["4. Top Critical Findings<br/>(Up to 5)"]
+        Parse --> Arch["5. Architecture<br/>Threat Overlay"]
+        Meta & Risk & Heat & Top & Arch --> Design["6. Visual Design<br/>Directives"]
+        Design --> Prompt["Gemini API<br/>Prompt Construction"]
+    end
+
+    IA --> Val["Validation<br/>(schemas/infographic.yaml)"]
+```
+
+## Tech Stack
+
+| Component | Technology | Rationale |
+|-----------|-----------|-----------|
+| Infographic Agent | Markdown prompt file | Consistent with tachi agent architecture — all agents are prompt files |
+| Output Schema | YAML | Matches `schemas/finding.yaml` and `schemas/output.yaml` patterns |
+| Image Generation | Google Gemini API (`gemini-3-pro-image-preview`) | Best-in-class text rendering for data-dense infographics; reasoning-based composition |
+| Specification Format | Markdown (6 sections) | Human-readable, designer-consumable, Gemini-promptable |
+| Validation | Schema-based structural check | Matches existing pattern from F-012 SARIF and F-015 report validation |
+
+## Complexity Tracking
+
+No constitution violations to justify. All deliverables are markdown/YAML files following established patterns.
+
+## Risk Mitigations
+
+| Risk | Likelihood | Mitigation |
+|------|-----------|------------|
+| Gemini image quality for data-dense infographics | Medium | Spec is primary deliverable; image is best-effort. Prompt uses simplified 5-6 key metrics, not full threat model. Short labels (2-4 words). |
+| Gemini API content policy rejection | Low | Business-oriented framing ("risk assessment summary"), avoid attack terminology in prompt |
+| Data accuracy in risk distribution | Low | Agent validates counts against `threats.md` Section 6 before writing spec |
+| Heat map overflow (many components) | Low | Cap at 8 components with "Other" aggregation; ordered by total finding count |
+| Context window pressure in Phase 6 | Low (mitigated by design) | Fresh context isolation — Phase 6 receives only `threats.md`, not accumulated pipeline context |
+| Gemini model deprecation | Low | Model ID is configurable in schema, not hardcoded in agent prompt |
+
+## Open Questions Resolved
+
+| Question | Decision | Rationale |
+|----------|----------|-----------|
+| Gemini model/endpoint | `gemini-3-pro-image-preview` (configurable) | Best text rendering and reasoning-based composition for data-dense layouts; configurable for future model updates |
+| Heat map component limit | Top 8 components, "Other" aggregation | Balances completeness with visual clarity; 8 rows fit cleanly in a single heat map |
+| Layout format | 16:9 landscape | Matches standard presentation slide format (PowerPoint, Google Slides, Keynote) |
+| SVG fallback | Deferred to future feature | MVP uses JPEG via Gemini; spec serves as manual rendering guide |
+| Opt-out flag naming | `--no-infographic` + `TACHI_SKIP_INFOGRAPHIC=true` | Matches PRD specification; PM concern about `--skip-infographic` vs `--no-infographic` noted for consistency review |
+| CVSS color palette | Modern hex codes (#DC2626, #F97316, #EAB308, #4169E1) | Research-grounded; more visually accessible than raw primary colors; same semantic meaning |
+
+## Deliverables Summary
+
+| # | File | Type | FR |
+|---|------|------|----|
+| 1 | `agents/threat-infographic.md` | NEW | FR-001 through FR-011, FR-013 |
+| 2 | `schemas/infographic.yaml` | NEW | FR-015 |
+| 3 | `agents/orchestrator.md` | MODIFIED | FR-012, FR-013, FR-014 |
+| 4 | `examples/mermaid-agentic-app/threat-infographic-spec.md` | NEW (validation) | SC-001 through SC-003, SC-008 |

--- a/specs/018-threat-infographic-agent/quickstart.md
+++ b/specs/018-threat-infographic-agent/quickstart.md
@@ -1,0 +1,67 @@
+# Quickstart: Threat Infographic Agent (F-018)
+
+## Prerequisites
+
+- Completed threat model: `threats.md` produced by the orchestrator (Phases 1–4)
+- Optional: `GEMINI_API_KEY` environment variable for image generation
+
+## Usage
+
+### Via Orchestrator (recommended)
+
+The infographic agent runs automatically as Phase 6 after Phase 5 (Report):
+
+```
+# Run full pipeline — Phase 6 included by default
+orchestrator analyze <architecture-input>
+
+# Skip infographic generation
+orchestrator analyze --skip-infographic <architecture-input>
+
+# Or via environment variable
+TACHI_SKIP_INFOGRAPHIC=true orchestrator analyze <architecture-input>
+```
+
+### Standalone (manual invocation)
+
+Invoke the infographic agent by providing `threats.md` as the sole input in a fresh context. The agent is a markdown prompt file — pass it to your LLM runtime with `threats.md` as context:
+
+```
+# Pseudo-syntax: provide threats.md as the agent's sole input
+agent run agents/threat-infographic.md --input <path-to-threats.md>
+```
+
+## Output Files
+
+| File | When Produced | Description |
+|------|--------------|-------------|
+| `threat-infographic-spec.md` | Always (when Phase 6 runs) | Structured infographic specification with 6 sections |
+| `threat-infographic.jpg` | Only when `GEMINI_API_KEY` is set and API succeeds | Presentation-ready 16:9 landscape image |
+
+## Configuration
+
+| Setting | Default | Options |
+|---------|---------|---------|
+| Phase 6 enabled | `true` | `--skip-infographic` flag or `TACHI_SKIP_INFOGRAPHIC=true` |
+| Gemini model | `gemini-3-pro-image-preview` | Configurable in `schemas/infographic.yaml` |
+| Image resolution | 2K | Defined in schema |
+| Aspect ratio | 16:9 landscape | Defined in schema |
+| Heat map max rows | 8 | Components beyond 8 aggregated as "Other" |
+
+## Gemini API Setup
+
+1. Get a Gemini API key from [Google AI Studio](https://aistudio.google.com/)
+2. Set the environment variable:
+   ```
+   export GEMINI_API_KEY=your-key-here
+   ```
+3. Run the pipeline — image generation is automatic when the key is present
+
+## Troubleshooting
+
+| Symptom | Cause | Resolution |
+|---------|-------|------------|
+| No `threat-infographic.jpg` | `GEMINI_API_KEY` not set | Set the environment variable; spec is still generated |
+| API rate limit error in logs | Gemini API quota exceeded | Wait and retry; spec is saved regardless |
+| Content policy rejection | Prompt triggered safety filter | Spec is saved; review Gemini prompt for sensitive terms |
+| Empty heat map | No findings in threats.md | Expected behavior for clean threat models |

--- a/specs/018-threat-infographic-agent/research.md
+++ b/specs/018-threat-infographic-agent/research.md
@@ -1,0 +1,74 @@
+# Research Summary: Threat Infographic Agent (F-018)
+
+## Knowledge Base Findings
+- No existing KB entries for infographic generation or visual output
+- F-015 (Threat Report Agent) is the closest predecessor — established Phase 5 pattern with optional phase, fresh context isolation, and graceful degradation
+- Key lesson from F-015: context isolation boundaries are critical — each phase receives only `threats.md` as input, no accumulated pipeline context (ADR-002, ADR-010)
+
+## Codebase Analysis
+
+### Similar Features
+- **`agents/threat-report.md`** (F-015): Closest pattern — markdown prompt agent producing narrative report + attack trees from `threats.md`
+- **`agents/orchestrator.md`**: Defines 5-phase pipeline; Phase 6 integration follows Phase 5 pattern (optional, default-on, fresh context)
+
+### Patterns to Follow
+- Agent prompt file structure: YAML frontmatter → Core Mission → Input Contract → Processing Methodology → Output Specification → Quality Standards → Error Handling → References
+- Phase integration pattern: check if enabled → dispatch agent with `threats.md` only → collect results → graceful failure handling
+- Opt-out pattern: `--skip-{phase}` flag and/or environment variable
+
+### Data Structures (Critical)
+- **`schemas/finding.yaml`** (v1.0): Finding IR with `id`, `category`, `component`, `threat`, `likelihood`, `impact`, `risk_level` (Critical/High/Medium/Low/Note), `mitigation`, `references`
+- **`schemas/output.yaml`** (v1.1): Defines `threats.md` structure — Section 6 (Risk Summary) has aggregate counts; Section 5 has Coverage Matrix; Section 7 has Recommended Actions
+- **No `schemas/infographic.yaml`** exists — must be created during implementation (architect concern)
+
+### Example Data
+- `examples/mermaid-agentic-app/threats.md`: 19 findings (3 Critical, 9 High, 7 Medium, 0 Low), component × category coverage matrix, recommended actions ordered by severity
+
+## Architecture Constraints
+- **Fresh context isolation**: Phase 6 receives ONLY `threats.md` as input — no accumulated pipeline context (ADR-002, ADR-010)
+- **No application code**: Agent is markdown prompt file; Gemini integration described in prompt instructions, not implemented in code
+- **Pipeline isolation**: Phase 6 failures MUST NOT block Phases 1-5 outputs
+- **Hub-and-spoke model**: New output schema `schemas/infographic.yaml` required for specification validation
+- **Configuration**: Opt-out flag for Phase 6; naming convention follows existing `--skip-report` pattern
+- **DoD exception**: Prompt files follow documentation-only DoD path (no production deployment needed)
+
+## Industry Research
+
+### Gemini API Image Generation
+- **Recommended model**: `gemini-3-pro-image-preview` (Nano Banana Pro) — best text rendering, reasoning-based composition planning for data-dense layouts
+- **Fallback model**: `gemini-3.1-flash-image-preview` — 3x cheaper, suitable for simpler layouts
+- **API endpoint**: `POST https://generativelanguage.googleapis.com/v1beta/models/{MODEL_ID}:generateContent` with `responseModalities: ["TEXT", "IMAGE"]`
+- **Resolution**: 2K default (cost/quality balance), 4K optional; aspect ratio 16:9 for presentation slides
+- **Limitations**: No function calling, no code execution, approximate chart proportions, text may need minor corrections
+- **Deprecation**: `gemini-2.5-flash-image` scheduled for shutdown October 2, 2026 — do not use
+
+### CVSS Severity Color Standards
+- **No official CVSS color standard** — de facto industry consensus exists
+- Industry standard: Critical=Red, High=Orange, Medium=Yellow, Low=Green, Info=Gray
+- PRD uses Low=Blue (#4169E1) per research §10 — diverges from some industry tools that use Green
+- Recommended hex codes: Critical=#DC2626, High=#F97316, Medium=#EAB308, Low=#4169E1 (matching PRD), Info=#6B7280
+
+### Executive Visualization Best Practices
+- Limit to 5-6 key visual elements per view
+- Lead with business impact, not technical metrics
+- Use traffic light protocol (red/yellow/green) for instant communication
+- Three-zone layout: Header (risk score) → Distribution (severity breakdown) → Findings (top critical)
+- Keep labels to 2-4 words; cap distinct text labels at 15-20 per infographic
+- Donut/bar charts preferred over pie charts
+
+### Prompt Engineering for Data-Rich Infographics
+- Narrative scene description outperforms keyword lists
+- Explicit spatial zone instructions ("top third contains..., middle shows...")
+- Include exact hex codes in prompt for color accuracy
+- Simplify to 5-6 key metrics rather than full threat model
+- Set expectation: "presentation-ready, minor text corrections may be needed"
+
+## Recommendations for Spec
+- Frame `threat-infographic-spec.md` as PRIMARY deliverable; image as best-effort (aligns with architect concern)
+- Follow F-015 agent structure exactly: YAML header, input/output contracts, methodology, quality standards
+- Design three-zone infographic layout: Header → Distribution → Critical Findings
+- Use `gemini-3-pro-image-preview` as default model ID (configurable, not hardcoded)
+- Cap heat map display at top 8 components by total finding count (addresses open question on truncation)
+- Phase 6 opt-out: `--no-infographic` flag + `TACHI_SKIP_INFOGRAPHIC=true` env var (follows PRD naming)
+- `threat-report.md` is NOT passed to Phase 6 (fresh context constraint) — spec must declare `threats.md` as sole input
+- Define `schemas/infographic.yaml` as implementation task (addresses architect concern)

--- a/specs/018-threat-infographic-agent/spec.md
+++ b/specs/018-threat-infographic-agent/spec.md
@@ -1,0 +1,231 @@
+---
+prd_reference: docs/product/02_PRD/018-threat-infographic-agent-2026-03-23.md
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-23
+    status: APPROVED_WITH_CONCERNS
+    notes: "All 8 PRD functional requirements mapped to 15 spec FRs. All 3 PRD user stories covered plus orchestrator integration elevated to P0 per Team Lead condition. All 4 open questions resolved. Architect concerns addressed. 3 low-severity non-blocking concerns: hex palette refinement, opt-out flag naming convention, SC-008 subjectivity — all addressable in plan/tasks phase."
+  architect_signoff: null
+  techlead_signoff: null
+---
+
+# Feature Specification: Threat Infographic Agent
+
+**Feature Branch**: `018-threat-infographic-agent`
+**Created**: 2026-03-23
+**Status**: Draft
+**PRD Reference**: `docs/product/02_PRD/018-threat-infographic-agent-2026-03-23.md`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Visual Threat Infographic Specification for Executive Communication (Priority: P0)
+
+As a CISO or security director, when I have a completed threat model (`threats.md`) and need to present risk posture to my board or management team, I want the findings transformed into a structured infographic specification that describes the visual layout, data points, color coding, and text content for a presentation-ready infographic so I can quickly communicate the security landscape without requiring the audience to read a full report.
+
+**Why this priority**: The infographic specification is the primary deliverable and the foundation for all visual outputs. It bridges the gap between comprehensive text-based threat reports and the single-slide visual artifact that executives actually review during board presentations. Without the specification, neither manual design nor automated image generation is possible.
+
+**Independent Test**: Run the infographic agent against the sample `examples/mermaid-agentic-app/threats.md` and verify it produces a `threat-infographic-spec.md` with all six required sections. Have a non-technical reader confirm the specification describes a visual that communicates risk posture within 10 seconds of viewing.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed `threats.md` with findings from STRIDE and AI agents, **When** the infographic agent runs, **Then** it produces `threat-infographic-spec.md` containing all six required sections: Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings, Architecture Threat Overlay, and Visual Design Directives.
+
+2. **Given** the Risk Distribution section of the specification, **When** it describes finding counts, **Then** the counts per severity level (Critical, High, Medium, Low) exactly match the aggregate counts in `threats.md` Section 6 (Risk Summary) — zero discrepancy.
+
+3. **Given** the Coverage Heat Map section, **When** it describes the component × severity matrix, **Then** it includes all components with findings from `threats.md`, ordered by total finding count (most findings first), capped at the top 8 components if more than 8 exist.
+
+4. **Given** the Top Critical Findings section, **When** it lists findings, **Then** it includes up to 5 findings selected from the highest severity levels (Critical first, then High), each with finding ID, component name, threat summary (one sentence), and risk level.
+
+5. **Given** the Architecture Threat Overlay section, **When** it describes component risk, **Then** it annotates which components carry the highest cumulative risk with a description of visual weight proportional to finding severity and count.
+
+6. **Given** the Visual Design Directives section, **When** it specifies colors, **Then** it uses CVSS severity color conventions: Critical=#DC2626 (red), High=#F97316 (orange), Medium=#EAB308 (yellow), Low=#4169E1 (blue), Informational=#6B7280 (gray).
+
+---
+
+### User Story 2 — Automated Image Generation via Gemini API (Priority: P0)
+
+As a developer or DevSecOps engineer, when I want the infographic agent to produce a visual automatically from threat data, I want the agent to generate a detailed infographic specification and feed it to the Gemini image generation API so I get a presentation-ready `threat-infographic.jpg` without manual design work.
+
+**Why this priority**: Automated image generation removes the translation step between threat analysis data and a shareable visual artifact. While the specification is the primary deliverable, the image is the artifact that gets embedded in slide decks, Confluence pages, and audit documentation. Co-equal P0 because it completes the end-to-end automation promise.
+
+**Independent Test**: Set the `GEMINI_API_KEY` environment variable, run the infographic agent against the sample `threats.md`, and verify it produces both `threat-infographic-spec.md` and `threat-infographic.jpg`. Verify the image is a valid JPEG at minimum 1920x1080 resolution with a clean, professional layout.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed `threats.md` and a valid `GEMINI_API_KEY` environment variable, **When** the infographic agent runs, **Then** it produces both `threat-infographic-spec.md` (the specification) and `threat-infographic.jpg` (the rendered image).
+
+2. **Given** the infographic specification, **When** fed to the Gemini image generation API, **Then** the resulting image uses a 16:9 landscape aspect ratio at minimum 1920x1080 resolution, suitable for presentation slides.
+
+3. **Given** the Gemini API returns an error, times out, or rejects the prompt due to content policy, **When** the agent detects the failure, **Then** it saves the specification as a standalone deliverable and logs a warning with the specific failure reason — it does NOT fail the pipeline.
+
+4. **Given** the infographic specification, **When** saved as markdown without Gemini API access, **Then** it is detailed enough for a designer to manually render the infographic using any design tool (Figma, Canva, PowerPoint).
+
+5. **Given** the Gemini API prompt constructed from the specification, **When** submitted, **Then** the prompt uses business-oriented language ("risk assessment summary," "security posture overview") rather than attack-specific terminology to minimize content policy rejection risk.
+
+---
+
+### User Story 3 — Optional and Configurable Infographic Generation (Priority: P0)
+
+As a tachi user, when my project does not have Gemini API access or I want to skip infographic generation entirely, I want infographic generation to be optional and configurable so I can use all other tachi features without requiring a Gemini API key.
+
+**Why this priority**: Optionality is a prerequisite for all other user stories. If infographic generation is mandatory or breaks the pipeline when unavailable, it violates tachi's core principle that features are additive. This must be P0 because it gates the safety of deploying US-1 and US-2.
+
+**Independent Test**: Run the full orchestrator pipeline without `GEMINI_API_KEY` set and verify Phases 1–5 complete normally. Then run with `TACHI_SKIP_INFOGRAPHIC=true` and verify Phase 6 is skipped entirely with no warning.
+
+**Acceptance Scenarios**:
+
+1. **Given** a project without a `GEMINI_API_KEY` environment variable, **When** the orchestrator runs, **Then** the infographic specification (`threat-infographic-spec.md`) is still generated but no image is produced. An informational message is logged: "Gemini API key not configured — infographic image generation skipped. Specification saved."
+
+2. **Given** the orchestrator configuration with infographic generation disabled via opt-out flag (`--no-infographic`) or environment variable (`TACHI_SKIP_INFOGRAPHIC=true`), **When** the orchestrator runs, **Then** Phase 6 is skipped entirely — no specification, no image, no warning logged.
+
+3. **Given** a project with all features enabled, **When** the orchestrator runs the full pipeline, **Then** Phases 1–5 complete and produce their outputs regardless of whether Phase 6 succeeds or fails. Phase 6 failures are isolated and never block the core pipeline.
+
+4. **Given** the opt-out configuration, **When** both `--no-infographic` flag and `TACHI_SKIP_INFOGRAPHIC=true` are set, **Then** the flag takes precedence (either one is sufficient to skip Phase 6).
+
+---
+
+### User Story 4 — Orchestrator Integration as Phase 6 (Priority: P0)
+
+As a tachi user running the threat modeling pipeline, when the orchestrator completes Phase 5 (Report), I want Phase 6 (Infographic) to automatically generate the infographic specification and optional image so I receive a complete threat model deliverable without manual intervention.
+
+**Why this priority**: Without orchestrator integration, the infographic agent cannot be invoked as part of the standard pipeline — users would need to manually trigger infographic generation. Elevated to P0 per Team Lead condition during PRD review (FR-7 elevation).
+
+**Independent Test**: Run the full orchestrator pipeline against the sample input and verify that Phase 6 automatically produces `threat-infographic-spec.md` (and `threat-infographic.jpg` if Gemini API is available) in the output directory alongside existing pipeline outputs.
+
+**Acceptance Scenarios**:
+
+1. **Given** the orchestrator completes Phase 5 (Report), **When** Phase 6 (Infographic) is enabled (default), **Then** the infographic agent is invoked with `threats.md` as its sole input and produces outputs in the same output directory.
+
+2. **Given** Phase 6 execution, **When** the infographic agent is invoked, **Then** it runs in a fresh context with only `threats.md` as input — not the accumulated pipeline context from Phases 1–5 and not `threat-report.md`.
+
+3. **Given** Phase 6 is set to skip via opt-out configuration, **When** the pipeline runs, **Then** it completes after Phase 5 without invoking the infographic agent. Existing Phase 1–5 behavior is unchanged.
+
+4. **Given** a completed Phase 6, **When** the output directory is examined, **Then** the structure includes:
+   ```
+   YYYY-MM-DD-{phase}/
+   ├── threats.md                     (Phase 4 — existing)
+   ├── threats.sarif                  (Phase 4 — existing, F-012)
+   ├── threat-report.md               (Phase 5 — existing, F-015)
+   ├── attack-trees/                  (Phase 5 — existing, F-015)
+   ├── threat-infographic-spec.md     (Phase 6 — new)
+   └── threat-infographic.jpg         (Phase 6 — new, conditional on Gemini API)
+   ```
+
+---
+
+### Edge Cases
+
+- **Empty threat model**: If `threats.md` contains zero findings, the infographic agent produces a specification with zero-count risk distribution, empty heat map, and a note stating "No threats identified in this threat model." No image generation is attempted.
+- **No Critical or High findings**: If all findings are Medium or Low, the Top Critical Findings section states "No Critical or High findings identified" and lists the top 5 Medium findings instead. The specification is still complete and valid.
+- **Large threat model (>30 findings)**: The specification always includes all findings in the Risk Distribution counts and Coverage Heat Map. The Top Critical Findings section remains capped at 5 entries regardless of total count.
+- **More than 8 components**: The Coverage Heat Map displays the top 8 components by total finding count. Remaining components are aggregated into an "Other" row with combined counts.
+- **Single component**: If all findings target a single component, the Coverage Heat Map shows one row. The Architecture Threat Overlay notes the concentration risk.
+- **Gemini API rate limit**: If the API returns a rate limit error (429), the agent logs the error, saves the specification, and continues the pipeline without retrying.
+- **Gemini content policy rejection**: If the API rejects the prompt, the agent logs the rejection reason, saves the specification, and continues. The prompt is designed to use business language to minimize this risk.
+- **Missing Section 6 in threats.md**: If `threats.md` lacks a Risk Summary section, the agent computes severity counts directly from individual findings in Sections 3 and 4.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide an infographic agent defined as a markdown prompt file (`agents/threat-infographic.md`) that consumes the structured `threats.md` and produces a structured infographic specification (`threat-infographic-spec.md`).
+
+- **FR-002**: The infographic specification MUST contain six required sections: (1) Metadata, (2) Risk Distribution, (3) Coverage Heat Map, (4) Top Critical Findings, (5) Architecture Threat Overlay, (6) Visual Design Directives.
+
+- **FR-003**: The Metadata section MUST include: project name, scan date, total agent count, total finding count, and overall risk posture summary (one sentence). All values derived from `threats.md` YAML frontmatter and Section 6.
+
+- **FR-004**: The Risk Distribution section MUST include finding counts per severity level (Critical, High, Medium, Low) with percentages of total, formatted for both donut chart and bar chart representation. Counts MUST exactly match `threats.md` Section 6 — zero discrepancy.
+
+- **FR-005**: The Coverage Heat Map section MUST present a component × severity matrix showing finding density per component. Rows ordered by total finding count (descending), capped at top 8 components with remaining aggregated as "Other." Component names MUST match `threats.md` exactly.
+
+- **FR-006**: The Top Critical Findings section MUST list up to 5 findings selected from the highest severity levels (Critical first, then High). Each entry includes: finding ID, component name, one-sentence threat summary, and risk level.
+
+- **FR-007**: The Architecture Threat Overlay section MUST describe which components carry the highest cumulative risk, with visual weight guidance proportional to finding severity and count. This section enables a designer or AI model to annotate an architecture diagram.
+
+- **FR-008**: The Visual Design Directives section MUST specify: CVSS severity color palette with hex codes (Critical=#DC2626, High=#F97316, Medium=#EAB308, Low=#4169E1, Info=#6B7280), layout structure (three-zone: header, distribution, findings), font hierarchy, spacing guidance, and 16:9 landscape aspect ratio.
+
+- **FR-009**: The infographic agent MUST construct a Gemini API prompt from the specification sections, using business-oriented language ("risk assessment summary," "security posture overview"), explicit hex color codes, spatial zone descriptions, and short text labels (2-4 words per element, maximum 15-20 distinct text labels total).
+
+- **FR-010**: When a `GEMINI_API_KEY` environment variable is present, the agent MUST submit the constructed prompt to the Gemini image generation API (model: configurable, default `gemini-3-pro-image-preview`) requesting a 16:9 landscape image at 2K resolution, and save the result as `threat-infographic.jpg`.
+
+- **FR-011**: When `GEMINI_API_KEY` is absent or the API returns an error (rate limit, timeout, content policy rejection), the agent MUST save the specification as a standalone deliverable, log the specific condition, and continue the pipeline without failure.
+
+- **FR-012**: The orchestrator MUST integrate the infographic agent as Phase 6 (Infographic) that runs after Phase 5 (Report) completes. Phase 6 is default-on with opt-out via `--no-infographic` flag or `TACHI_SKIP_INFOGRAPHIC=true` environment variable.
+
+- **FR-013**: Phase 6 MUST invoke the infographic agent in a fresh context with only `threats.md` as input — not the accumulated pipeline context from Phases 1–5 and not `threat-report.md` or attack tree files.
+
+- **FR-014**: Phase 6 failures MUST NOT block or invalidate Phases 1–5 outputs. The pipeline completes successfully regardless of Phase 6 outcome.
+
+- **FR-015**: An infographic output schema (`schemas/infographic.yaml`) MUST be defined specifying the required sections, data accuracy constraints, color palette, and file naming conventions for structural validation.
+
+### Key Entities
+
+- **Infographic Specification** (`threat-infographic-spec.md`): The primary output document containing six sections that describe the visual layout, data points, color coding, and text content for a threat infographic. Authored by the infographic agent, consumed by designers, Gemini API, or presentation authors.
+
+- **Infographic Image** (`threat-infographic.jpg`): A JPEG image rendered from the specification via Gemini API. Optional output — produced only when `GEMINI_API_KEY` is available and the API call succeeds. 16:9 landscape format at minimum 1920x1080 resolution.
+
+- **Risk Distribution**: Aggregated finding counts per severity level with percentages. Source: `threats.md` Section 6 (Risk Summary). Primary visualization in the infographic.
+
+- **Coverage Heat Map**: A component × severity matrix showing finding density across architecture components. Source: cross-tabulation of `component` and `risk_level` fields across all findings. Capped at top 8 components.
+
+- **Gemini Prompt**: A structured text prompt constructed from the infographic specification, designed for the Gemini image generation API. Uses business language, explicit colors, spatial layout instructions, and short labels.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The infographic agent produces a complete `threat-infographic-spec.md` from the sample `examples/mermaid-agentic-app/threats.md` containing all six required sections with non-empty content in each.
+
+- **SC-002**: Risk distribution counts in the specification exactly match `threats.md` Section 6 — zero discrepancy when compared field by field (Critical, High, Medium, Low counts and percentages).
+
+- **SC-003**: The Coverage Heat Map includes all components with findings from the sample `threats.md`, ordered by total finding count, with correct per-severity counts cross-validated against individual findings.
+
+- **SC-004**: When `GEMINI_API_KEY` is configured, the agent produces a `threat-infographic.jpg` that is a valid JPEG file with 16:9 aspect ratio at minimum 1920x1080 resolution.
+
+- **SC-005**: When `GEMINI_API_KEY` is not configured, the specification is saved as a standalone deliverable and the pipeline completes without error — no pipeline failure, no missing Phase 1–5 outputs.
+
+- **SC-006**: The full orchestrator pipeline (Phases 1–6) completes successfully against the sample input, with Phase 6 producing `threat-infographic-spec.md` alongside existing Phase 4 and Phase 5 outputs.
+
+- **SC-007**: Phase 6 (Infographic) can be skipped via `--no-infographic` or `TACHI_SKIP_INFOGRAPHIC=true` without affecting Phase 1–5 behavior — backward compatibility preserved.
+
+- **SC-008**: The infographic specification is self-contained — a designer can render the infographic from the spec alone without access to `threats.md`, validated by having a designer confirm all necessary data and design direction is present.
+
+## Assumptions
+
+- `threats.md` is complete and valid, produced by the orchestrator with all Phases 1–4 (and optionally Phase 5) complete.
+- The finding IR schema (`schemas/finding.yaml`) and output schema (`schemas/output.yaml`) remain stable at their current versions.
+- The Gemini image generation API (`gemini-3-pro-image-preview`) is available and supports 16:9 landscape output at 2K resolution. The model ID is configurable for future model updates.
+- AI-generated images are "presentation-ready with possible minor text corrections needed" — the specification is the authoritative reference for data accuracy, not the image.
+- A single infographic image is sufficient for MVP — no multi-page or multi-image output needed.
+- JPEG format meets presentation needs (no transparency required).
+- The infographic agent runs within the same LLM context infrastructure as other tachi agents.
+- Phase 6 receives only `threats.md` as input (fresh context), not the accumulated orchestrator pipeline context from Phases 1–5.
+- CVSS severity colors follow de facto industry convention as no official standard exists. The chosen palette (red/orange/yellow/blue) matches the PRD specification.
+
+## Scope Boundaries
+
+### In Scope
+- Infographic agent prompt file (`agents/threat-infographic.md`)
+- Infographic output schema (`schemas/infographic.yaml`)
+- Infographic specification generation with all six sections
+- CVSS severity color coding with explicit hex codes
+- Gemini API integration for image generation (optional, when API key available)
+- Graceful fallback when Gemini API is unavailable (spec saved as standalone)
+- Orchestrator integration as Phase 6 (default-on, opt-out via flag or env var)
+- Fresh context isolation for Phase 6 (threats.md only)
+- Pipeline isolation — Phase 6 failures never block Phases 1–5
+- Three-zone infographic layout (header, distribution, findings) in 16:9 landscape
+- Heat map truncation to top 8 components
+
+### Out of Scope
+- Interactive or animated infographic visualization
+- Multiple image output formats (PNG, SVG, PDF) — JPEG only for MVP
+- Custom infographic templates or branding options
+- Alternative image generation APIs (DALL-E, Midjourney, Stable Diffusion) — Gemini only for MVP
+- Real-time infographic updates when `threats.md` changes
+- Infographic comparison across multiple threat model runs
+- Embedding infographic in `threat-report.md` (separate file output)
+- SVG fallback generation for environments without Gemini (deferred per PRD open question)
+- Attack tree visualization in the infographic (too granular for executive audience)
+- Retry/regeneration logic for Gemini API failures (single attempt for MVP)

--- a/specs/018-threat-infographic-agent/tasks.md
+++ b/specs/018-threat-infographic-agent/tasks.md
@@ -1,0 +1,207 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-23
+    status: APPROVED
+    notes: "All 4 user stories addressed. All 15 FRs covered with full traceability. Zero scope creep. US-3 composite validation through US-2+US-4 is correct approach. 2 non-blocking observations: opt-out flag naming needs reconciliation, 3 edge cases implicitly handled."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-23
+    status: APPROVED_WITH_CONCERNS
+    notes: "Technically complete. All 4 plan concerns (M-01 through M-04) addressed in specific tasks. 1 medium: TACHI_SKIP_INFOGRAPHIC env var has no Phase 5 precedent — decide parity before implementation. 4 low: T016 P marker, T014/T015 parallel opportunity, T012 section separation, output prose paragraph."
+  techlead_signoff:
+    agent: team-lead
+    date: 2026-03-23
+    status: APPROVED_WITH_CONCERNS
+    notes: "18 tasks, 4 waves, 2.3-3.0h with parallelism. Critical path: 12 tasks (132-188 min). Phase 3||Phase 4 parallelism saves 40-60 min. 3 non-blocking: single-file bottleneck (structural constraint), approximate line references, minor parallelization understatement."
+---
+
+# Tasks: Threat Infographic Agent
+
+**Input**: Design documents from `/specs/018-threat-infographic-agent/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Not requested in feature specification — no test tasks generated.
+
+**Organization**: Tasks grouped by user story. All 4 user stories are P0; ordered by dependency (US-1 is MVP, US-2 builds on US-1, US-4 integrates into pipeline, US-3 validated through US-2 + US-4).
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Schema Foundation)
+
+**Purpose**: Create the output schema that defines the infographic specification contract. Required before agent authoring.
+
+- [X] T001 Create infographic output schema in `schemas/infographic.yaml` — define schema_version, output_file, required_sections (Metadata, Risk Distribution, Coverage Heat Map, Top Critical Findings, Architecture Threat Overlay, Visual Design Directives), color_palette with CVSS hex codes, completeness_rule, and attack tree naming. Follow `schemas/report.yaml` structural pattern with namespaced root key and frontmatter block per architect review M-03.
+
+**Checkpoint**: Schema foundation ready — agent authoring can begin.
+
+---
+
+## Phase 2: User Story 1 — Infographic Specification Generation (Priority: P0) MVP
+
+**Goal**: The infographic agent produces a structured `threat-infographic-spec.md` with 6 required sections from `threats.md`, with data accuracy matching Section 6 exactly.
+
+**Independent Test**: Run the infographic agent against `examples/mermaid-agentic-app/threats.md` and verify all 6 sections are present with correct severity counts (3 Critical, 9 High, 7 Medium, 0 Low).
+
+### Implementation for User Story 1
+
+- [X] T002 [US1] Create infographic agent prompt file `agents/threat-infographic.md` — YAML frontmatter (agent_name, category, status, version, description, references including input_schema, output_schema, output_files) following `agents/threat-report.md` pattern. Include all standard fields per architect review M-01.
+
+- [X] T003 [US1] Add Core Mission section to `agents/threat-infographic.md` — define the agent's purpose: transform structured threat findings into a visual risk specification. Frame specification as primary deliverable, image as best-effort.
+
+- [X] T004 [US1] Add Input Contract section to `agents/threat-infographic.md` — declare `threats.md` as sole input per `schemas/output.yaml` (v1.1). Specify which sections are consumed: YAML frontmatter, Sections 1, 3, 4, 4a, 5, 6, 7. Explicitly state: does NOT consume `threat-report.md` (fresh context isolation).
+
+- [X] T005 [US1] Add Data Extraction Methodology section to `agents/threat-infographic.md` — define 5 extraction steps: (1) parse frontmatter for metadata, (2) extract Section 6 for risk distribution counts, (3) cross-tabulate component × risk_level from Sections 3/4/4a for heat map, (4) select top 5 findings from Section 7 by severity, (5) aggregate per-component risk for architecture overlay.
+
+- [X] T006 [US1] Add Infographic Specification Format section to `agents/threat-infographic.md` — define the 6 required output sections: Metadata, Risk Distribution (counts + percentages), Coverage Heat Map (component × severity matrix, max 8 rows, "Other" aggregation), Top Critical Findings (max 5, Critical first then High), Architecture Threat Overlay (component risk annotations), Visual Design Directives (CVSS hex codes, three-zone layout, 16:9 landscape).
+
+- [X] T007 [US1] Add Quality Standards / Validation Checklist section to `agents/threat-infographic.md` — all 6 sections present, risk counts match Section 6, component names match exactly, heat map ordered by total descending, CVSS hex codes correct, severity colors validated.
+
+**Checkpoint**: Agent can generate `threat-infographic-spec.md` from any `threats.md`. US-1 independently testable.
+
+---
+
+## Phase 3: User Story 2 — Gemini API Image Generation (Priority: P0)
+
+**Goal**: When `GEMINI_API_KEY` is available, the agent produces a `threat-infographic.jpg` from the specification via Gemini API. When unavailable, the specification is saved as standalone deliverable.
+
+**Independent Test**: With `GEMINI_API_KEY` set, run agent and verify JPEG output exists with 16:9 aspect ratio. Without key, verify spec is saved and informational message logged.
+
+### Implementation for User Story 2
+
+- [X] T008 [US2] Add Gemini API Prompt Construction section to `agents/threat-infographic.md` — narrative scene description (not keyword list) constructed from 6 spec sections, spatial zone instructions ("top third..., middle band..., bottom section..."), explicit hex codes for severity colors, max 15-20 distinct text labels, business-oriented framing ("risk assessment summary"), avoid attack terminology. Move gemini_config from schema to agent prompt per architect review M-04.
+
+- [X] T009 [US2] Add Gemini API Integration section to `agents/threat-infographic.md` — check `GEMINI_API_KEY` env var, call `POST .../models/{model_id}:generateContent` with `responseModalities: ["TEXT", "IMAGE"]`, `aspectRatio: "16:9"`, `imageSize: "2K"`, default model `gemini-3-pro-image-preview` (configurable), parse response for `inline_data` with image MIME type, decode base64, save as `threat-infographic.jpg`.
+
+- [X] T010 [US2] Add Error Handling & Graceful Degradation section to `agents/threat-infographic.md` — handle 6 conditions: (1) missing GEMINI_API_KEY → log info, save spec, continue; (2) API rate limit 429 → log warning, save spec, no retry; (3) API timeout → log error, save spec; (4) content policy rejection → log reason, save spec; (5) missing Section 6 → compute counts from individual findings; (6) empty threat model → produce zero-count spec with note.
+
+**Checkpoint**: Agent handles Gemini API integration with graceful fallback. US-2 independently testable.
+
+---
+
+## Phase 4: User Story 4 — Orchestrator Integration as Phase 6 (Priority: P0)
+
+**Goal**: Phase 6 (Infographic) runs automatically after Phase 5 (Report), invoked in fresh context with only `threats.md`, with pipeline isolation guaranteeing Phases 1–5 are never blocked.
+
+**Independent Test**: Run full orchestrator pipeline and verify `threat-infographic-spec.md` appears in output directory alongside existing Phase 4 and Phase 5 outputs.
+
+### Implementation for User Story 4
+
+- [X] T011 [P] [US4] Update orchestrator YAML frontmatter in `agents/orchestrator.md` — add `infographic: agents/threat-infographic.md` to `references.agents`, add `infographic: schemas/infographic.yaml` to `references.schemas`, update description to mention Phase 6.
+
+- [X] T012 [P] [US4] Update orchestrator pipeline description in `agents/orchestrator.md` — add Phase 6 to the 5-phase list (line ~48), update output format specification (line ~80) to include `threat-infographic-spec.md` and `threat-infographic.jpg` as conditional Phase 6 outputs.
+
+- [X] T013 [US4] Add Phase 6 dispatch section to `agents/orchestrator.md` — insert after Phase 5 section (~line 1767), following identical structure: check opt-out, fresh-context invocation with only `threats.md` path, `<infographic-input>` context isolation boundary tags, output placement in same directory, completion criteria. Include explicit pipeline isolation statement.
+
+- [X] T014 [US4] Add Phase 6 opt-out configuration to `agents/orchestrator.md` — `--skip-infographic` flag (standardized to match `--skip-report` per architect review M-02) or `TACHI_SKIP_INFOGRAPHIC=true` env var or `infographic: false` config. Document skip behavior: no spec, no image, no warning, Phases 1–5 unchanged.
+
+- [X] T015 [US4] Add Phase 6 output validation checks to `agents/orchestrator.md` — insert after Phase 5 validation section (~line 1204): `threat-infographic-spec.md` exists, contains 6 sections, risk counts match `threats.md` Section 6, conditional image check if GEMINI_API_KEY set.
+
+**Checkpoint**: Full pipeline (Phases 1–6) operational. US-4 independently testable. US-3 (optionality) validated through opt-out config (T014) and error handling (T010).
+
+---
+
+## Phase 5: Validation & Polish
+
+**Purpose**: End-to-end validation against sample data, sample output creation, and cross-cutting quality checks.
+
+- [X] T016 [P] Create sample infographic specification output at `examples/mermaid-agentic-app/threat-infographic-spec.md` — run infographic agent against `examples/mermaid-agentic-app/threats.md` (19 findings: 3 Critical, 9 High, 7 Medium) and save the produced specification as the canonical sample output for validation.
+
+- [X] T017 Validate data accuracy of sample output — verify risk distribution counts (Critical=3, High=9, Medium=7, Low=0, Total=19), coverage heat map component names match `threats.md` exactly, top findings selected from Critical/High, CVSS hex codes correct.
+
+- [X] T018 Run quickstart.md validation at `specs/018-threat-infographic-agent/quickstart.md` — verify all documented commands and configuration options are consistent with the implemented agent and orchestrator changes.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **US-1 (Phase 2)**: Depends on Phase 1 (schema must exist before agent references it)
+- **US-2 (Phase 3)**: Depends on Phase 2 (Gemini sections extend the agent created in US-1)
+- **US-4 (Phase 4)**: Depends on Phase 2 (orchestrator references the agent file from US-1). Can run in parallel with Phase 3.
+- **Validation (Phase 5)**: Depends on Phases 2, 3, and 4 (all implementation complete)
+
+### User Story Dependencies
+
+- **US-1 (Spec Generation)**: Foundation — no story dependencies. MVP deliverable.
+- **US-2 (Gemini API)**: Depends on US-1 (extends the same agent file with API sections)
+- **US-3 (Optionality)**: No separate implementation — validated through US-2 error handling (T010) + US-4 opt-out config (T014)
+- **US-4 (Orchestrator)**: Depends on US-1 (agent must exist to be dispatched). Independent of US-2.
+
+### Within Each User Story
+
+- Schema before agent prompt
+- Agent sections in logical order (mission → input → methodology → format → quality)
+- Gemini prompt construction before API integration before error handling
+- Orchestrator frontmatter and description before dispatch section before opt-out before validation
+
+### Parallel Opportunities
+
+- T011 and T012 can run in parallel (different sections of orchestrator, no overlap)
+- Phase 3 (US-2) and Phase 4 (US-4) can run in parallel after Phase 2 completes
+- T016 can run in parallel with T017/T018 if sample output is pre-generated
+
+---
+
+## Parallel Example: Phase 4 (Orchestrator Integration)
+
+```
+# These tasks modify different sections of orchestrator.md — can run in parallel:
+Wave 1 (parallel):
+  T011: Update orchestrator YAML frontmatter
+  T012: Update orchestrator pipeline description
+
+Wave 2 (sequential, depends on Wave 1):
+  T013: Add Phase 6 dispatch section
+
+Wave 3 (sequential, depends on Wave 2):
+  T014: Add Phase 6 opt-out configuration
+  T015: Add Phase 6 output validation checks
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Schema (T001)
+2. Complete Phase 2: US-1 Agent Prompt (T002–T007)
+3. **STOP and VALIDATE**: Run agent against sample `threats.md`, verify 6 sections with correct data
+4. The infographic specification alone delivers value — designers can render manually
+
+### Incremental Delivery
+
+1. Schema + US-1 → Specification generation works → MVP!
+2. Add US-2 → Gemini image generation works (when API available)
+3. Add US-4 → Pipeline integration works → Full feature!
+4. Validation → Sample output verified → Ready for delivery
+
+### Parallel Agent Strategy
+
+With multiple agents:
+
+1. Agent A completes Phase 1 (schema)
+2. Agent A works on Phase 2 (US-1: agent prompt)
+3. Once Phase 2 is done:
+   - Agent A: Phase 3 (US-2: Gemini sections in agent prompt)
+   - Agent B: Phase 4 (US-4: orchestrator integration)
+4. Both complete → Phase 5 (validation)
+
+---
+
+## Notes
+
+- All deliverables are markdown/YAML files — no application code
+- Total: 18 tasks across 5 phases
+- 3 files created (agent, schema, sample output), 1 file modified (orchestrator)
+- US-3 (optionality) has no dedicated tasks — it is validated through US-2 and US-4
+- Architect review concerns (M-01 through M-04) are addressed in specific tasks: M-01→T002, M-02→T014, M-03→T001, M-04→T008


### PR DESCRIPTION
## Summary
- Adds threat infographic agent that transforms structured `threats.md` findings into a 6-section visual risk specification (`threat-infographic-spec.md`) and optional Gemini-generated image (`threat-infographic.jpg`)
- Integrates as Phase 6 in the orchestrator pipeline with full opt-out support (`--skip-infographic`, `TACHI_SKIP_INFOGRAPHIC=true`)
- Includes output schema, sample specification output, PRD, spec, plan, and all 18 tasks completed

## Key Deliverables
- `agents/threat-infographic.md` — Agent prompt with data extraction, spec format, Gemini API integration, and graceful degradation
- `schemas/infographic.yaml` — Output schema with 6 required sections and CVSS color palette
- `agents/orchestrator.md` — Phase 6 dispatch, opt-out config, and output validation
- `examples/mermaid-agentic-app/threat-infographic-spec.md` — Sample output (19 findings: 3 Critical, 9 High, 7 Medium)
- `specs/018-threat-infographic-agent/` — Full feature artifacts (spec, plan, tasks, research)

## Test Plan
- [ ] Run infographic agent against `examples/mermaid-agentic-app/threats.md` — verify 6-section spec output
- [ ] Verify risk distribution counts match threats.md Section 6 (3C/9H/7M/0L)
- [ ] Test with `GEMINI_API_KEY` set — verify image generation
- [ ] Test without `GEMINI_API_KEY` — verify spec-only output with info message
- [ ] Test `--skip-infographic` flag — verify Phase 6 fully skipped
- [ ] Verify orchestrator Phases 1-5 unaffected

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)