### PR TITLE
docs: add baseball card hero image to What is tachi section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ tachi is a threat modeling sidecar that you add to any project. It dispatches 14
 
 tachi is built with the [Agentic Oriented Development Kit (AOD Kit)](https://github.com/davidmatousek/agentic-oriented-development-kit), a governance framework for AI agent-assisted development.
 
+![Threat Baseball Card](examples/agentic-app/sample-report/threat-baseball-card.jpg)
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Move the baseball card infographic into the "What is tachi?" section so visitors see sample output above the fold

## Test plan
- [ ] Verify image renders between the bullet list and Quick Start on the GitHub repo page

🤖 Generated with [Claude Code](https://claude.com/claude-code)