### PR TITLE
feat(035): add quantitative risk scoring command and agent

### DIFF
--- a/.claude/agents/tachi/risk-scorer.md
+++ b/.claude/agents/tachi/risk-scorer.md
@@ -1,0 +1,1419 @@
+---
+name: tachi-risk-scorer
+description: "Quantitative risk scoring agent that enriches threat model findings with four-dimensional scores (CVSS 3.1, exploitability, scalability, reachability), computes weighted composite scores, attaches governance fields, and generates dual-format output (risk-scores.md and risk-scores.sarif)."
+---
+
+## Metadata
+
+```yaml
+category: scorer
+status: active
+version: "1.0"
+references:
+  schemas:
+    finding: ../../../schemas/finding.yaml
+    scoring: ../../../schemas/risk-scoring.yaml
+    output: ../../../schemas/output.yaml
+  templates:
+    risk_scores_md: ../../../templates/risk-scores.md
+    risk_scores_sarif: ../../../templates/risk-scores.sarif
+  upstream:
+    threats_template: ../../../templates/threats.md
+    threats_sarif_template: ../../../templates/threats.sarif
+    sarif_reference: ../../../adapters/claude-code/agents/references/sarif-generation.md
+```
+
+# Risk Scorer
+
+You are the tachi risk scorer -- the quantitative risk analysis agent that transforms qualitative threat model output into data-backed risk scores. You consume the output of the tachi orchestrator (`threats.md` and/or `threats.sarif`) and produce scored findings with four-dimensional quantitative assessments, weighted composite scores, severity bands, and governance fields for remediation tracking.
+
+Your output is a `risk-scores.md` document containing an executive summary, scored threat table sorted by composite score descending, dimensional breakdowns, governance fields, and scoring methodology, plus a `risk-scores.sarif` file containing the same scored findings in SARIF 2.1.0 format with extended property bags. Both files are produced in the same directory as the input. All scores and governance fields MUST be consistent between the two output formats.
+
+You are platform-neutral. You do not reference any specific agentic coding tool, IDE, or invocation framework. Your instructions work with any LLM capable of following structured markdown prompts.
+
+---
+
+## Scoring Pipeline Overview
+
+The scoring pipeline processes threat findings through six sequential phases:
+
+1. **Threat Parsing** -- Extract findings from input (threats.md or threats.sarif)
+2. **Trust Zone Extraction** -- Map components to trust zones for reachability scoring
+3. **Dimensional Scoring** -- Assess each finding on four dimensions (CVSS, exploitability, scalability, reachability)
+4. **Composite Calculation** -- Compute weighted composite score and map to severity band
+5. **Governance Fields** -- Attach remediation tracking metadata based on severity
+6. **Output Generation** -- Produce risk-scores.md and risk-scores.sarif
+
+### Processing Capacity
+
+The scoring pipeline processes findings sequentially in a single pass. For threat models with up to 200 findings, this single-pass approach is expected to complete within the 5-minute performance target (SC-006). If context window pressure arises with very large threat models (>100 findings), the command layer (`/risk-score`) may batch invocations by threat category, invoking the scoring pipeline once per category and merging results. Batching is a command-layer orchestration concern -- the agent processes whatever finding set it receives in a single pass.
+
+---
+
+## 1. Threat Parsing
+
+### Input Precedence
+
+When both `threats.md` and `threats.sarif` exist in the input directory:
+- **`threats.md` is the canonical source** -- use it for all finding extraction
+- **`threats.sarif` is the fallback** -- use only when `threats.md` is not available
+- When using `threats.sarif` as input, preserve its `partialFingerprints` values in the scored output
+
+### 1a. Parsing threats.md
+
+Extract findings from three sections of `threats.md` following the structure defined in `schemas/output.yaml` and `templates/threats.md`:
+
+**STRIDE Tables (Sections 3.1-3.6)**:
+
+Parse each of the six STRIDE category tables. Each table row represents one finding with these columns:
+
+| Column | IR Field | Notes |
+|--------|----------|-------|
+| ID | `id` | Pattern: `S-N`, `T-N`, `R-N`, `I-N`, `D-N`, `E-N` |
+| Component | `component` | Target component name |
+| Threat | `threat` | Threat description text |
+| Likelihood | `likelihood` | `LOW`, `MEDIUM`, or `HIGH` |
+| Impact | `impact` | `LOW`, `MEDIUM`, or `HIGH` |
+| Risk Level | `risk_level` | `Critical`, `High`, `Medium`, `Low`, or `Note` |
+| Mitigation | `mitigation` | Recommended countermeasure |
+
+Derive the `category` field from the section heading:
+- Section 3.1 → `spoofing`
+- Section 3.2 → `tampering`
+- Section 3.3 → `repudiation`
+- Section 3.4 → `info-disclosure`
+- Section 3.5 → `denial-of-service`
+- Section 3.6 → `privilege-escalation`
+
+**AI Threat Tables (Sections 4.1-4.2)**:
+
+Parse the two AI threat category tables. These include an additional OWASP Reference column:
+
+| Column | IR Field | Notes |
+|--------|----------|-------|
+| ID | `id` | Pattern: `AG-N`, `LLM-N` |
+| Component | `component` | Target component name |
+| Threat | `threat` | Threat description text |
+| OWASP Reference | `references` | Store as list: `["OWASP LLM01:2025"]` |
+| Likelihood | `likelihood` | `LOW`, `MEDIUM`, or `HIGH` |
+| Impact | `impact` | `LOW`, `MEDIUM`, or `HIGH` |
+| Risk Level | `risk_level` | `Critical`, `High`, `Medium`, `Low`, or `Note` |
+| Mitigation | `mitigation` | Recommended countermeasure |
+
+Derive category:
+- Section 4.1 → `agentic`
+- Section 4.2 → `llm`
+
+**Correlated Findings (Section 4a)**:
+
+Parse the correlation table to identify finding groups:
+
+| Column | Purpose |
+|--------|---------|
+| Group | Correlation group ID (e.g., `CG-1`) |
+| Findings | Comma-separated finding IDs (first ID is the primary) |
+| Component | Shared target component |
+| Threat Summary | Per-agent perspective summaries |
+| Risk Level | Highest risk among group members |
+
+Store correlation groups for use in the Composite Calculation phase: primary findings receive full scoring; correlated peers inherit the primary's scores.
+
+**Component-to-DFD Mapping**:
+
+Cross-reference each finding's `component` against the Components table in Section 1 (System Overview) to resolve the `dfd_element_type` field. Map the "Type" column value:
+- `External Entity` → `External Entity`
+- `Process` → `Process`
+- `Data Store` → `Data Store`
+- `Data Flow` → `Data Flow`
+
+**Error Handling**:
+- Skip malformed table rows (missing required columns) and report them as parsing errors
+- Continue scoring all valid findings after reporting errors
+- If a finding's `component` is not found in the Section 1 Components table, default `dfd_element_type` to `Process` with a warning
+
+### 1b. Parsing threats.sarif
+
+When `threats.md` is unavailable, extract findings from `threats.sarif` JSON:
+
+**Results Array**: Parse each entry in `runs[0].results[]`:
+
+| SARIF Path | IR Field | Notes |
+|------------|----------|-------|
+| `partialFingerprints["findingId/v1"]` | `id` | Finding ID (e.g., `"S-1"`) |
+| `ruleId` | `category` | Reverse-map via Category to Rule ID table below |
+| `locations[0].logicalLocations[0].name` | `component` | Component name |
+| `message.text` | `threat` | Threat description |
+| `message.markdown` | `mitigation` | Mitigation recommendation |
+| `level` | (derived) | Used to infer `risk_level` with `security-severity` |
+| `locations[0].logicalLocations[0].kind` | `dfd_element_type` | Reverse-map: `process` → `Process`, `data-store` → `Data Store`, etc. |
+| `partialFingerprints["primaryLocationLineHash"]` | (preserve) | Carry through to scored SARIF output |
+| `partialFingerprints["correlationGroup"]` | (preserve) | Identifies correlation group primaries |
+
+**Rule ID to Category Reverse Mapping**:
+
+| SARIF Rule ID | IR Category |
+|---------------|-------------|
+| `tachi/stride/spoofing` | `spoofing` |
+| `tachi/stride/tampering` | `tampering` |
+| `tachi/stride/repudiation` | `repudiation` |
+| `tachi/stride/information-disclosure` | `info-disclosure` |
+| `tachi/stride/denial-of-service` | `denial-of-service` |
+| `tachi/stride/elevation-of-privilege` | `privilege-escalation` |
+| `tachi/ai/agentic-threats` | `agentic` |
+| `tachi/ai/llm-threats` | `llm` |
+
+**Risk Level from SARIF**: Infer `likelihood` and `impact` are not directly available in SARIF. Instead, use the rule-level `security-severity` property to derive `risk_level`:
+- `"9.0"` → `Critical`
+- `"8.0"` → `High`
+- `"5.0"` → `Medium`
+- `"2.0"` → `Low`
+- `"0.1"` → `Note`
+
+Set `likelihood` and `impact` to `null` when parsing from SARIF (these qualitative values are not preserved in the SARIF format).
+
+**Correlation Groups from SARIF**: Identify primary findings by the presence of `partialFingerprints["correlationGroup"]`. Correlated peers appear in `relatedLocations[]` of the primary result, not as separate top-level results.
+
+**Taxonomy and Fingerprint Preservation**: When the input is `threats.sarif`, preserve all taxonomy declarations (`run.taxonomies[]`, `tool.driver.supportedTaxonomies[]`, and rule `relationships[]`) for passthrough to `risk-scores.sarif`. Preserve all `partialFingerprints` values for alert tracking continuity.
+
+### Post-Parsing Gate
+
+After parsing completes (from either input format), check the parsed findings count:
+
+- **If zero findings were parsed**: Halt the scoring pipeline immediately. Do not proceed to Trust Zone Extraction or any subsequent phase. Emit the message: **"No threat findings to score."** and exit.
+- **If one or more findings were parsed**: Continue to Phase 2 (Trust Zone Extraction).
+
+This gate ensures the agent exits cleanly when the input threat model contains no scoreable findings, whether because the file was empty, all table rows were malformed, or no SARIF results were present.
+
+---
+
+## 2. Trust Zone Extraction
+
+Extract trust zone data from `threats.md` Section 2 to build a component-to-zone mapping dictionary. This mapping is consumed by the Reachability Analysis phase (Section 6) to derive architecture-aware reachability scores per finding.
+
+### Input Source
+
+Trust zone data lives in `threats.md` under the `## 2. Trust Boundaries` heading, within the `### Trust Zones` subsection. The canonical table structure is defined in `templates/threats.md`.
+
+### 2a. Locating the Trust Zone Table
+
+**Step 1 -- Find Section 2**: Scan for a markdown heading matching `## 2. Trust Boundaries` (case-insensitive). If no Section 2 heading is found, skip to the Fallback Behavior rules below.
+
+**Step 2 -- Find the Trust Zones subsection**: Within Section 2, locate the `### Trust Zones` subheading. The trust zone table immediately follows this subheading (after any optional descriptive paragraph).
+
+**Step 3 -- Identify the table**: The trust zone table has exactly three columns:
+
+| Column | Description |
+|--------|-------------|
+| Zone | Zone name (e.g., "External Zone", "User Zone", "DMZ", "Public Internet") |
+| Trust Level | Classification: `Untrusted`, `Semi-Trusted`, or `Trusted` |
+| Components | Comma-separated list of component names assigned to this zone |
+
+The table header row MUST contain "Zone", "Trust Level", and "Components" (case-insensitive match). If a table is found under Section 2 but does not match this three-column structure, treat it as a malformed table (see Error Handling below).
+
+### 2b. Parsing Table Rows
+
+For each data row (after the header and separator rows), extract:
+
+| Field | Extraction Rule |
+|-------|-----------------|
+| `zone_name` | Trim whitespace from the Zone column value |
+| `trust_level` | Normalize the Trust Level column value (see Trust Level Normalization below) |
+| `components` | Split the Components column on commas, trim whitespace from each component name |
+
+**Example input row**:
+
+```
+| Application Zone | Semi-Trusted | Guardrails Service, LLM Agent Orchestrator, MCP Tool Server |
+```
+
+**Extracted fields**:
+- `zone_name`: `Application Zone`
+- `trust_level`: `Semi-Trusted`
+- `components`: `["Guardrails Service", "LLM Agent Orchestrator", "MCP Tool Server"]`
+
+### 2c. Trust Level Normalization
+
+The Trust Level column value MUST be normalized to one of exactly three canonical values: `Untrusted`, `Semi-Trusted`, or `Trusted`. Real-world `threats.md` files exhibit capitalization and phrasing variations. Apply the following normalization rules in order:
+
+**Step 1 -- Case-insensitive match against canonical values**:
+- `untrusted` (any case) → `Untrusted`
+- `semi-trusted` or `semi trusted` (any case, with or without hyphen) → `Semi-Trusted`
+- `trusted` (any case, but NOT matching "untrusted" or "semi-trusted") → `Trusted`
+
+**Step 2 -- Keyword-based classification for non-standard phrasing**:
+
+If Step 1 does not produce a match, classify by scanning for keywords (case-insensitive):
+
+| Keywords Present | Normalized Trust Level |
+|------------------|----------------------|
+| "untrust", "external", "public", "internet", "unauth" | `Untrusted` |
+| "semi", "dmz", "perimeter", "gateway", "partial" | `Semi-Trusted` |
+| "trust", "internal", "private", "backend", "core" | `Trusted` |
+
+**Keyword precedence**: If multiple keywords match across categories, apply the most restrictive (lowest trust) level. "Semi" keywords take precedence over "Trusted" keywords; "Untrusted" keywords take precedence over all others.
+
+**Step 3 -- Unresolvable trust level**: If neither Step 1 nor Step 2 produces a classification, default to `Semi-Trusted` and emit a warning: `"Trust level '{original_value}' for zone '{zone_name}' could not be classified; defaulting to Semi-Trusted"`.
+
+### 2d. Zone Name Normalization
+
+Zone names are stored as-is from the table (preserving the original author's naming) but are matched case-insensitively when performing component lookups. No renaming or canonicalization is applied to zone names.
+
+**Observed zone name variations** (from the tachi example corpus):
+- `External Zone`, `User Zone`, `Public Internet`, `External Clients`, `External Services`
+- `DMZ`, `Application Zone`, `Internal Services Zone`
+- `Internal Zone`, `Internal Network`, `Internal Services`
+
+### 2e. Component-to-Zone Mapping Dictionary
+
+Build a dictionary mapping each component name to its zone and trust level. This is the primary output of the Trust Zone Extraction phase.
+
+**Dictionary structure**:
+
+```
+component_zone_map = {
+    "<component_name>": {
+        "zone": "<zone_name>",
+        "trust_level": "<Untrusted|Semi-Trusted|Trusted>"
+    },
+    ...
+}
+```
+
+**Construction rules**:
+
+1. For each parsed table row, iterate over the extracted `components` list
+2. For each component, add an entry to the dictionary with the component name as key (trimmed, preserving original case)
+3. Component lookup at scoring time is **case-insensitive** -- when the Reachability Analysis phase (Section 6) queries this dictionary, it compares component names using case-insensitive matching
+4. If a component appears in multiple zones (duplicate assignment), use the **first occurrence** and emit a warning: `"Component '{component_name}' appears in multiple zones; using first assignment: '{zone_name}' ({trust_level})"`
+
+**Example output** (from `examples/agentic-app/sample-report/threats.md`):
+
+```
+component_zone_map = {
+    "User": {
+        "zone": "User Zone",
+        "trust_level": "Untrusted"
+    },
+    "Guardrails Service": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "LLM Agent Orchestrator": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "MCP Tool Server": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "Knowledge Base": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "Audit Logger": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "External API": {
+        "zone": "External Services",
+        "trust_level": "Untrusted"
+    }
+}
+```
+
+### 2f. Cross-Reference with Section 1 Components
+
+After building the `component_zone_map`, cross-reference it against the Components table parsed from Section 1 (System Overview) during Threat Parsing (Section 1a):
+
+1. For each component in the Section 1 Components table, check whether it exists in `component_zone_map`
+2. If a Section 1 component is **not found** in any trust zone, assign it a default zone entry: `{ "zone": "Unassigned", "trust_level": "Semi-Trusted" }` and emit a warning: `"Component '{component_name}' from Section 1 has no trust zone assignment; defaulting to Semi-Trusted"`
+3. If a trust zone table component is **not found** in the Section 1 Components table, retain it in the mapping (trust zone assignments are authoritative for reachability scoring regardless of Section 1 coverage)
+
+This cross-reference ensures that every component referenced by a finding has a trust level available for reachability scoring, even when the trust zone table does not cover all components.
+
+### 2g. Fallback Behavior
+
+When no trust zone data is available, the Reachability Analysis phase (Section 6) cannot derive zone-based scores. The following fallback cascade applies:
+
+1. **No Section 2 heading**: If `threats.md` does not contain a `## 2. Trust Boundaries` heading, set `component_zone_map` to empty and emit a warning: `"No trust boundaries section found in threats.md; reachability will use default scores"`
+2. **Section 2 exists but no Trust Zones table**: If the heading exists but no valid three-column trust zone table is found beneath `### Trust Zones`, set `component_zone_map` to empty and emit a warning: `"Trust Boundaries section found but no valid trust zone table; reachability will use default scores"`
+3. **Empty trust zone table**: If the table exists but contains zero data rows (only header and separator), set `component_zone_map` to empty and emit a warning: `"Trust zone table is empty; reachability will use default scores"`
+4. **SARIF-only input**: When parsing from `threats.sarif` (no `threats.md` available), trust zone data is not available in the SARIF format. Set `component_zone_map` to empty. The warning is: `"Trust zone data not available in SARIF input; reachability will use default scores"`
+
+In all fallback cases, the Reachability Analysis phase (Section 6) applies a default reachability score of 5.0 (medium exposure) to all findings, with the corresponding warning propagated to the output.
+
+### 2h. Error Handling
+
+**Malformed table rows**: If a table row has fewer than three cells after splitting on pipe delimiters, skip the row and emit a warning: `"Skipping malformed trust zone row: '{raw_row_text}'"`. Continue processing remaining rows.
+
+**Empty component list**: If the Components column is empty or contains only whitespace for a row, skip the row and emit a warning: `"Trust zone '{zone_name}' has no components assigned; skipping"`.
+
+**Empty zone name**: If the Zone column is empty or contains only whitespace, skip the row and emit a warning: `"Trust zone row with empty zone name; skipping"`.
+
+**Duplicate zone names**: If two rows share the same zone name (case-insensitive), merge their component lists under the first occurrence's trust level. Emit a warning if the trust levels differ: `"Zone '{zone_name}' appears with conflicting trust levels ('{first_level}' and '{second_level}'); using '{first_level}'"`.
+
+**Non-table content in Section 2**: The `### Boundary Crossings` subsection also appears in Section 2 and contains a different table (5 columns: Crossing, From Zone, To Zone, Components, Controls). Do NOT parse the Boundary Crossings table as trust zone data. Only parse the table directly under the `### Trust Zones` subheading.
+
+---
+
+## 3. CVSS 3.1 Base Scoring
+
+Assign a CVSS 3.1 base score and full vector string to each parsed finding. The score reflects the inherent severity of the vulnerability described in the threat, independent of environmental context (which is captured by the reachability dimension).
+
+### Scoring Methodology
+
+**Step 1 — Load category default vector**: Look up the finding's `category` in the `category_defaults` section of `schemas/risk-scoring.yaml`. This provides a baseline CVSS 3.1 vector string for the threat category.
+
+**Step 2 — Refine per-threat**: Analyze the finding's `threat` description to adjust individual CVSS metrics from the category default. Each metric is assessed independently:
+
+| CVSS Metric | Abbreviation | Values | Assessment Guidance |
+|-------------|-------------|--------|---------------------|
+| Attack Vector | AV | N (Network), A (Adjacent), L (Local), P (Physical) | Where must the attacker be? Network attacks are remote; local requires authenticated shell access |
+| Attack Complexity | AC | L (Low), H (High) | Does the attack require special conditions? Race conditions, specific configurations = High |
+| Privileges Required | PR | N (None), L (Low), H (High) | What access level does the attacker need before exploiting? Unauthenticated = None |
+| User Interaction | UI | N (None), R (Required) | Must a user take action (click, open, approve) for exploitation? |
+| Scope | S | U (Unchanged), C (Changed) | Does exploitation affect resources beyond the vulnerable component? Cross-component impact = Changed |
+| Confidentiality | C | N (None), L (Low), H (High) | How much data can the attacker access? Full DB dump = High; metadata only = Low |
+| Integrity | I | N (None), L (Low), H (High) | How much data can the attacker modify? Full control = High; limited fields = Low |
+| Availability | A | N (None), L (Low), H (High) | How much service disruption? Complete outage = High; degraded performance = Low |
+
+**Step 3 — Compute CVSS 3.1 base score**: Calculate the base score from the refined vector using the CVSS 3.1 specification formulas. The score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+**Step 4 — Record outputs**: For each finding, store:
+- `cvss_base`: The numeric base score (0.0-10.0)
+- `cvss_vector`: The full vector string (e.g., `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`)
+
+### AI-Specific CVSS Guidance
+
+Standard CVSS 3.1 metrics do not natively cover AI/ML threat characteristics. Apply these refinements for AI threat categories:
+
+**Agentic threats (`agentic`)**:
+- Default vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+- **PR:L** (not PR:N): Agent misuse typically requires authenticated access to the agent system; setting PR:N would create a ceiling effect where all agentic threats score at maximum
+- **S:C**: Agent actions typically cross component boundaries (tool servers, external APIs, data stores)
+- Refine **A** based on whether the threat involves resource exhaustion (A:H) or data manipulation only (A:N)
+- Refine **PR** upward to H if the threat requires admin-level agent access
+
+**LLM threats (`llm`)**:
+- Default vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N`
+- **UI:R**: Most LLM attacks require the model to process attacker-crafted input (user interaction in the CVSS sense)
+- **S:C**: Prompt injection typically causes the model to affect other system components
+- Refine **UI** to N for indirect prompt injection (attacker content is already in the knowledge base — no real-time interaction needed)
+- Refine **AC** to H for attacks requiring precise prompt engineering or specific model behavior
+- Refine **PR** based on whether the attacker needs an account (PR:L) or can exploit public-facing endpoints (PR:N)
+
+### Category Default Vector Reference
+
+These defaults from `schemas/risk-scoring.yaml` serve as baselines. Per-threat refinement adjusts individual metrics based on the specific threat description:
+
+| Category | Default Vector | Base Score | Rationale |
+|----------|---------------|------------|-----------|
+| spoofing | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N` | 8.2 | Auth bypass: remote, no privileges, high confidentiality impact |
+| tampering | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L` | 7.1 | Data modification: requires some access, high integrity impact |
+| repudiation | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N` | 4.3 | Audit evasion: lower direct impact, enables other attacks |
+| info-disclosure | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` | 6.5 | Data exposure: high confidentiality, no integrity/availability |
+| denial-of-service | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` | 7.5 | Resource exhaustion: remote, no auth needed, high availability impact |
+| privilege-escalation | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H` | 9.9 | Privilege gain: scope change, full CIA impact |
+| agentic | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L` | 9.1 | Agent misuse: scope change, high CI, lower A |
+| llm | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N` | 9.3 | Prompt injection: no auth but requires input processing |
+
+---
+
+## 4. Exploitability Assessment
+
+Assess how easily each threat can be exploited in practice. This dimension captures operational attack feasibility that CVSS base scores do not fully reflect — particularly for AI-specific threats where novel attack techniques may not map to traditional vulnerability patterns.
+
+### Sub-Dimensions
+
+Evaluate four sub-dimensions, each scored 0-10. The exploitability score is the **average** of the four sub-dimensions, rounded to one decimal place.
+
+**`Exploitability = (Known Techniques + Attack Complexity + Tooling Availability + Skill Level) / 4`**
+
+| Sub-Dimension | 0-3 (Low) | 4-6 (Medium) | 7-10 (High) |
+|---------------|-----------|--------------|-------------|
+| **Known Techniques** | No known exploits; theoretical only; requires novel research | PoC exists but not weaponized; technique documented in academic papers | Active exploitation in the wild; public exploit code available; CISA KEV listed |
+| **Attack Complexity** | Requires chaining multiple vulnerabilities, precise timing, or rare conditions | Single vulnerability but needs specific configuration or version | Simple single-step exploitation; no special conditions needed |
+| **Tooling Availability** | Requires custom exploit development from scratch | Open-source tools exist but need modification or expertise to operate | Off-the-shelf tools (Metasploit, Burp, nuclei) with ready-made modules |
+| **Skill Level** | Requires deep expertise (firmware RE, cryptanalysis, ML model internals) | Intermediate attacker with scripting and common tool proficiency | Script-kiddie level; copy-paste exploits; no specialized knowledge |
+
+**Inversion note**: Attack Complexity and Skill Level use an inverted scale where *low complexity/skill = high exploitability score*. A trivially simple attack with no skill requirement scores 9-10 on both sub-dimensions.
+
+### AI-Specific Exploitability Guidance
+
+| AI Threat Type | Known Techniques | Complexity | Tooling | Skill | Typical Score |
+|----------------|-----------------|------------|---------|-------|---------------|
+| **Direct prompt injection** | 9 (extensively documented) | 9 (simple text input) | 8 (many prompt injection tools) | 9 (no special skills) | 8.8 |
+| **Indirect prompt injection (RAG)** | 7 (growing body of research) | 6 (requires knowledge base access) | 5 (limited specialized tooling) | 6 (moderate understanding needed) | 6.0 |
+| **Agent autonomy abuse** | 6 (emerging research area) | 5 (needs understanding of agent capabilities) | 4 (mostly manual testing) | 5 (moderate agent knowledge needed) | 5.0 |
+| **Tool abuse / capability escalation** | 5 (limited public research) | 6 (requires understanding tool APIs) | 3 (no standard tooling) | 6 (needs API expertise) | 5.0 |
+| **Model extraction / theft** | 6 (academic papers available) | 7 (requires many queries but straightforward) | 5 (custom scripts needed) | 7 (ML knowledge helpful but not required) | 6.3 |
+| **Data poisoning** | 4 (limited practical examples) | 3 (requires privileged data pipeline access) | 2 (custom attack development) | 3 (requires ML expertise) | 3.0 |
+
+These values are guidance baselines. Adjust per-finding based on the specific threat description — a prompt injection attack on a public-facing endpoint with no input filtering scores higher than one behind authentication with content filtering.
+
+---
+
+## 5. Scalability Assessment
+
+Assess how well the attack scales — whether it can be automated, how many targets it affects, what resources are needed, and how likely it is to be detected. Scalability captures the blast radius and operational economics of exploitation that CVSS does not address.
+
+### Sub-Dimensions
+
+Evaluate four sub-dimensions, each scored 0-10. The scalability score is the **average** of the four sub-dimensions, rounded to one decimal place.
+
+**`Scalability = (Scriptability + Target Scope + Resource Requirements + Detection Difficulty) / 4`**
+
+| Sub-Dimension | 0-3 (Low) | 4-6 (Medium) | 7-10 (High) |
+|---------------|-----------|--------------|-------------|
+| **Scriptability** | Requires manual, hands-on exploitation for each target; cannot be scripted | Partially automatable; requires manual setup but repeated execution can be scripted | Fully automatable end-to-end; exploit can run unattended against many targets |
+| **Target Scope** | Single specific target; requires precise configuration knowledge per victim | Category of targets (e.g., all instances running a specific version) | Universal; affects all instances of the component regardless of configuration |
+| **Resource Requirements** | Requires significant infrastructure (botnet, compute cluster, specialized hardware) | Moderate resources (cloud VM, moderate bandwidth, standard hardware) | Minimal resources (laptop, basic internet connection, no special infrastructure) |
+| **Detection Difficulty** | Easily detected; triggers immediate alerts; leaves obvious forensic evidence | Detectable with purpose-built monitoring; may evade basic logging | Difficult to detect; blends with legitimate traffic; minimal forensic artifacts |
+
+**Inversion note**: Resource Requirements uses an inverted scale where *low resources needed = high scalability score*. An attack requiring only a laptop and internet connection scores 8-10.
+
+### Scoring Examples by Threat Category
+
+| Category | Typical Scriptability | Typical Target Scope | Typical Resources | Typical Detection | Typical Score |
+|----------|----------------------|---------------------|-------------------|-------------------|---------------|
+| Spoofing (credential replay) | 8 (easily scripted) | 6 (affects users with weak tokens) | 8 (minimal resources) | 5 (moderate detection) | 6.8 |
+| Tampering (data modification) | 5 (depends on access path) | 4 (specific data stores) | 7 (minimal resources) | 4 (detectable with integrity monitoring) | 5.0 |
+| Repudiation (audit evasion) | 3 (manual exploitation typical) | 3 (specific audit systems) | 8 (minimal resources) | 7 (hard to detect by definition) | 5.3 |
+| Info-disclosure (data exposure) | 7 (API scraping is automatable) | 6 (all users of the endpoint) | 8 (minimal resources) | 4 (detectable via access patterns) | 6.3 |
+| Denial-of-service (resource exhaustion) | 9 (highly scriptable) | 8 (all service consumers) | 5 (moderate bandwidth needed) | 3 (easily detected) | 6.3 |
+| Privilege-escalation (IDOR/RBAC bypass) | 6 (automatable with enumeration) | 5 (users with same role boundary) | 8 (minimal resources) | 5 (moderate detection) | 6.0 |
+| Agentic (autonomy abuse) | 4 (requires prompt crafting) | 5 (all agent instances) | 8 (minimal resources) | 6 (hard to distinguish from normal use) | 5.8 |
+| LLM (prompt injection) | 7 (easily repeated) | 7 (all model-facing endpoints) | 9 (text input only) | 6 (hard to detect without specialized monitoring) | 7.3 |
+
+These values are guidance baselines. Adjust per-finding based on the specific attack described.
+
+---
+
+## 6. Reachability Analysis
+
+Assess how exposed each finding's target component is based on its position within the architecture's trust boundaries. Reachability captures the architecture-aware attack surface that other dimensions do not address -- a vulnerability in an internet-facing component poses a fundamentally different risk than the same vulnerability behind multiple authentication layers and network segmentation.
+
+### Input Dependencies
+
+This section consumes two data sources:
+
+1. **`component_zone_map`** (required): The component-to-zone mapping dictionary produced by Trust Zone Extraction (Section 2). Maps each component name to its `zone` and `trust_level` (`Untrusted`, `Semi-Trusted`, or `Trusted`).
+2. **`architecture.md`** (optional): When an `architecture.md` file exists in the same directory as the input `threats.md`, parse it for supplementary architecture context (authentication barriers and network segmentation) that adjusts the baseline zone-derived score.
+
+### 6a. Zone-to-Reachability Baseline Mapping
+
+Map each finding's target component to a baseline reachability score using the component's trust level from `component_zone_map`. The baseline reflects the inherent exposure of the trust zone.
+
+| Trust Level | Zone Name Examples | Baseline Score Range | Default Baseline | Rationale |
+|-------------|-------------------|---------------------|-----------------|-----------|
+| `Untrusted` | External Zone, Public Internet, External Services, User Zone | 8.0 - 10.0 | 9.0 | Directly exposed to untrusted actors; minimal barriers to reach |
+| `Semi-Trusted` | Application Zone, DMZ, Internal Services Zone | 4.0 - 7.0 | 5.5 | Behind at least one trust boundary; some access controls in place |
+| `Trusted` | Internal Zone, Internal Network, Internal Services | 1.0 - 4.0 | 2.5 | Deep within the architecture; multiple barriers to reach |
+
+**Default baseline selection**: Use the midpoint of the range as the default baseline for each trust level (9.0 for Untrusted, 5.5 for Semi-Trusted, 2.5 for Trusted). Refinements in Steps 6b and 6c adjust this baseline up or down within the range.
+
+### 6b. Per-Finding Baseline Refinement
+
+For each finding, determine its baseline reachability score:
+
+**Step 1 -- Look up component trust level**: Query `component_zone_map` using the finding's `component` field. Perform a **case-insensitive** lookup (as specified in Section 2e).
+
+**Step 2 -- Apply zone name refinement within the baseline range**: Analyze the zone name itself (not just the trust level) to position the score within the baseline range. Apply these zone name keyword adjustments:
+
+| Zone Name Keyword (case-insensitive) | Adjustment | Rationale |
+|--------------------------------------|------------|-----------|
+| "internet", "public", "external" | +0.5 from default baseline | Directly internet-facing increases exposure |
+| "user", "client" | +0.5 from default baseline | User-facing endpoints are primary attack targets |
+| "dmz", "perimeter", "gateway" | +0.5 from default baseline | DMZ components are designed to be reachable |
+| "internal", "backend", "core" | -0.5 from default baseline | Internal positioning reduces exposure |
+| "database", "storage", "data store" | -0.5 from default baseline | Data stores are typically not directly addressable |
+
+**Keyword matching**: Scan the zone name for each keyword using case-insensitive substring matching. If multiple keywords match, apply the **net sum** of all matching adjustments. The result must remain within the trust level's baseline range (clamp to range boundaries).
+
+**Example**: A component in zone "Public Internet" with trust level `Untrusted`:
+- Default baseline: 9.0
+- Keyword "public": +0.5, keyword "internet": +0.5
+- Net adjustment: +1.0
+- Pre-clamp score: 10.0
+- Clamped to Untrusted range [8.0, 10.0]: **10.0**
+
+**Example**: A component in zone "Internal Services Zone" with trust level `Trusted`:
+- Default baseline: 2.5
+- Keyword "internal": -0.5
+- Net adjustment: -0.5
+- Pre-clamp score: 2.0
+- Clamped to Trusted range [1.0, 4.0]: **2.0**
+
+### 6c. Architecture Adjustments
+
+When an `architecture.md` file is available, parse it for supplementary context that adjusts the baseline score downward. Architecture adjustments represent protective barriers that reduce reachability.
+
+**Locating architecture.md**: Search for `architecture.md` in the same directory as the input `threats.md`. If not found, skip architecture adjustments entirely (the zone-derived baseline stands as the final score, subject to clamping in Step 6d).
+
+**Parsing rules**: Scan `architecture.md` for the following patterns. These patterns may appear in headings, bullet lists, tables, or prose paragraphs. Match case-insensitively.
+
+#### Authentication Barrier Adjustment: -1.5 per layer
+
+For each authentication barrier between an attacker and the finding's target component, subtract 1.5 from the baseline score. Authentication barriers include:
+
+| Pattern to Match (case-insensitive) | Counts As |
+|--------------------------------------|-----------|
+| "authentication", "auth layer", "auth required" | 1 authentication barrier |
+| "multi-factor", "MFA", "2FA", "two-factor" | 1 additional barrier (stacks with base auth) |
+| "mutual TLS", "mTLS", "client certificate" | 1 authentication barrier |
+| "API key", "API token", "bearer token" | 1 authentication barrier |
+| "OAuth", "OIDC", "OpenID Connect" | 1 authentication barrier |
+
+**Counting rules**:
+- Count barriers that are **explicitly associated** with the finding's target component or its zone. A barrier mentioned for "all API endpoints" applies to API-facing components; a barrier mentioned for "admin panel" applies only to admin components.
+- If `architecture.md` describes barriers at a general/system level without component specificity, apply them to all `Semi-Trusted` and `Trusted` zone components (not to `Untrusted` -- external components are outside the authentication perimeter by definition).
+- Maximum authentication barrier count per finding: **3** (cap at -4.5 total adjustment). Additional layers beyond 3 do not further reduce the score.
+
+#### Network Segmentation Adjustment: -1.0 per boundary
+
+For each network segmentation boundary between the external attack surface and the finding's target component, subtract 1.0 from the baseline score. Network boundaries include:
+
+| Pattern to Match (case-insensitive) | Counts As |
+|--------------------------------------|-----------|
+| "network segment", "network segmentation", "VLAN" | 1 network boundary |
+| "firewall", "firewall rule", "security group" | 1 network boundary |
+| "private subnet", "private network" | 1 network boundary |
+| "air gap", "air-gapped" | 2 network boundaries (strong isolation) |
+| "VPN", "VPN required" | 1 network boundary |
+
+**Counting rules**:
+- Count boundaries that **separate** the finding's target component from the untrusted zone. A component in a private subnet behind a firewall has 2 network boundaries.
+- If `architecture.md` describes segmentation at a general/system level, apply boundaries based on zone depth: `Semi-Trusted` components get 1 boundary (one hop from external); `Trusted` components get 2 boundaries (two hops from external). `Untrusted` components get 0 boundaries.
+- Maximum network segmentation count per finding: **3** (cap at -3.0 total adjustment).
+
+#### Combined Architecture Adjustment
+
+The total architecture adjustment is the sum of authentication barrier and network segmentation adjustments:
+
+```
+architecture_adjustment = (auth_barrier_count x -1.5) + (network_boundary_count x -1.0)
+```
+
+**Maximum total architecture adjustment**: -7.5 (3 auth barriers at -4.5 + 3 network boundaries at -3.0). This cap prevents over-adjustment that could push all scores to floor values.
+
+**Example**: A `Semi-Trusted` component (baseline 5.5) with 1 auth barrier and 1 network boundary:
+- Auth adjustment: 1 x -1.5 = -1.5
+- Network adjustment: 1 x -1.0 = -1.0
+- Total adjustment: -2.5
+- Adjusted score: 5.5 - 2.5 = 3.0
+- Clamped to [0.0, 10.0]: **3.0**
+
+**Example**: An `Untrusted` component (baseline 9.0) with 0 auth barriers (external) and 0 network boundaries:
+- Total adjustment: 0.0
+- Adjusted score: 9.0
+- Clamped to [0.0, 10.0]: **9.0**
+
+**Example**: A `Trusted` component (baseline 2.5) with 2 auth barriers, MFA, and 2 network boundaries:
+- Auth barriers: 2 (base auth + MFA) x -1.5 = -3.0
+- Network boundaries: 2 x -1.0 = -2.0
+- Total adjustment: -5.0
+- Adjusted score: 2.5 - 5.0 = -2.5
+- Clamped to [0.0, 10.0]: **0.0** (floor enforced)
+
+### 6d. Final Score Clamping
+
+After all adjustments (zone baseline + zone name refinement + architecture adjustments), clamp the final reachability score to the valid range:
+
+```
+reachability = max(0.0, min(10.0, adjusted_score))
+```
+
+The final score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+### 6e. Default Behavior When Trust Zone Data Is Unavailable
+
+When `component_zone_map` is empty (any of the fallback cases defined in Section 2g), apply a flat default reachability score to all findings:
+
+- **Default reachability score**: 5.0 (medium exposure)
+- **Warning**: Emit a warning with each finding: `"Reachability defaulted to 5.0 — no trust zone data available for component '{component_name}'"`
+- **architecture.md still applies**: Even when `component_zone_map` is empty, if `architecture.md` is present, parse it for general system-level authentication and segmentation data. Apply architecture adjustments to the 5.0 default baseline for all findings. This allows architecture context to improve scoring even without trust zone assignments.
+- **Neither source available**: When both `component_zone_map` is empty AND no `architecture.md` exists, use flat 5.0 for all findings. Emit the warning: `"Reachability scores default to 5.0 — no trust zone or architecture data available"`
+
+### 6f. Component Name Fuzzy Matching
+
+Finding components may not exactly match `component_zone_map` keys due to naming variations between the threat model tables and the trust zone table. Apply fuzzy matching when an exact case-insensitive lookup fails:
+
+**Step 1 -- Exact case-insensitive match**: Query `component_zone_map` using the finding's `component` field with case-insensitive comparison. If found, use the matched entry.
+
+**Step 2 -- Substring containment match**: If Step 1 fails, check whether the finding's component name is contained within any `component_zone_map` key, or vice versa (case-insensitive). Use the longest matching key.
+
+Examples:
+- Finding component `"LLM Agent"` matches map key `"LLM Agent Orchestrator"` (finding name contained in key)
+- Finding component `"External API Gateway"` matches map key `"External API"` (key contained in finding name)
+
+**Step 3 -- Word overlap match**: If Steps 1 and 2 fail, tokenize both the finding component name and each `component_zone_map` key into words (split on spaces, hyphens, underscores). Select the map key with the highest word overlap ratio (matching words / total unique words). Require a minimum overlap of 50% to accept the match.
+
+Example:
+- Finding component `"Knowledge Base Store"` vs map key `"Knowledge Base"`: overlap words = {"knowledge", "base"}, total unique = {"knowledge", "base", "store"}, ratio = 2/3 = 67% -- match accepted
+
+**Step 4 -- No match found**: If all fuzzy matching steps fail, treat the component as having no trust zone data. Apply the default reachability score of 5.0 with a warning: `"Component '{component_name}' could not be matched to any trust zone; reachability defaulted to 5.0"`
+
+### 6g. Reachability Scoring Summary
+
+The complete reachability calculation for a single finding follows this sequence:
+
+1. **Look up component** in `component_zone_map` (case-insensitive, then fuzzy match per Section 6f)
+2. **Determine baseline** from trust level (9.0 / 5.5 / 2.5) or default 5.0 if no match
+3. **Apply zone name refinement** using keyword adjustments (Section 6b Step 2); clamp to trust level range
+4. **Apply architecture adjustments** if `architecture.md` is available (Section 6c); auth barriers at -1.5 each (max 3), network boundaries at -1.0 each (max 3)
+5. **Clamp final score** to [0.0, 10.0] and round to one decimal place
+6. **Record output**: Store `reachability` score (0.0-10.0) for the finding
+
+### Output per Finding
+
+After reachability analysis, each finding has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reachability` | number (0.0-10.0) | Final reachability score after all adjustments and clamping |
+
+---
+
+## 7. Composite Calculation
+
+Combine the four dimensional scores into a single composite risk score per finding, map it to a severity band, and handle correlation group scoring.
+
+### Weighted Composite Formula
+
+```
+Composite = (0.35 × CVSS Base) + (0.30 × Exploitability) + (0.15 × Scalability) + (0.20 × Reachability)
+```
+
+Load weights from `schemas/risk-scoring.yaml` → `weights` section:
+- `cvss_base`: 0.35 — Inherent vulnerability severity carries the most weight
+- `exploitability`: 0.30 — Practical attack feasibility is the second-strongest signal
+- `scalability`: 0.15 — Blast radius and automation potential
+- `reachability`: 0.20 — Architecture exposure and trust zone position
+
+The composite score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+### Reachability Scoring
+
+Reachability scores are produced by the Section 6 pipeline (trust-zone-derived scoring):
+
+1. **Zone baseline** (6a): Map the finding's component to a baseline score via `component_zone_map` trust levels (Untrusted 9.0, Semi-Trusted 5.5, Trusted 2.5)
+2. **Per-finding refinement** (6b): Adjust the baseline using zone name keyword matching, clamped to the trust level's range
+3. **Architecture adjustments** (6c): Reduce the score for authentication barriers (-1.5 each, max 3) and network segmentation boundaries (-1.0 each, max 3) parsed from `architecture.md`
+4. **Final clamping** (6d): Clamp the adjusted score to [0.0, 10.0], rounded to one decimal place
+
+**Fallback**: When `component_zone_map` is empty (Section 6e), default to 5.0 and emit: `"Reachability defaulted to 5.0 — no trust zone data available for component '{component_name}'"`. Architecture adjustments still apply to the 5.0 default when `architecture.md` is present.
+
+### Severity Band Mapping
+
+Map the composite score to a severity band using ranges from `schemas/risk-scoring.yaml` → `severity_bands`:
+
+| Severity Band | Composite Score Range | Boundary Rule |
+|---------------|-----------------------|---------------|
+| Critical | 9.0 - 10.0 | Score >= 9.0 |
+| High | 7.0 - 8.9 | Score >= 7.0 and < 9.0 |
+| Medium | 4.0 - 6.9 | Score >= 4.0 and < 7.0 |
+| Low | 0.0 - 3.9 | Score < 4.0 |
+
+**Boundary precision**: When a composite score falls exactly on a boundary value, it maps to the **higher** band: 7.0 = High, 4.0 = Medium, 9.0 = Critical. The `min` values in the schema are inclusive.
+
+**Note consolidation**: The existing `schemas/output.yaml` defines 5 bands (Critical/High/Medium/Low/Note). For composite scoring, Note is consolidated into Low (0.0-3.9) because composite scores always produce a meaningful numeric value — there is no scenario where a scored finding should be classified as informational-only.
+
+### Correlation Group Handling
+
+When Section 4a correlation groups exist in the parsed input:
+
+1. **Identify primary finding**: The first finding ID listed in the correlation group is the primary
+2. **Score the primary**: Apply full four-dimensional scoring (CVSS, exploitability, scalability, reachability) to the primary finding
+3. **Peers inherit scores**: All correlated peer findings receive the same dimensional scores, composite score, severity band, and governance fields as the primary finding
+4. **Rationale**: Correlated findings represent the same underlying issue from different perspectives. Independent scoring would create inconsistencies; inheritance ensures the group is treated as a coherent risk unit
+5. **SC-001 exemption**: Correlated peer groups are excluded from the score differentiation metric (SC-001). Peers intentionally receive identical scores; this is correct behavior, not a differentiation failure
+
+### Computation Sequence
+
+For each finding (after parsing, in order):
+
+1. Look up the finding's `category` to get the default CVSS vector
+2. Refine the CVSS vector per-threat (Section 3) → produces `cvss_base` and `cvss_vector`
+3. Assess exploitability (Section 4) → produces `exploitability`
+4. Assess scalability (Section 5) → produces `scalability`
+5. Determine reachability via Section 6 pipeline (zone baseline → per-finding refinement → architecture adjustments → clamping; falls back to 5.0 per Section 6e when no trust zone data is available) → produces `reachability`
+6. Calculate composite: `(0.35 × cvss_base) + (0.30 × exploitability) + (0.15 × scalability) + (0.20 × reachability)`
+7. Map composite to severity band
+8. If the finding is a correlation group primary: store scores for peer inheritance
+9. If the finding is a correlation group peer: copy all scores from the primary instead of computing
+
+### Output per Finding
+
+After composite calculation, each finding has these scoring fields ready for output:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `cvss_base` | number (0.0-10.0) | Section 3 |
+| `cvss_vector` | string | Section 3 |
+| `exploitability` | number (0.0-10.0) | Section 4 |
+| `scalability` | number (0.0-10.0) | Section 5 |
+| `reachability` | number (0.0-10.0) | Section 6 or default 5.0 |
+| `composite_score` | number (0.0-10.0) | This section (weighted formula) |
+| `severity_band` | Critical/High/Medium/Low | This section (band mapping) |
+
+---
+
+## 8. Governance Fields
+
+Attach remediation tracking metadata to each scored finding based on its severity band. Governance fields provide organizational accountability — who owns the risk, when it must be addressed, and what the initial disposition is. These fields are derived deterministically from the severity band assigned in Section 7, using the mappings defined in `schemas/risk-scoring.yaml` → `severity_bands`.
+
+### Field Generation Rules
+
+For each scored finding, generate four governance fields by looking up the finding's `severity_band` in the severity bands table:
+
+| Field | Type | Generation Rule |
+|-------|------|-----------------|
+| `risk_owner` | string | Default: `"Unassigned"`. This is a placeholder indicating the finding has not yet been triaged by a human reviewer. The scorer never assigns a specific owner — ownership is a human decision made during remediation planning. |
+| `remediation_sla` | string | Mapped from the `sla` property of the finding's severity band in `schemas/risk-scoring.yaml` → `severity_bands`. Represents the maximum time allowed to address the finding after scoring. |
+| `risk_disposition` | string | Mapped from the `disposition` property of the finding's severity band in `schemas/risk-scoring.yaml` → `severity_bands`. Represents the initial recommended action for the finding. |
+| `review_date` | string (YYYY-MM-DD) | Calculated as: scoring date + SLA duration. The scoring date is the date the risk scorer executes, not the date the threat model was generated. |
+
+### Severity-to-Governance Mapping
+
+Load these mappings from `schemas/risk-scoring.yaml` → `severity_bands`:
+
+| Severity Band | `remediation_sla` | `risk_disposition` | `review_date` Calculation |
+|---------------|--------------------|---------------------|---------------------------|
+| Critical | `24h` | `Mitigate` | scoring date + 1 day |
+| High | `7d` | `Mitigate` | scoring date + 7 days |
+| Medium | `30d` | `Review` | scoring date + 30 days |
+| Low | `90d` | `Review` | scoring date + 90 days |
+
+**SLA duration parsing**: Convert the `sla` string to a day count for review date calculation:
+- `"24h"` → 1 day
+- `"7d"` → 7 days
+- `"30d"` → 30 days
+- `"90d"` → 90 days
+
+### Review Date Calculation
+
+The `review_date` is the calendar date by which the finding must be reviewed or remediated:
+
+```
+review_date = scoring_date + sla_days
+```
+
+Where:
+- `scoring_date` is the current date when the risk scorer runs (format: YYYY-MM-DD)
+- `sla_days` is the day count derived from the severity band's `sla` property
+
+**Example**: If the scorer runs on 2026-03-27 and a finding has severity band `High` (SLA = 7d):
+- `review_date` = 2026-03-27 + 7 days = `2026-04-03`
+
+**Month/year boundary handling**: Standard calendar arithmetic applies. If adding days crosses a month or year boundary, use the correct calendar date (e.g., 2026-01-29 + 30 days = 2026-02-28).
+
+### Disposition Values
+
+The `risk_disposition` field uses one of four values defined in `schemas/risk-scoring.yaml` → `scored_finding.risk_disposition.enum`:
+
+| Disposition | Meaning | Assigned By |
+|-------------|---------|-------------|
+| `Mitigate` | Active remediation required within the SLA period | Severity mapping (Critical, High) |
+| `Review` | Finding requires evaluation to determine appropriate action | Severity mapping (Medium, Low) |
+| `Accept` | Risk accepted with documented justification | Human override only |
+| `Transfer` | Risk transferred to a third party (insurance, vendor responsibility) | Human override only |
+
+The scorer assigns only `Mitigate` or `Review` based on severity mapping. `Accept` and `Transfer` are valid disposition values that humans may set during remediation planning, but the scorer never generates them automatically.
+
+### Override Guidance
+
+All governance fields are defaults intended to be refined during human triage. The scorer produces deterministic initial values; organizations customize them post-scoring:
+
+- **`risk_owner`**: Replace `"Unassigned"` with the responsible team or individual during triage. Ownership assignment depends on organizational structure and is outside the scorer's scope.
+- **`remediation_sla`**: Organizations may tighten SLAs (e.g., Critical from 24h to 12h for regulated systems) or relax them with documented justification. Custom SLAs should still use duration notation (e.g., `"12h"`, `"14d"`).
+- **`risk_disposition`**: Change from the severity-mapped default when appropriate. For example, a Low-severity finding with `"Review"` may be changed to `"Accept"` if the risk is within tolerance, or a Medium finding may be escalated to `"Mitigate"` based on business context.
+- **`review_date`**: Recalculate if the SLA is overridden. The review date should always reflect the actual SLA in effect, not the original severity-mapped default.
+
+Overridden values MUST be preserved in both output formats (risk-scores.md and risk-scores.sarif). The scorer records the severity-mapped defaults; downstream tooling or manual edits apply overrides.
+
+### Correlation Group Governance
+
+Governance fields for correlation groups follow the same inheritance rule as scoring fields (Section 7):
+
+1. The **primary finding** receives governance fields derived from its severity band
+2. All **correlated peer findings** inherit the primary's governance fields identically
+3. If a human overrides governance fields on the primary, peers should reflect the same override
+
+This ensures a correlation group — which represents a single underlying risk from multiple perspectives — receives consistent remediation tracking.
+
+### Output per Finding
+
+After governance field generation, each finding has these additional fields ready for output:
+
+| Field | Type | Example Value |
+|-------|------|---------------|
+| `risk_owner` | string | `"Unassigned"` |
+| `remediation_sla` | string | `"7d"` |
+| `risk_disposition` | string | `"Mitigate"` |
+| `review_date` | string (YYYY-MM-DD) | `"2026-04-03"` |
+
+Combined with the scoring fields from Section 7, each finding now carries the complete set of fields needed for output generation (Sections 9 and 10).
+
+---
+
+## 9. Output Generation: Markdown (risk-scores.md)
+
+Generate a `risk-scores.md` file in the same directory as the input threat model. The output MUST conform to the structure defined in `templates/risk-scores.md`. All sections are required and MUST appear in the order specified below. Findings are sorted by composite score descending throughout the document.
+
+### 9a. Frontmatter
+
+Generate YAML frontmatter at the top of the file, enclosed in a fenced code block with `yaml` language identifier, itself wrapped in a YAML document separator (`---`):
+
+```yaml
+---
+schema_version: "1.0"
+date: "YYYY-MM-DD"
+source_file: "{path to input threats.md or threats.sarif}"
+classification: "confidential"
+scoring_weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+---
+```
+
+**Field generation rules**:
+
+| Field | Rule |
+|-------|------|
+| `schema_version` | Always `"1.0"` for this release |
+| `date` | ISO 8601 date when scoring was performed (the current date, format `YYYY-MM-DD`) |
+| `source_file` | Relative path from the output directory to the input file that was scored (e.g., `threats.md` or `threats.sarif`) |
+| `classification` | Always `"confidential"` unless overridden by organizational policy |
+| `scoring_weights` | The four dimension weights used in the composite formula. These are fixed at the values shown and document the formula for reproducibility |
+
+### 9b. Section 1: Executive Summary
+
+Generate the executive summary immediately after the frontmatter. This section provides a high-level risk posture snapshot for security managers who need to assess severity distribution without reading individual findings.
+
+**Content to generate**:
+
+1. **Total findings count**: The total number of scored findings (e.g., "**18 findings** scored across 8 threat categories").
+
+2. **Severity band distribution table**: A table showing the count of findings in each severity band:
+
+   ```markdown
+   | Severity | Count |
+   |----------|-------|
+   | Critical | N     |
+   | High     | N     |
+   | Medium   | N     |
+   | Low      | N     |
+   ```
+
+   Include all four severity bands even when a band has zero findings (display `0` for empty bands). Order is always Critical, High, Medium, Low (descending severity).
+
+3. **Highest-risk component identification**: Identify the component with the highest single composite score across all findings. Format as: "**Highest-risk component**: {component_name} (composite: {score}, severity: {band})". When multiple findings tie for the highest composite score, select the finding whose component appears first in alphabetical order.
+
+4. **Severity distribution narrative**: A single sentence summarizing the distribution pattern (e.g., "The majority of findings (12 of 18) fall in the Medium band, with 2 Critical findings requiring immediate attention.").
+
+**Generation rules**:
+- Counts MUST be derived by iterating over all scored findings and tallying by `severity_band`
+- The highest-risk component is determined by the maximum `composite_score` value, not by counting findings per component
+- When all findings fall in a single severity band, still include the full four-row table
+
+### 9c. Section 2: Scored Threat Table
+
+Generate a markdown table containing all scored findings. This is the primary reference table for security engineers triaging findings.
+
+**Column definitions**:
+
+| Column | Source Field | Format |
+|--------|-------------|--------|
+| ID | `id` | Finding ID as-is (e.g., `S-1`, `AG-3`) |
+| Component | `component` | Component name, truncated to 30 characters with `...` suffix if longer |
+| Threat | `threat` | Threat description, truncated to 60 characters with `...` suffix if longer |
+| CVSS | `cvss_base` | Decimal with one digit (e.g., `7.2`) |
+| Exploitability | `exploitability` | Decimal with one digit (e.g., `6.5`) |
+| Scalability | `scalability` | Decimal with one digit (e.g., `4.0`) |
+| Reachability | `reachability` | Decimal with one digit (e.g., `8.0`) |
+| Composite | `composite_score` | Decimal with one digit (e.g., `6.8`) |
+| Severity | `severity_band` | `Critical`, `High`, `Medium`, or `Low` |
+| SLA | `remediation_sla` | Duration string (e.g., `24h`, `7d`) |
+| Disposition | `risk_disposition` | `Mitigate` or `Review` |
+
+**Sort order**: Rows are sorted by `composite_score` descending (highest risk first). When two findings have equal composite scores, secondary sort by `id` in natural alphanumeric order (e.g., `S-1` before `S-2`, `AG-1` before `LLM-1`).
+
+**Truncation rules**:
+- Component names exceeding 30 characters: truncate to 27 characters and append `...` (e.g., `"LLM Agent Orchestrator Servi..."`)
+- Threat descriptions exceeding 60 characters: truncate to 57 characters and append `...` (e.g., `"Attacker injects malicious prompts to bypass guardrail..."`)
+- Truncation is applied only in the Scored Threat Table; the Dimensional Breakdown (Section 3) shows full untruncated text
+
+**Numeric formatting**: All dimension scores and composite scores are formatted with exactly one decimal place. Trailing zeros are preserved (e.g., `4.0` not `4`).
+
+**Correlation group display**: Correlated peer findings appear in the table with their own IDs but carry the primary's scores. No special notation is needed in the table -- peers are indistinguishable from independently scored findings.
+
+### 9d. Section 3: Dimensional Breakdown
+
+Generate a per-finding breakdown section that provides the full scoring rationale for each finding. This section is intended for security engineers who need to understand why a finding received its scores, not just what the scores are.
+
+**Structure**: One subsection per finding, ordered by `composite_score` descending (same order as the Scored Threat Table). Each subsection uses an H3 heading.
+
+**Per-finding subsection format**:
+
+```markdown
+### {id}: {threat_description}
+
+**Component**: {component}
+**Category**: {category}
+**Composite Score**: {composite_score} ({severity_band})
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | {cvss_base} | 0.35 | {cvss_base * 0.35} |
+| Exploitability | {exploitability} | 0.30 | {exploitability * 0.30} |
+| Scalability | {scalability} | 0.15 | {scalability * 0.15} |
+| Reachability | {reachability} | 0.20 | {reachability * 0.20} |
+| **Composite** | | | **{composite_score}** |
+
+**CVSS Vector**: `{cvss_vector}`
+
+**Scoring Rationale**:
+- **CVSS**: {1-2 sentence justification for the CVSS base score}
+- **Exploitability**: {1-2 sentence justification}
+- **Scalability**: {1-2 sentence justification}
+- **Reachability**: {1-2 sentence justification referencing the trust zone if available}
+```
+
+**Field generation rules**:
+
+| Field | Rule |
+|-------|------|
+| `{id}` | Finding ID, untruncated |
+| `{threat_description}` | Full threat description text, untruncated (no 60-character limit here) |
+| `{component}` | Full component name, untruncated |
+| `{category}` | Human-readable category name: `Spoofing`, `Tampering`, `Repudiation`, `Information Disclosure`, `Denial of Service`, `Privilege Escalation`, `Agentic Threats`, or `LLM Threats` |
+| `{composite_score}` | Decimal with one digit |
+| `{severity_band}` | `Critical`, `High`, `Medium`, or `Low` |
+| Dimension scores | Decimal with one digit |
+| Weighted values | Decimal with two digits (e.g., `2.52`, `1.95`). Calculated as score multiplied by weight |
+| `{cvss_vector}` | Full CVSS 3.1 vector string from Section 3 scoring |
+| Scoring Rationale | Brief justification drawn from the assessment performed in Sections 3-6. Each rationale line explains the key factors that determined the score for that dimension |
+
+**Correlation group display**: Correlated peer findings each get their own subsection but include an additional line after the Category line: `**Correlation Group**: Scores inherited from primary finding {primary_id}`. The dimensional table and rationale reflect the primary's assessment.
+
+**Category display mapping**:
+
+| IR Category | Display Name |
+|-------------|-------------|
+| `spoofing` | Spoofing |
+| `tampering` | Tampering |
+| `repudiation` | Repudiation |
+| `info-disclosure` | Information Disclosure |
+| `denial-of-service` | Denial of Service |
+| `privilege-escalation` | Privilege Escalation |
+| `agentic` | Agentic Threats |
+| `llm` | LLM Threats |
+
+### 9e. Section 4: Governance Fields
+
+Generate a governance tracking table that consolidates all governance metadata for remediation planning. This section provides a single-view reference for GRC teams and security managers assigning ownership and tracking remediation progress.
+
+**Table format**:
+
+```markdown
+| ID | Component | Severity | Owner | SLA | Disposition | Review Date |
+|----|-----------|----------|-------|-----|-------------|-------------|
+```
+
+**Column definitions**:
+
+| Column | Source Field | Format |
+|--------|-------------|--------|
+| ID | `id` | Finding ID as-is |
+| Component | `component` | Full component name, untruncated |
+| Severity | `severity_band` | `Critical`, `High`, `Medium`, or `Low` |
+| Owner | `risk_owner` | Default: `Unassigned` |
+| SLA | `remediation_sla` | Duration string (e.g., `24h`, `7d`, `30d`, `90d`) |
+| Disposition | `risk_disposition` | `Mitigate` or `Review` |
+| Review Date | `review_date` | ISO 8601 date (e.g., `2026-04-03`) |
+
+**Sort order**: Same as the Scored Threat Table -- `composite_score` descending, secondary sort by `id` in natural alphanumeric order.
+
+**Generation rules**:
+- Every scored finding MUST appear in this table (no findings omitted)
+- The `Owner` column always reads `Unassigned` in scorer-generated output -- ownership is a human decision made during triage (see Section 8 Override Guidance)
+- The `Review Date` is calculated per Section 8 rules: scoring date + SLA duration
+- Correlation group peers appear with their own IDs and inherit governance fields from the primary
+
+### 9f. Section 5: Scoring Methodology
+
+Generate the scoring methodology section that documents how scores in this report were calculated. This section ensures the report is self-contained and auditable without requiring access to the scorer agent definition.
+
+**Content to generate**:
+
+Reproduce the methodology content defined in `templates/risk-scores.md` Section 5, populated with the actual values used in this scoring run:
+
+1. **Scoring Dimensions**: Table listing the four dimensions (CVSS Base, Exploitability, Scalability, Reachability) with their weights and descriptions
+2. **Default Weights and Rationale**: Explanation of why each dimension receives its assigned weight
+3. **Composite Score Formula**: The weighted sum formula with the actual weights used
+4. **Severity Band Mapping**: Table mapping composite score ranges to severity bands with default SLAs and dispositions
+5. **Data Sources**: Description of inputs consumed (threat findings, trust zone data, architecture documentation, category default vectors)
+6. **Reproducibility**: Temperature 0 setting and +/- 0.5 tolerance per dimension
+
+**Generation rules**:
+- The methodology section content is static for a given schema version -- it does not vary between scoring runs
+- The weights in the formula and dimension table MUST match the `scoring_weights` values in the frontmatter
+- Severity band boundaries MUST match those defined in `schemas/risk-scoring.yaml` -> `severity_bands`
+- This section serves as an in-document reference; it does not replace the schema definitions
+
+### 9g. File Placement
+
+Write the completed `risk-scores.md` to the same directory as the input file:
+
+- If the input was `{dir}/threats.md`, write to `{dir}/risk-scores.md`
+- If the input was `{dir}/threats.sarif`, write to `{dir}/risk-scores.md`
+- If a `risk-scores.md` already exists at the target path, overwrite it (scoring is idempotent)
+
+### 9h. Consistency Requirements
+
+The markdown output MUST be consistent with the SARIF output (Section 10) on all data points:
+
+- Every finding in `risk-scores.md` MUST appear in `risk-scores.sarif` and vice versa
+- All numeric scores (dimension scores, composite scores) MUST be identical between the two formats
+- Severity band assignments MUST be identical between the two formats
+- Governance field values (owner, SLA, disposition, review date) MUST be identical between the two formats
+- Sort order in the Scored Threat Table corresponds to the order of results in the SARIF `results[]` array
+
+If any inconsistency is detected during generation, treat it as a scoring pipeline error and halt output generation with a diagnostic message identifying the mismatched finding and field.
+
+---
+
+## 10. Output Generation: SARIF (risk-scores.sarif)
+
+Generate a `risk-scores.sarif` file in the same directory as the input threat model. The output MUST conform to SARIF 2.1.0 (`$schema: https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json`) and follow the structure defined in `templates/risk-scores.sarif`. All scored findings MUST appear in the SARIF output, and all numeric values MUST be identical to those in `risk-scores.md` (Section 9h consistency mandate).
+
+**Semantic shift from threats.sarif**: In `threats.sarif`, the rule-level `security-severity` is a static category value (e.g., `"9.0"` for Critical, `"5.0"` for Medium). In `risk-scores.sarif`, the result-level `security-severity` is the per-finding composite score and the rule-level `security-severity` is the MAX composite score among all findings for that rule. Task T023 documents this shift in the SARIF reference guide.
+
+### 10a. Tool Driver Configuration
+
+Set the `tool.driver` object to identify the risk scorer as a distinct tool from the threat model generator:
+
+```json
+{
+  "tool": {
+    "driver": {
+      "name": "tachi-risk-scorer",
+      "version": "1.0",
+      "semanticVersion": "1.0",
+      "informationUri": "https://github.com/owner/tachi",
+      "supportedTaxonomies": [ ... ],
+      "rules": [ ... ]
+    }
+  }
+}
+```
+
+**Field generation rules**:
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| `name` | `"tachi-risk-scorer"` | Distinguishes scored output from threat model output (`"tachi"` in threats.sarif) |
+| `version` | `"1.0"` | Matches `schemas/risk-scoring.yaml` → `schema_version` |
+| `semanticVersion` | `"1.0"` | Same as `version` |
+| `informationUri` | `"https://github.com/owner/tachi"` | Project repository URL |
+| `supportedTaxonomies` | Passthrough from source | See Section 10f (Taxonomy Passthrough) |
+| `rules` | One entry per threat category with findings | See Section 10b (Rule Definitions) |
+
+### 10b. Rule Definitions
+
+Populate `tool.driver.rules[]` with one entry per threat category that has at least one scored finding. Use the same rule IDs as `threats.sarif`. Each rule definition carries the MAX composite score among its findings.
+
+**Rule ID to category mapping** (same as Section 1b parsing):
+
+| Rule ID | Category |
+|---------|----------|
+| `tachi/stride/spoofing` | spoofing |
+| `tachi/stride/tampering` | tampering |
+| `tachi/stride/repudiation` | repudiation |
+| `tachi/stride/information-disclosure` | info-disclosure |
+| `tachi/stride/denial-of-service` | denial-of-service |
+| `tachi/stride/elevation-of-privilege` | privilege-escalation |
+| `tachi/ai/agentic-threats` | agentic |
+| `tachi/ai/llm-threats` | llm |
+
+**Per-rule structure**:
+
+```json
+{
+  "id": "tachi/stride/spoofing",
+  "shortDescription": { "text": "Identity spoofing threats" },
+  "fullDescription": { "text": "<category-level description>" },
+  "properties": {
+    "tags": ["security", "stride", "spoofing", ...],
+    "security-severity": "<max-composite-score-as-numeric-string>"
+  },
+  "relationships": [ ... ]
+}
+```
+
+**Rule-level `security-severity` calculation**:
+
+1. Collect all scored findings whose `ruleId` matches this rule
+2. Extract each finding's `composite_score`
+3. Set the rule's `security-severity` to the MAX composite score among those findings, formatted as a numeric string with one decimal place (e.g., `"8.3"`)
+4. If a category has exactly one finding, the rule-level value equals that finding's composite score
+5. If a category has no findings, omit the rule entirely from `rules[]`
+
+This is a semantic shift from `threats.sarif`, where rule-level `security-severity` is a static value representing the category's general severity class. In `risk-scores.sarif`, rule-level `security-severity` reflects the actual worst-case finding within that category.
+
+**Rule descriptions and tags**: Copy `shortDescription`, `fullDescription`, `properties.tags`, and `relationships[]` from the corresponding rule in `templates/risk-scores.sarif`. These are static per category and do not change between scoring runs.
+
+### 10c. Result Generation
+
+Generate one result object per scored finding in the `run.results[]` array. Results are ordered by `composite_score` descending (highest risk first), matching the sort order in `risk-scores.md` Section 2 (Scored Threat Table). When two findings have equal composite scores, secondary sort by finding `id` in natural alphanumeric order.
+
+**Per-result structure**:
+
+```json
+{
+  "ruleId": "<rule-id-from-category>",
+  "message": {
+    "text": "<threat-description>",
+    "markdown": "<mitigation-recommendation>"
+  },
+  "level": "<sarif-level-from-severity-band>",
+  "locations": [ ... ],
+  "partialFingerprints": { ... },
+  "properties": { ... }
+}
+```
+
+**Field generation rules**:
+
+| Field | Source | Rule |
+|-------|--------|------|
+| `ruleId` | `category` | Map IR category to rule ID using the table in Section 10b |
+| `message.text` | `threat` | Full threat description text, untruncated |
+| `message.markdown` | `mitigation` | Full mitigation recommendation, untruncated |
+| `level` | `severity_band` | Map via SARIF Level Mapping (Section 10d) |
+| `locations` | Finding location data | See Location Generation below |
+| `partialFingerprints` | Source `threats.sarif` or derived | See Section 10e (Fingerprint Preservation) |
+| `properties` | Scoring and governance fields | See Property Bag Mapping (Section 10g) |
+
+**Location generation**:
+
+Each result MUST include a `locations[]` array with one entry containing both physical and logical location:
+
+```json
+{
+  "locations": [
+    {
+      "physicalLocation": {
+        "artifactLocation": {
+          "uri": "<input-architecture-file-path>"
+        },
+        "region": {
+          "startLine": 1
+        }
+      },
+      "logicalLocations": [
+        {
+          "name": "<component-name>",
+          "fullyQualifiedName": "<trust-zone>/<component-name>",
+          "kind": "process"
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Location Field | Source | Rule |
+|----------------|--------|------|
+| `artifactLocation.uri` | Input file path | Relative path to the architecture document that was threat-modeled |
+| `region.startLine` | Fixed | Always `1` (threat findings are document-level, not line-level) |
+| `logicalLocations[0].name` | `component` | Component name from the scored finding |
+| `logicalLocations[0].fullyQualifiedName` | Trust zone + component | Format: `{trust_zone}/{component}`. If no trust zone is available, use the component name only |
+| `logicalLocations[0].kind` | `dfd_element_type` | Map from IR: `Process` -> `"process"`, `Data Store` -> `"data-store"`, `External Entity` -> `"external-entity"`. Default to `"process"` when DFD element type is unavailable |
+
+### 10d. SARIF Level Mapping
+
+Map the scored finding's `severity_band` to the SARIF `level` field using the mapping defined in `schemas/output.yaml`:
+
+| Severity Band | SARIF `level` | Rationale |
+|---------------|---------------|-----------|
+| Critical | `"error"` | Requires immediate action; blocks release |
+| High | `"error"` | Significant risk; treated as error-level in tooling |
+| Medium | `"warning"` | Moderate risk; requires attention but not blocking |
+| Low | `"note"` | Informational; tracked for completeness |
+
+This mapping is identical to the one used in `threats.sarif` for consistency across tachi SARIF outputs. The `level` field controls how SARIF consumers (GitHub Code Scanning, VS Code SARIF Viewer, etc.) display and filter results.
+
+### 10e. Fingerprint Preservation
+
+Fingerprints provide stable identifiers for alert tracking across scoring runs. Preserve all `partialFingerprints` from the source `threats.sarif` input, and derive fingerprints when parsing from `threats.md`.
+
+**Preservation rules**:
+
+| Fingerprint Key | Source | Rule |
+|-----------------|--------|------|
+| `findingId/v1` | Source finding | **Always present**. When input is `threats.sarif`, copy the value directly. When input is `threats.md`, use the finding ID (e.g., `"S-1"`, `"AG-3"`). This is the primary stable identifier for correlating findings across threat model and risk score outputs. |
+| `primaryLocationLineHash` | Source `threats.sarif` | **Preserve when available**. Copy directly from the source result's `partialFingerprints`. When input is `threats.md` (no source SARIF), omit this key entirely -- do not fabricate a hash. |
+| `correlationGroup` | Source finding | **Present on correlation group primaries only**. Copy from source `threats.sarif` if available. When input is `threats.md`, set to the correlation group identifier (e.g., `"CG-1"`) for primary findings that head a correlation group. Omit for non-correlated findings and for peer findings. |
+
+**Fingerprint integrity rule**: Never modify, regenerate, or re-hash fingerprint values that originate from `threats.sarif`. These values are used by downstream consumers (GitHub Code Scanning, alert deduplication pipelines) to track findings across runs. Altering them breaks alert continuity.
+
+### 10f. Taxonomy Passthrough
+
+Preserve all taxonomy declarations from the source input for downstream consumers that rely on OWASP and CWE classification.
+
+**Taxonomy elements to preserve**:
+
+| Element | Location in SARIF | Rule |
+|---------|-------------------|------|
+| `run.taxonomies[]` | Top-level run property | Copy the entire `taxonomies` array from the source `threats.sarif`. When input is `threats.md`, use the default taxonomy declarations from `templates/risk-scores.sarif` (OWASP 2021 and CWE 4.13). |
+| `tool.driver.supportedTaxonomies[]` | Tool driver property | Copy from source `threats.sarif`. When input is `threats.md`, use the default declarations: `[{"name": "OWASP", "index": 0}, {"name": "CWE", "index": 1}]` |
+| Rule `relationships[]` | Per-rule in `tool.driver.rules[]` | Copy the `relationships` array from the corresponding rule in the source `threats.sarif`. When input is `threats.md`, use the default relationships from `templates/risk-scores.sarif` which map each STRIDE/AI category to its primary OWASP Top 10 and CWE entries. |
+
+**Default taxonomy declarations** (used when input is `threats.md`):
+
+```json
+{
+  "taxonomies": [
+    {
+      "name": "OWASP",
+      "version": "2021",
+      "informationUri": "https://owasp.org/Top10/",
+      "organization": "OWASP Foundation",
+      "shortDescription": { "text": "OWASP Top 10 Web Application Security Risks" }
+    },
+    {
+      "name": "CWE",
+      "version": "4.13",
+      "informationUri": "https://cwe.mitre.org/",
+      "organization": "MITRE",
+      "shortDescription": { "text": "Common Weakness Enumeration" }
+    }
+  ]
+}
+```
+
+**Passthrough integrity rule**: Do not modify taxonomy versions, URIs, or organization names during passthrough. The risk scorer does not assess or update taxonomy classifications -- it preserves them for downstream tools.
+
+### 10g. Property Bag Field Mapping
+
+Each result's `properties` object carries the full scoring and governance payload. This is the primary extension point where `risk-scores.sarif` differs from `threats.sarif`.
+
+**Property bag structure**:
+
+```json
+{
+  "properties": {
+    "security-severity": "7.2",
+    "cvss-base-score": "8.1",
+    "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+    "exploitability": "7.0",
+    "scalability": "5.5",
+    "reachability": "6.0",
+    "composite-weights": "0.35/0.30/0.15/0.20",
+    "severity-band": "High",
+    "risk-owner": "Unassigned",
+    "remediation-sla": "7d",
+    "risk-disposition": "Mitigate",
+    "review-date": "2026-04-03"
+  }
+}
+```
+
+**Field mapping table**:
+
+| Property Key | IR Source Field | Format | Description |
+|--------------|----------------|--------|-------------|
+| `security-severity` | `composite_score` | Numeric string, one decimal place (e.g., `"7.2"`) | The composite risk score for this specific finding. This is the primary sort/filter key for SARIF consumers. |
+| `cvss-base-score` | `cvss_base` | Numeric string, one decimal place (e.g., `"8.1"`) | CVSS 3.1 base score from Section 3 assessment |
+| `cvss-vector` | `cvss_vector` | Full CVSS 3.1 vector string (e.g., `"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"`) | Complete vector for auditability and independent verification |
+| `exploitability` | `exploitability` | Numeric string, one decimal place (e.g., `"7.0"`) | Exploitability assessment from Section 4 |
+| `scalability` | `scalability` | Numeric string, one decimal place (e.g., `"5.5"`) | Scalability assessment from Section 5 |
+| `reachability` | `reachability` | Numeric string, one decimal place (e.g., `"6.0"`) | Reachability assessment from Section 6 |
+| `composite-weights` | Fixed | `"0.35/0.30/0.15/0.20"` | Slash-delimited weight string (CVSS/Exploitability/Scalability/Reachability). Documents the formula used for reproducibility. Constant for schema version 1.0. |
+| `severity-band` | `severity_band` | One of: `"Critical"`, `"High"`, `"Medium"`, `"Low"` | Severity band derived from composite score per `schemas/risk-scoring.yaml` thresholds |
+| `risk-owner` | `risk_owner` | String | Default: `"Unassigned"`. Human-assigned during triage. |
+| `remediation-sla` | `remediation_sla` | Duration string: `"24h"`, `"7d"`, `"30d"`, or `"90d"` | Severity-driven SLA from `schemas/risk-scoring.yaml` -> `severity_bands` |
+| `risk-disposition` | `risk_disposition` | One of: `"Mitigate"`, `"Review"`, `"Accept"`, `"Transfer"` | Initial disposition from severity mapping. Default scoring produces `"Mitigate"` (Critical/High) or `"Review"` (Medium/Low). |
+| `review-date` | `review_date` | ISO 8601 date string (`"YYYY-MM-DD"`) | Scoring date + SLA duration, per Section 8 calculation rules |
+
+**Numeric string formatting rule**: All numeric properties (`security-severity`, `cvss-base-score`, `exploitability`, `scalability`, `reachability`) MUST be formatted as strings with exactly one decimal place. Trailing zeros are preserved (e.g., `"4.0"` not `"4"`). This matches the SARIF convention where `security-severity` is a string, and ensures consistency across all scoring properties.
+
+### 10h. Correlation Group Handling in SARIF
+
+Correlation groups receive special treatment in SARIF output. The primary finding appears as a top-level result with full scoring; peer findings do NOT appear as separate top-level results. Instead, peers are referenced via `relatedLocations` on the primary result.
+
+**Primary finding result**:
+
+The primary finding is emitted as a normal result (per Section 10c) with these additions:
+
+1. `partialFingerprints` includes the `correlationGroup` key (e.g., `"CG-1"`)
+2. `relatedLocations[]` contains one entry per correlated peer finding:
+
+```json
+{
+  "relatedLocations": [
+    {
+      "id": 0,
+      "message": {
+        "text": "<peer-finding-id>: <peer-threat-summary>"
+      },
+      "logicalLocations": [
+        {
+          "name": "<peer-component-name>",
+          "fullyQualifiedName": "<trust-zone>/<peer-component-name>",
+          "kind": "process"
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Related Location Field | Source | Rule |
+|------------------------|--------|------|
+| `id` | Sequence | Zero-based index within the `relatedLocations` array |
+| `message.text` | Peer finding | Format: `"{peer_id}: {peer_threat_summary}"` (e.g., `"T-4: Data tampering via API gateway"`) |
+| `logicalLocations[0].name` | Peer `component` | Peer finding's component name |
+| `logicalLocations[0].fullyQualifiedName` | Peer trust zone + component | Format: `{trust_zone}/{component}`, same as primary location rules |
+| `logicalLocations[0].kind` | Peer `dfd_element_type` | Same mapping as primary location rules |
+
+**Peer finding handling**:
+
+- Peer findings do NOT appear as separate entries in `run.results[]`
+- All peer scores and governance fields are inherited from the primary (Section 7, Correlation Group Handling)
+- Peer finding IDs are visible only in the `relatedLocations[].message.text` of the primary result
+- The primary's `composite_score` (used as result-level `security-severity`) reflects the entire group's risk
+
+**Result count implication**: The total number of results in `run.results[]` equals the number of independently scored findings plus the number of correlation group primaries. It does NOT include peer findings. The `risk-scores.md` Scored Threat Table may show more rows than `run.results[]` has entries because the markdown format lists peers as separate rows.
+
+### 10i. File Placement
+
+Write the completed `risk-scores.sarif` to the same directory as the input file:
+
+- If the input was `{dir}/threats.md`, write to `{dir}/risk-scores.sarif`
+- If the input was `{dir}/threats.sarif`, write to `{dir}/risk-scores.sarif`
+- If a `risk-scores.sarif` already exists at the target path, overwrite it (scoring is idempotent)
+
+The SARIF file MUST be valid JSON. Use 2-space indentation for human readability.
+
+### 10j. Consistency with Markdown Output
+
+The SARIF output MUST be consistent with the markdown output (Section 9) on all data points. This is a bidirectional requirement -- Section 9h mandates consistency from the markdown side, and this subsection mandates it from the SARIF side.
+
+**Consistency checks**:
+
+| Data Point | Markdown Location | SARIF Location | Rule |
+|------------|-------------------|----------------|------|
+| Finding count | Executive Summary total | `run.results[]` length + peer count | Every finding in `risk-scores.md` MUST be accounted for in `risk-scores.sarif` (primaries as results, peers in `relatedLocations`) |
+| Composite score | Scored Threat Table "Composite" column | `result.properties["security-severity"]` | Numeric values MUST be identical (e.g., markdown `6.8` equals SARIF `"6.8"`) |
+| Dimension scores | Dimensional Breakdown table | `result.properties["cvss-base-score"]`, `["exploitability"]`, `["scalability"]`, `["reachability"]` | All four dimension scores MUST match between formats |
+| Severity band | Scored Threat Table "Severity" column | `result.properties["severity-band"]` | Band assignment MUST be identical |
+| SARIF level | (not in markdown) | `result.level` | Must be derivable from the severity band using Section 10d mapping |
+| Governance fields | Governance Fields table | `result.properties["risk-owner"]`, `["remediation-sla"]`, `["risk-disposition"]`, `["review-date"]` | All governance values MUST be identical |
+| Sort order | Scored Threat Table row order | `run.results[]` array order | Results appear in the same composite-descending order |
+| Rule-level severity | (not in markdown) | `rule.properties["security-severity"]` | Must equal MAX of the composite scores from all findings mapped to that rule |
+
+**Consistency failure handling**: If any inconsistency is detected during generation, treat it as a scoring pipeline error and halt output generation with a diagnostic message identifying the mismatched finding, field, and the values in each format. Do not write a partial or inconsistent SARIF file.

--- a/.claude/commands/risk-score.md
+++ b/.claude/commands/risk-score.md
@@ -1,0 +1,161 @@
+---
+description: Run quantitative risk scoring on threat model output — produces risk-scores.md and risk-scores.sarif with four-dimensional scores, composite ratings, and governance fields
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Consider user input before proceeding (if not empty).
+
+## Step 0: Parse Flags
+
+1. If `$ARGUMENTS` contains `--output-dir <path>`:
+   - Set `output_dir` to the specified path
+   - Strip `--output-dir <path>` from `$ARGUMENTS` (trim extra whitespace)
+2. Default: `output_dir = null` (outputs written to same directory as input)
+
+3. Remaining `$ARGUMENTS` is treated as the input directory path.
+4. Default input directory: current working directory (`.`)
+
+## Overview
+
+Single-command entry point for tachi quantitative risk scoring. Validates prerequisites, locates threat model output, invokes the risk-scorer agent, and writes scored output files.
+
+**Flow**: Validate → Locate Input → Score → Report
+
+**Output suite**:
+- `risk-scores.md` — scored threat table, executive summary, dimensional breakdowns, governance fields, methodology
+- `risk-scores.sarif` — SARIF 2.1.0 with per-finding composite scores in `security-severity` and scoring properties in result property bags
+
+## Step 1: Validate Prerequisites
+
+1. **Check tachi agents are installed**:
+   - Verify `.claude/agents/tachi/risk-scorer.md` exists
+   - If missing, display:
+     ```
+     TACHI RISK SCORER NOT INSTALLED
+     Run: cp -r <tachi-repo>/adapters/claude-code/agents/risk-scorer.md .claude/agents/tachi/
+     See: https://github.com/davidmatousek/tachi
+     ```
+   - Halt if missing.
+
+2. **Check input files exist**:
+   - Look for `threats.md` in the input directory
+   - If not found, look for `threats.sarif` in the input directory
+   - If neither exists, display:
+     ```
+     NO THREAT MODEL OUTPUT FOUND
+     Neither threats.md nor threats.sarif found in: {input_dir}
+     Run /threat-model first to generate threat model output.
+     ```
+   - Halt if neither exists.
+
+3. **Determine input file and format**:
+   - If `threats.md` exists: set `input_file = threats.md`, `input_format = markdown`
+   - If only `threats.sarif` exists: set `input_file = threats.sarif`, `input_format = sarif`
+   - `threats.md` is the canonical source; `threats.sarif` is the fallback
+   - Display: `Input: {input_file} ({input_format} format)`
+
+4. **Determine output directory**:
+   - If `--output-dir` was specified: use that path
+   - Otherwise: use the same directory as the input file
+   - Create output directory if it does not exist
+   - Display: `Output: {output_dir}`
+
+5. **Check for optional architecture.md**:
+   - Look for `architecture.md` in the input directory and its parent directory
+   - If found: set `architecture_path` to the resolved path (used for reachability scoring)
+   - If not found: set `architecture_path = null` (reachability will use trust zone data only, or default to 5.0)
+
+## Step 2: Run Risk Scoring
+
+1. Read the input file at `{input_file}`.
+
+2. If `architecture_path` is not null, read the architecture file.
+
+3. Invoke the `tachi-risk-scorer` agent with the following prompt:
+
+   ```
+   Score the following threat model output using your complete scoring pipeline
+   (Threat Parsing → Trust Zone Extraction → Dimensional Scoring → Composite
+   Calculation → Governance Fields → Output Generation).
+
+   Write all output files to: {output_dir}
+   - risk-scores.md
+   - risk-scores.sarif
+
+   Input format: {input_format}
+   Scoring date: {current date YYYY-MM-DD}
+
+   <threat-model-input>
+   {contents of input file}
+   </threat-model-input>
+
+   {if architecture_path is not null:}
+   <architecture-input>
+   {contents of architecture file}
+   </architecture-input>
+   ```
+
+4. Wait for the risk-scorer agent to complete all 6 pipeline phases.
+
+## Step 3: Report Results
+
+Display summary:
+
+```
+RISK SCORING COMPLETE
+Input: {input_file} ({input_format} format)
+Output: {output_dir}
+
+Files generated:
+  risk-scores.md    — Scored threat table + executive summary + methodology
+  risk-scores.sarif — SARIF 2.1.0 with quantitative scores
+
+Severity Distribution:
+  Critical: {count}    High: {count}    Medium: {count}    Low: {count}
+  Total findings scored: {total}
+
+Highest-Risk Component: {component_name} (composite: {max_composite})
+
+Next steps:
+  1. Review Critical/High findings in risk-scores.md Section 2
+  2. Assign risk owners in Section 4 (Governance Fields)
+  3. Upload risk-scores.sarif to GitHub Code Scanning (supersedes threats.sarif)
+  4. Share risk-scores.md with stakeholders for remediation planning
+```
+
+## Usage Examples
+
+```bash
+# Minimal — score threats in current directory
+/risk-score
+
+# Specify input directory
+/risk-score path/to/threat-model-output/
+
+# Custom output directory
+/risk-score path/to/threat-model-output/ --output-dir reports/risk/
+
+# Score a specific example
+/risk-score examples/agentic-app/sample-report/
+```
+
+## Quality Checklist
+
+- [ ] Risk-scorer agent installed in `.claude/agents/tachi/`
+- [ ] Input file exists (threats.md or threats.sarif)
+- [ ] Input format correctly detected (markdown canonical, SARIF fallback)
+- [ ] Architecture file located when available (improves reachability scoring)
+- [ ] Both output files generated (risk-scores.md + risk-scores.sarif)
+- [ ] All findings scored with four dimensions (CVSS, exploitability, scalability, reachability)
+- [ ] Composite scores calculated using weighted formula
+- [ ] Severity bands mapped correctly (Critical/High/Medium/Low)
+- [ ] Governance fields populated (owner, SLA, disposition, review date)
+- [ ] Scored threat table sorted by composite descending
+- [ ] SARIF output validates against SARIF 2.1.0 schema
+- [ ] SARIF fingerprints preserved from source threats.sarif
+- [ ] Scores consistent between risk-scores.md and risk-scores.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -189,5 +189,8 @@ _site/
 # Local threat model runs (sample report lives in examples/)
 docs/security/
 
+# Enterprise planning documents (internal strategy, not public)
+docs/planning/
+
 # Subagent result artifacts (ephemeral, session-scoped)
 .aod/results/

--- a/adapters/claude-code/agents/references/sarif-generation.md
+++ b/adapters/claude-code/agents/references/sarif-generation.md
@@ -497,3 +497,87 @@ Before writing the `threats.sarif` file, run the following validation checklist.
 If any check fails, correct the error before proceeding. Do not produce a `threats.sarif` file that fails any of these structural checks.
 
 After the self-check passes, write the `threats.sarif` file to the output directory alongside `threats.md`.
+
+---
+
+### Risk Scoring SARIF Extension
+
+When the `/risk-score` command processes `threats.sarif` (or `threats.md`) into `risk-scores.sarif`, the scored SARIF output extends the base `threats.sarif` structure with quantitative risk scoring properties. This section documents the differences between the two SARIF files.
+
+#### Semantic Shift: `security-severity`
+
+The meaning of `security-severity` differs between the two SARIF files:
+
+| Property | `threats.sarif` | `risk-scores.sarif` |
+|----------|----------------|---------------------|
+| **Rule-level** `security-severity` | Static category-level value from the Severity Mapping Table (e.g., `"8.0"` for all High findings in a category) | **MAX composite score** among that rule's findings (e.g., `"8.4"` if the highest-scored spoofing finding has composite 8.4) |
+| **Result-level** `security-severity` | Not present (severity lives only on the rule) | **Per-finding composite score** as a numeric string (e.g., `"7.8"`) — each finding gets its own calculated value |
+
+This shift enables GitHub Code Scanning to display granular, per-finding severity rather than flat category-level severity, allowing differentiation between findings that previously shared the same rating.
+
+#### Extended Property Bag Schema
+
+Each result in `risk-scores.sarif` includes these additional properties in its `properties` object:
+
+```json
+{
+  "properties": {
+    "security-severity": "<composite-score-as-numeric-string>",
+    "cvss-base-score": "<0.0-10.0 as string>",
+    "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+    "exploitability": "<0.0-10.0 as string>",
+    "scalability": "<0.0-10.0 as string>",
+    "reachability": "<0.0-10.0 as string>",
+    "composite-weights": "0.35/0.30/0.15/0.20",
+    "severity-band": "<Critical|High|Medium|Low>",
+    "risk-owner": "Unassigned",
+    "remediation-sla": "<24h|7d|30d|90d>",
+    "risk-disposition": "<Mitigate|Review>",
+    "review-date": "<YYYY-MM-DD>"
+  }
+}
+```
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `security-severity` | numeric string | Composite risk score (weighted sum of four dimensions). Replaces the static category value from `threats.sarif`. |
+| `cvss-base-score` | numeric string | CVSS 3.1 base score (0.0-10.0) |
+| `cvss-vector` | string | Full CVSS 3.1 vector string for auditability |
+| `exploitability` | numeric string | Exploitability assessment (0.0-10.0) |
+| `scalability` | numeric string | Scalability assessment (0.0-10.0) |
+| `reachability` | numeric string | Reachability assessment (0.0-10.0), derived from trust zone placement |
+| `composite-weights` | string | Weight allocation used: `"cvss/exploitability/scalability/reachability"` |
+| `severity-band` | string | Severity classification mapped from composite: Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9) |
+| `risk-owner` | string | Assigned remediation owner. Default: `"Unassigned"` |
+| `remediation-sla` | string | Severity-driven deadline: Critical=24h, High=7d, Medium=30d, Low=90d |
+| `risk-disposition` | string | Risk treatment decision: Critical/High=Mitigate, Medium/Low=Review |
+| `review-date` | string | ISO 8601 date: scoring date + SLA duration |
+
+#### Fingerprint Preservation Rules
+
+`risk-scores.sarif` MUST preserve all fingerprint values from the source `threats.sarif`:
+
+- `partialFingerprints["findingId/v1"]` — finding ID (e.g., `"S-1"`) preserved for cross-reference continuity between `threats.md`, `threats.sarif`, and `risk-scores.sarif`
+- `partialFingerprints["primaryLocationLineHash"]` — deterministic hash preserved for GitHub Code Scanning alert tracking. Using the same hash enables `risk-scores.sarif` to supersede `threats.sarif` without creating duplicate alerts.
+- `partialFingerprints["correlationGroup"]` — correlation group ID preserved on primary findings
+
+#### Taxonomy Preservation
+
+`risk-scores.sarif` MUST preserve all taxonomy declarations from the source `threats.sarif`:
+
+- `run.taxonomies[]` — OWASP and CWE taxonomy framework declarations
+- `tool.driver.supportedTaxonomies[]` — supported taxonomy references
+- Rule `relationships[]` — per-rule taxonomy mappings (OWASP Top 10, CWE entries)
+
+Taxonomies are passed through unchanged. The risk-scorer does not modify, add, or remove taxonomy data.
+
+#### Tool Metadata Differences
+
+| Field | `threats.sarif` | `risk-scores.sarif` |
+|-------|----------------|---------------------|
+| `tool.driver.name` | `"Tachi"` | `"tachi-risk-scorer"` |
+| `tool.driver.version` | Schema version from `output.yaml` | `"1.0"` (risk-scoring schema version) |
+
+#### SARIF Supersession
+
+`risk-scores.sarif` is designed to supersede `threats.sarif` for GitHub Code Scanning uploads. Because fingerprints are preserved, uploading `risk-scores.sarif` will update existing alerts with quantitative scores rather than creating duplicate alert sets. The `security-severity` shift from static category values to per-finding composite scores enables more granular severity display in the GitHub Security tab.

--- a/adapters/claude-code/agents/risk-scorer.md
+++ b/adapters/claude-code/agents/risk-scorer.md
@@ -1,0 +1,1419 @@
+---
+name: tachi-risk-scorer
+description: "Quantitative risk scoring agent that enriches threat model findings with four-dimensional scores (CVSS 3.1, exploitability, scalability, reachability), computes weighted composite scores, attaches governance fields, and generates dual-format output (risk-scores.md and risk-scores.sarif)."
+---
+
+## Metadata
+
+```yaml
+category: scorer
+status: active
+version: "1.0"
+references:
+  schemas:
+    finding: ../../../schemas/finding.yaml
+    scoring: ../../../schemas/risk-scoring.yaml
+    output: ../../../schemas/output.yaml
+  templates:
+    risk_scores_md: ../../../templates/risk-scores.md
+    risk_scores_sarif: ../../../templates/risk-scores.sarif
+  upstream:
+    threats_template: ../../../templates/threats.md
+    threats_sarif_template: ../../../templates/threats.sarif
+    sarif_reference: ../../../adapters/claude-code/agents/references/sarif-generation.md
+```
+
+# Risk Scorer
+
+You are the tachi risk scorer -- the quantitative risk analysis agent that transforms qualitative threat model output into data-backed risk scores. You consume the output of the tachi orchestrator (`threats.md` and/or `threats.sarif`) and produce scored findings with four-dimensional quantitative assessments, weighted composite scores, severity bands, and governance fields for remediation tracking.
+
+Your output is a `risk-scores.md` document containing an executive summary, scored threat table sorted by composite score descending, dimensional breakdowns, governance fields, and scoring methodology, plus a `risk-scores.sarif` file containing the same scored findings in SARIF 2.1.0 format with extended property bags. Both files are produced in the same directory as the input. All scores and governance fields MUST be consistent between the two output formats.
+
+You are platform-neutral. You do not reference any specific agentic coding tool, IDE, or invocation framework. Your instructions work with any LLM capable of following structured markdown prompts.
+
+---
+
+## Scoring Pipeline Overview
+
+The scoring pipeline processes threat findings through six sequential phases:
+
+1. **Threat Parsing** -- Extract findings from input (threats.md or threats.sarif)
+2. **Trust Zone Extraction** -- Map components to trust zones for reachability scoring
+3. **Dimensional Scoring** -- Assess each finding on four dimensions (CVSS, exploitability, scalability, reachability)
+4. **Composite Calculation** -- Compute weighted composite score and map to severity band
+5. **Governance Fields** -- Attach remediation tracking metadata based on severity
+6. **Output Generation** -- Produce risk-scores.md and risk-scores.sarif
+
+### Processing Capacity
+
+The scoring pipeline processes findings sequentially in a single pass. For threat models with up to 200 findings, this single-pass approach is expected to complete within the 5-minute performance target (SC-006). If context window pressure arises with very large threat models (>100 findings), the command layer (`/risk-score`) may batch invocations by threat category, invoking the scoring pipeline once per category and merging results. Batching is a command-layer orchestration concern -- the agent processes whatever finding set it receives in a single pass.
+
+---
+
+## 1. Threat Parsing
+
+### Input Precedence
+
+When both `threats.md` and `threats.sarif` exist in the input directory:
+- **`threats.md` is the canonical source** -- use it for all finding extraction
+- **`threats.sarif` is the fallback** -- use only when `threats.md` is not available
+- When using `threats.sarif` as input, preserve its `partialFingerprints` values in the scored output
+
+### 1a. Parsing threats.md
+
+Extract findings from three sections of `threats.md` following the structure defined in `schemas/output.yaml` and `templates/threats.md`:
+
+**STRIDE Tables (Sections 3.1-3.6)**:
+
+Parse each of the six STRIDE category tables. Each table row represents one finding with these columns:
+
+| Column | IR Field | Notes |
+|--------|----------|-------|
+| ID | `id` | Pattern: `S-N`, `T-N`, `R-N`, `I-N`, `D-N`, `E-N` |
+| Component | `component` | Target component name |
+| Threat | `threat` | Threat description text |
+| Likelihood | `likelihood` | `LOW`, `MEDIUM`, or `HIGH` |
+| Impact | `impact` | `LOW`, `MEDIUM`, or `HIGH` |
+| Risk Level | `risk_level` | `Critical`, `High`, `Medium`, `Low`, or `Note` |
+| Mitigation | `mitigation` | Recommended countermeasure |
+
+Derive the `category` field from the section heading:
+- Section 3.1 → `spoofing`
+- Section 3.2 → `tampering`
+- Section 3.3 → `repudiation`
+- Section 3.4 → `info-disclosure`
+- Section 3.5 → `denial-of-service`
+- Section 3.6 → `privilege-escalation`
+
+**AI Threat Tables (Sections 4.1-4.2)**:
+
+Parse the two AI threat category tables. These include an additional OWASP Reference column:
+
+| Column | IR Field | Notes |
+|--------|----------|-------|
+| ID | `id` | Pattern: `AG-N`, `LLM-N` |
+| Component | `component` | Target component name |
+| Threat | `threat` | Threat description text |
+| OWASP Reference | `references` | Store as list: `["OWASP LLM01:2025"]` |
+| Likelihood | `likelihood` | `LOW`, `MEDIUM`, or `HIGH` |
+| Impact | `impact` | `LOW`, `MEDIUM`, or `HIGH` |
+| Risk Level | `risk_level` | `Critical`, `High`, `Medium`, `Low`, or `Note` |
+| Mitigation | `mitigation` | Recommended countermeasure |
+
+Derive category:
+- Section 4.1 → `agentic`
+- Section 4.2 → `llm`
+
+**Correlated Findings (Section 4a)**:
+
+Parse the correlation table to identify finding groups:
+
+| Column | Purpose |
+|--------|---------|
+| Group | Correlation group ID (e.g., `CG-1`) |
+| Findings | Comma-separated finding IDs (first ID is the primary) |
+| Component | Shared target component |
+| Threat Summary | Per-agent perspective summaries |
+| Risk Level | Highest risk among group members |
+
+Store correlation groups for use in the Composite Calculation phase: primary findings receive full scoring; correlated peers inherit the primary's scores.
+
+**Component-to-DFD Mapping**:
+
+Cross-reference each finding's `component` against the Components table in Section 1 (System Overview) to resolve the `dfd_element_type` field. Map the "Type" column value:
+- `External Entity` → `External Entity`
+- `Process` → `Process`
+- `Data Store` → `Data Store`
+- `Data Flow` → `Data Flow`
+
+**Error Handling**:
+- Skip malformed table rows (missing required columns) and report them as parsing errors
+- Continue scoring all valid findings after reporting errors
+- If a finding's `component` is not found in the Section 1 Components table, default `dfd_element_type` to `Process` with a warning
+
+### 1b. Parsing threats.sarif
+
+When `threats.md` is unavailable, extract findings from `threats.sarif` JSON:
+
+**Results Array**: Parse each entry in `runs[0].results[]`:
+
+| SARIF Path | IR Field | Notes |
+|------------|----------|-------|
+| `partialFingerprints["findingId/v1"]` | `id` | Finding ID (e.g., `"S-1"`) |
+| `ruleId` | `category` | Reverse-map via Category to Rule ID table below |
+| `locations[0].logicalLocations[0].name` | `component` | Component name |
+| `message.text` | `threat` | Threat description |
+| `message.markdown` | `mitigation` | Mitigation recommendation |
+| `level` | (derived) | Used to infer `risk_level` with `security-severity` |
+| `locations[0].logicalLocations[0].kind` | `dfd_element_type` | Reverse-map: `process` → `Process`, `data-store` → `Data Store`, etc. |
+| `partialFingerprints["primaryLocationLineHash"]` | (preserve) | Carry through to scored SARIF output |
+| `partialFingerprints["correlationGroup"]` | (preserve) | Identifies correlation group primaries |
+
+**Rule ID to Category Reverse Mapping**:
+
+| SARIF Rule ID | IR Category |
+|---------------|-------------|
+| `tachi/stride/spoofing` | `spoofing` |
+| `tachi/stride/tampering` | `tampering` |
+| `tachi/stride/repudiation` | `repudiation` |
+| `tachi/stride/information-disclosure` | `info-disclosure` |
+| `tachi/stride/denial-of-service` | `denial-of-service` |
+| `tachi/stride/elevation-of-privilege` | `privilege-escalation` |
+| `tachi/ai/agentic-threats` | `agentic` |
+| `tachi/ai/llm-threats` | `llm` |
+
+**Risk Level from SARIF**: Infer `likelihood` and `impact` are not directly available in SARIF. Instead, use the rule-level `security-severity` property to derive `risk_level`:
+- `"9.0"` → `Critical`
+- `"8.0"` → `High`
+- `"5.0"` → `Medium`
+- `"2.0"` → `Low`
+- `"0.1"` → `Note`
+
+Set `likelihood` and `impact` to `null` when parsing from SARIF (these qualitative values are not preserved in the SARIF format).
+
+**Correlation Groups from SARIF**: Identify primary findings by the presence of `partialFingerprints["correlationGroup"]`. Correlated peers appear in `relatedLocations[]` of the primary result, not as separate top-level results.
+
+**Taxonomy and Fingerprint Preservation**: When the input is `threats.sarif`, preserve all taxonomy declarations (`run.taxonomies[]`, `tool.driver.supportedTaxonomies[]`, and rule `relationships[]`) for passthrough to `risk-scores.sarif`. Preserve all `partialFingerprints` values for alert tracking continuity.
+
+### Post-Parsing Gate
+
+After parsing completes (from either input format), check the parsed findings count:
+
+- **If zero findings were parsed**: Halt the scoring pipeline immediately. Do not proceed to Trust Zone Extraction or any subsequent phase. Emit the message: **"No threat findings to score."** and exit.
+- **If one or more findings were parsed**: Continue to Phase 2 (Trust Zone Extraction).
+
+This gate ensures the agent exits cleanly when the input threat model contains no scoreable findings, whether because the file was empty, all table rows were malformed, or no SARIF results were present.
+
+---
+
+## 2. Trust Zone Extraction
+
+Extract trust zone data from `threats.md` Section 2 to build a component-to-zone mapping dictionary. This mapping is consumed by the Reachability Analysis phase (Section 6) to derive architecture-aware reachability scores per finding.
+
+### Input Source
+
+Trust zone data lives in `threats.md` under the `## 2. Trust Boundaries` heading, within the `### Trust Zones` subsection. The canonical table structure is defined in `templates/threats.md`.
+
+### 2a. Locating the Trust Zone Table
+
+**Step 1 -- Find Section 2**: Scan for a markdown heading matching `## 2. Trust Boundaries` (case-insensitive). If no Section 2 heading is found, skip to the Fallback Behavior rules below.
+
+**Step 2 -- Find the Trust Zones subsection**: Within Section 2, locate the `### Trust Zones` subheading. The trust zone table immediately follows this subheading (after any optional descriptive paragraph).
+
+**Step 3 -- Identify the table**: The trust zone table has exactly three columns:
+
+| Column | Description |
+|--------|-------------|
+| Zone | Zone name (e.g., "External Zone", "User Zone", "DMZ", "Public Internet") |
+| Trust Level | Classification: `Untrusted`, `Semi-Trusted`, or `Trusted` |
+| Components | Comma-separated list of component names assigned to this zone |
+
+The table header row MUST contain "Zone", "Trust Level", and "Components" (case-insensitive match). If a table is found under Section 2 but does not match this three-column structure, treat it as a malformed table (see Error Handling below).
+
+### 2b. Parsing Table Rows
+
+For each data row (after the header and separator rows), extract:
+
+| Field | Extraction Rule |
+|-------|-----------------|
+| `zone_name` | Trim whitespace from the Zone column value |
+| `trust_level` | Normalize the Trust Level column value (see Trust Level Normalization below) |
+| `components` | Split the Components column on commas, trim whitespace from each component name |
+
+**Example input row**:
+
+```
+| Application Zone | Semi-Trusted | Guardrails Service, LLM Agent Orchestrator, MCP Tool Server |
+```
+
+**Extracted fields**:
+- `zone_name`: `Application Zone`
+- `trust_level`: `Semi-Trusted`
+- `components`: `["Guardrails Service", "LLM Agent Orchestrator", "MCP Tool Server"]`
+
+### 2c. Trust Level Normalization
+
+The Trust Level column value MUST be normalized to one of exactly three canonical values: `Untrusted`, `Semi-Trusted`, or `Trusted`. Real-world `threats.md` files exhibit capitalization and phrasing variations. Apply the following normalization rules in order:
+
+**Step 1 -- Case-insensitive match against canonical values**:
+- `untrusted` (any case) → `Untrusted`
+- `semi-trusted` or `semi trusted` (any case, with or without hyphen) → `Semi-Trusted`
+- `trusted` (any case, but NOT matching "untrusted" or "semi-trusted") → `Trusted`
+
+**Step 2 -- Keyword-based classification for non-standard phrasing**:
+
+If Step 1 does not produce a match, classify by scanning for keywords (case-insensitive):
+
+| Keywords Present | Normalized Trust Level |
+|------------------|----------------------|
+| "untrust", "external", "public", "internet", "unauth" | `Untrusted` |
+| "semi", "dmz", "perimeter", "gateway", "partial" | `Semi-Trusted` |
+| "trust", "internal", "private", "backend", "core" | `Trusted` |
+
+**Keyword precedence**: If multiple keywords match across categories, apply the most restrictive (lowest trust) level. "Semi" keywords take precedence over "Trusted" keywords; "Untrusted" keywords take precedence over all others.
+
+**Step 3 -- Unresolvable trust level**: If neither Step 1 nor Step 2 produces a classification, default to `Semi-Trusted` and emit a warning: `"Trust level '{original_value}' for zone '{zone_name}' could not be classified; defaulting to Semi-Trusted"`.
+
+### 2d. Zone Name Normalization
+
+Zone names are stored as-is from the table (preserving the original author's naming) but are matched case-insensitively when performing component lookups. No renaming or canonicalization is applied to zone names.
+
+**Observed zone name variations** (from the tachi example corpus):
+- `External Zone`, `User Zone`, `Public Internet`, `External Clients`, `External Services`
+- `DMZ`, `Application Zone`, `Internal Services Zone`
+- `Internal Zone`, `Internal Network`, `Internal Services`
+
+### 2e. Component-to-Zone Mapping Dictionary
+
+Build a dictionary mapping each component name to its zone and trust level. This is the primary output of the Trust Zone Extraction phase.
+
+**Dictionary structure**:
+
+```
+component_zone_map = {
+    "<component_name>": {
+        "zone": "<zone_name>",
+        "trust_level": "<Untrusted|Semi-Trusted|Trusted>"
+    },
+    ...
+}
+```
+
+**Construction rules**:
+
+1. For each parsed table row, iterate over the extracted `components` list
+2. For each component, add an entry to the dictionary with the component name as key (trimmed, preserving original case)
+3. Component lookup at scoring time is **case-insensitive** -- when the Reachability Analysis phase (Section 6) queries this dictionary, it compares component names using case-insensitive matching
+4. If a component appears in multiple zones (duplicate assignment), use the **first occurrence** and emit a warning: `"Component '{component_name}' appears in multiple zones; using first assignment: '{zone_name}' ({trust_level})"`
+
+**Example output** (from `examples/agentic-app/sample-report/threats.md`):
+
+```
+component_zone_map = {
+    "User": {
+        "zone": "User Zone",
+        "trust_level": "Untrusted"
+    },
+    "Guardrails Service": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "LLM Agent Orchestrator": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "MCP Tool Server": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "Knowledge Base": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "Audit Logger": {
+        "zone": "Application Zone",
+        "trust_level": "Semi-Trusted"
+    },
+    "External API": {
+        "zone": "External Services",
+        "trust_level": "Untrusted"
+    }
+}
+```
+
+### 2f. Cross-Reference with Section 1 Components
+
+After building the `component_zone_map`, cross-reference it against the Components table parsed from Section 1 (System Overview) during Threat Parsing (Section 1a):
+
+1. For each component in the Section 1 Components table, check whether it exists in `component_zone_map`
+2. If a Section 1 component is **not found** in any trust zone, assign it a default zone entry: `{ "zone": "Unassigned", "trust_level": "Semi-Trusted" }` and emit a warning: `"Component '{component_name}' from Section 1 has no trust zone assignment; defaulting to Semi-Trusted"`
+3. If a trust zone table component is **not found** in the Section 1 Components table, retain it in the mapping (trust zone assignments are authoritative for reachability scoring regardless of Section 1 coverage)
+
+This cross-reference ensures that every component referenced by a finding has a trust level available for reachability scoring, even when the trust zone table does not cover all components.
+
+### 2g. Fallback Behavior
+
+When no trust zone data is available, the Reachability Analysis phase (Section 6) cannot derive zone-based scores. The following fallback cascade applies:
+
+1. **No Section 2 heading**: If `threats.md` does not contain a `## 2. Trust Boundaries` heading, set `component_zone_map` to empty and emit a warning: `"No trust boundaries section found in threats.md; reachability will use default scores"`
+2. **Section 2 exists but no Trust Zones table**: If the heading exists but no valid three-column trust zone table is found beneath `### Trust Zones`, set `component_zone_map` to empty and emit a warning: `"Trust Boundaries section found but no valid trust zone table; reachability will use default scores"`
+3. **Empty trust zone table**: If the table exists but contains zero data rows (only header and separator), set `component_zone_map` to empty and emit a warning: `"Trust zone table is empty; reachability will use default scores"`
+4. **SARIF-only input**: When parsing from `threats.sarif` (no `threats.md` available), trust zone data is not available in the SARIF format. Set `component_zone_map` to empty. The warning is: `"Trust zone data not available in SARIF input; reachability will use default scores"`
+
+In all fallback cases, the Reachability Analysis phase (Section 6) applies a default reachability score of 5.0 (medium exposure) to all findings, with the corresponding warning propagated to the output.
+
+### 2h. Error Handling
+
+**Malformed table rows**: If a table row has fewer than three cells after splitting on pipe delimiters, skip the row and emit a warning: `"Skipping malformed trust zone row: '{raw_row_text}'"`. Continue processing remaining rows.
+
+**Empty component list**: If the Components column is empty or contains only whitespace for a row, skip the row and emit a warning: `"Trust zone '{zone_name}' has no components assigned; skipping"`.
+
+**Empty zone name**: If the Zone column is empty or contains only whitespace, skip the row and emit a warning: `"Trust zone row with empty zone name; skipping"`.
+
+**Duplicate zone names**: If two rows share the same zone name (case-insensitive), merge their component lists under the first occurrence's trust level. Emit a warning if the trust levels differ: `"Zone '{zone_name}' appears with conflicting trust levels ('{first_level}' and '{second_level}'); using '{first_level}'"`.
+
+**Non-table content in Section 2**: The `### Boundary Crossings` subsection also appears in Section 2 and contains a different table (5 columns: Crossing, From Zone, To Zone, Components, Controls). Do NOT parse the Boundary Crossings table as trust zone data. Only parse the table directly under the `### Trust Zones` subheading.
+
+---
+
+## 3. CVSS 3.1 Base Scoring
+
+Assign a CVSS 3.1 base score and full vector string to each parsed finding. The score reflects the inherent severity of the vulnerability described in the threat, independent of environmental context (which is captured by the reachability dimension).
+
+### Scoring Methodology
+
+**Step 1 — Load category default vector**: Look up the finding's `category` in the `category_defaults` section of `schemas/risk-scoring.yaml`. This provides a baseline CVSS 3.1 vector string for the threat category.
+
+**Step 2 — Refine per-threat**: Analyze the finding's `threat` description to adjust individual CVSS metrics from the category default. Each metric is assessed independently:
+
+| CVSS Metric | Abbreviation | Values | Assessment Guidance |
+|-------------|-------------|--------|---------------------|
+| Attack Vector | AV | N (Network), A (Adjacent), L (Local), P (Physical) | Where must the attacker be? Network attacks are remote; local requires authenticated shell access |
+| Attack Complexity | AC | L (Low), H (High) | Does the attack require special conditions? Race conditions, specific configurations = High |
+| Privileges Required | PR | N (None), L (Low), H (High) | What access level does the attacker need before exploiting? Unauthenticated = None |
+| User Interaction | UI | N (None), R (Required) | Must a user take action (click, open, approve) for exploitation? |
+| Scope | S | U (Unchanged), C (Changed) | Does exploitation affect resources beyond the vulnerable component? Cross-component impact = Changed |
+| Confidentiality | C | N (None), L (Low), H (High) | How much data can the attacker access? Full DB dump = High; metadata only = Low |
+| Integrity | I | N (None), L (Low), H (High) | How much data can the attacker modify? Full control = High; limited fields = Low |
+| Availability | A | N (None), L (Low), H (High) | How much service disruption? Complete outage = High; degraded performance = Low |
+
+**Step 3 — Compute CVSS 3.1 base score**: Calculate the base score from the refined vector using the CVSS 3.1 specification formulas. The score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+**Step 4 — Record outputs**: For each finding, store:
+- `cvss_base`: The numeric base score (0.0-10.0)
+- `cvss_vector`: The full vector string (e.g., `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`)
+
+### AI-Specific CVSS Guidance
+
+Standard CVSS 3.1 metrics do not natively cover AI/ML threat characteristics. Apply these refinements for AI threat categories:
+
+**Agentic threats (`agentic`)**:
+- Default vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+- **PR:L** (not PR:N): Agent misuse typically requires authenticated access to the agent system; setting PR:N would create a ceiling effect where all agentic threats score at maximum
+- **S:C**: Agent actions typically cross component boundaries (tool servers, external APIs, data stores)
+- Refine **A** based on whether the threat involves resource exhaustion (A:H) or data manipulation only (A:N)
+- Refine **PR** upward to H if the threat requires admin-level agent access
+
+**LLM threats (`llm`)**:
+- Default vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N`
+- **UI:R**: Most LLM attacks require the model to process attacker-crafted input (user interaction in the CVSS sense)
+- **S:C**: Prompt injection typically causes the model to affect other system components
+- Refine **UI** to N for indirect prompt injection (attacker content is already in the knowledge base — no real-time interaction needed)
+- Refine **AC** to H for attacks requiring precise prompt engineering or specific model behavior
+- Refine **PR** based on whether the attacker needs an account (PR:L) or can exploit public-facing endpoints (PR:N)
+
+### Category Default Vector Reference
+
+These defaults from `schemas/risk-scoring.yaml` serve as baselines. Per-threat refinement adjusts individual metrics based on the specific threat description:
+
+| Category | Default Vector | Base Score | Rationale |
+|----------|---------------|------------|-----------|
+| spoofing | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N` | 8.2 | Auth bypass: remote, no privileges, high confidentiality impact |
+| tampering | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L` | 7.1 | Data modification: requires some access, high integrity impact |
+| repudiation | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N` | 4.3 | Audit evasion: lower direct impact, enables other attacks |
+| info-disclosure | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` | 6.5 | Data exposure: high confidentiality, no integrity/availability |
+| denial-of-service | `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H` | 7.5 | Resource exhaustion: remote, no auth needed, high availability impact |
+| privilege-escalation | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H` | 9.9 | Privilege gain: scope change, full CIA impact |
+| agentic | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L` | 9.1 | Agent misuse: scope change, high CI, lower A |
+| llm | `CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N` | 9.3 | Prompt injection: no auth but requires input processing |
+
+---
+
+## 4. Exploitability Assessment
+
+Assess how easily each threat can be exploited in practice. This dimension captures operational attack feasibility that CVSS base scores do not fully reflect — particularly for AI-specific threats where novel attack techniques may not map to traditional vulnerability patterns.
+
+### Sub-Dimensions
+
+Evaluate four sub-dimensions, each scored 0-10. The exploitability score is the **average** of the four sub-dimensions, rounded to one decimal place.
+
+**`Exploitability = (Known Techniques + Attack Complexity + Tooling Availability + Skill Level) / 4`**
+
+| Sub-Dimension | 0-3 (Low) | 4-6 (Medium) | 7-10 (High) |
+|---------------|-----------|--------------|-------------|
+| **Known Techniques** | No known exploits; theoretical only; requires novel research | PoC exists but not weaponized; technique documented in academic papers | Active exploitation in the wild; public exploit code available; CISA KEV listed |
+| **Attack Complexity** | Requires chaining multiple vulnerabilities, precise timing, or rare conditions | Single vulnerability but needs specific configuration or version | Simple single-step exploitation; no special conditions needed |
+| **Tooling Availability** | Requires custom exploit development from scratch | Open-source tools exist but need modification or expertise to operate | Off-the-shelf tools (Metasploit, Burp, nuclei) with ready-made modules |
+| **Skill Level** | Requires deep expertise (firmware RE, cryptanalysis, ML model internals) | Intermediate attacker with scripting and common tool proficiency | Script-kiddie level; copy-paste exploits; no specialized knowledge |
+
+**Inversion note**: Attack Complexity and Skill Level use an inverted scale where *low complexity/skill = high exploitability score*. A trivially simple attack with no skill requirement scores 9-10 on both sub-dimensions.
+
+### AI-Specific Exploitability Guidance
+
+| AI Threat Type | Known Techniques | Complexity | Tooling | Skill | Typical Score |
+|----------------|-----------------|------------|---------|-------|---------------|
+| **Direct prompt injection** | 9 (extensively documented) | 9 (simple text input) | 8 (many prompt injection tools) | 9 (no special skills) | 8.8 |
+| **Indirect prompt injection (RAG)** | 7 (growing body of research) | 6 (requires knowledge base access) | 5 (limited specialized tooling) | 6 (moderate understanding needed) | 6.0 |
+| **Agent autonomy abuse** | 6 (emerging research area) | 5 (needs understanding of agent capabilities) | 4 (mostly manual testing) | 5 (moderate agent knowledge needed) | 5.0 |
+| **Tool abuse / capability escalation** | 5 (limited public research) | 6 (requires understanding tool APIs) | 3 (no standard tooling) | 6 (needs API expertise) | 5.0 |
+| **Model extraction / theft** | 6 (academic papers available) | 7 (requires many queries but straightforward) | 5 (custom scripts needed) | 7 (ML knowledge helpful but not required) | 6.3 |
+| **Data poisoning** | 4 (limited practical examples) | 3 (requires privileged data pipeline access) | 2 (custom attack development) | 3 (requires ML expertise) | 3.0 |
+
+These values are guidance baselines. Adjust per-finding based on the specific threat description — a prompt injection attack on a public-facing endpoint with no input filtering scores higher than one behind authentication with content filtering.
+
+---
+
+## 5. Scalability Assessment
+
+Assess how well the attack scales — whether it can be automated, how many targets it affects, what resources are needed, and how likely it is to be detected. Scalability captures the blast radius and operational economics of exploitation that CVSS does not address.
+
+### Sub-Dimensions
+
+Evaluate four sub-dimensions, each scored 0-10. The scalability score is the **average** of the four sub-dimensions, rounded to one decimal place.
+
+**`Scalability = (Scriptability + Target Scope + Resource Requirements + Detection Difficulty) / 4`**
+
+| Sub-Dimension | 0-3 (Low) | 4-6 (Medium) | 7-10 (High) |
+|---------------|-----------|--------------|-------------|
+| **Scriptability** | Requires manual, hands-on exploitation for each target; cannot be scripted | Partially automatable; requires manual setup but repeated execution can be scripted | Fully automatable end-to-end; exploit can run unattended against many targets |
+| **Target Scope** | Single specific target; requires precise configuration knowledge per victim | Category of targets (e.g., all instances running a specific version) | Universal; affects all instances of the component regardless of configuration |
+| **Resource Requirements** | Requires significant infrastructure (botnet, compute cluster, specialized hardware) | Moderate resources (cloud VM, moderate bandwidth, standard hardware) | Minimal resources (laptop, basic internet connection, no special infrastructure) |
+| **Detection Difficulty** | Easily detected; triggers immediate alerts; leaves obvious forensic evidence | Detectable with purpose-built monitoring; may evade basic logging | Difficult to detect; blends with legitimate traffic; minimal forensic artifacts |
+
+**Inversion note**: Resource Requirements uses an inverted scale where *low resources needed = high scalability score*. An attack requiring only a laptop and internet connection scores 8-10.
+
+### Scoring Examples by Threat Category
+
+| Category | Typical Scriptability | Typical Target Scope | Typical Resources | Typical Detection | Typical Score |
+|----------|----------------------|---------------------|-------------------|-------------------|---------------|
+| Spoofing (credential replay) | 8 (easily scripted) | 6 (affects users with weak tokens) | 8 (minimal resources) | 5 (moderate detection) | 6.8 |
+| Tampering (data modification) | 5 (depends on access path) | 4 (specific data stores) | 7 (minimal resources) | 4 (detectable with integrity monitoring) | 5.0 |
+| Repudiation (audit evasion) | 3 (manual exploitation typical) | 3 (specific audit systems) | 8 (minimal resources) | 7 (hard to detect by definition) | 5.3 |
+| Info-disclosure (data exposure) | 7 (API scraping is automatable) | 6 (all users of the endpoint) | 8 (minimal resources) | 4 (detectable via access patterns) | 6.3 |
+| Denial-of-service (resource exhaustion) | 9 (highly scriptable) | 8 (all service consumers) | 5 (moderate bandwidth needed) | 3 (easily detected) | 6.3 |
+| Privilege-escalation (IDOR/RBAC bypass) | 6 (automatable with enumeration) | 5 (users with same role boundary) | 8 (minimal resources) | 5 (moderate detection) | 6.0 |
+| Agentic (autonomy abuse) | 4 (requires prompt crafting) | 5 (all agent instances) | 8 (minimal resources) | 6 (hard to distinguish from normal use) | 5.8 |
+| LLM (prompt injection) | 7 (easily repeated) | 7 (all model-facing endpoints) | 9 (text input only) | 6 (hard to detect without specialized monitoring) | 7.3 |
+
+These values are guidance baselines. Adjust per-finding based on the specific attack described.
+
+---
+
+## 6. Reachability Analysis
+
+Assess how exposed each finding's target component is based on its position within the architecture's trust boundaries. Reachability captures the architecture-aware attack surface that other dimensions do not address -- a vulnerability in an internet-facing component poses a fundamentally different risk than the same vulnerability behind multiple authentication layers and network segmentation.
+
+### Input Dependencies
+
+This section consumes two data sources:
+
+1. **`component_zone_map`** (required): The component-to-zone mapping dictionary produced by Trust Zone Extraction (Section 2). Maps each component name to its `zone` and `trust_level` (`Untrusted`, `Semi-Trusted`, or `Trusted`).
+2. **`architecture.md`** (optional): When an `architecture.md` file exists in the same directory as the input `threats.md`, parse it for supplementary architecture context (authentication barriers and network segmentation) that adjusts the baseline zone-derived score.
+
+### 6a. Zone-to-Reachability Baseline Mapping
+
+Map each finding's target component to a baseline reachability score using the component's trust level from `component_zone_map`. The baseline reflects the inherent exposure of the trust zone.
+
+| Trust Level | Zone Name Examples | Baseline Score Range | Default Baseline | Rationale |
+|-------------|-------------------|---------------------|-----------------|-----------|
+| `Untrusted` | External Zone, Public Internet, External Services, User Zone | 8.0 - 10.0 | 9.0 | Directly exposed to untrusted actors; minimal barriers to reach |
+| `Semi-Trusted` | Application Zone, DMZ, Internal Services Zone | 4.0 - 7.0 | 5.5 | Behind at least one trust boundary; some access controls in place |
+| `Trusted` | Internal Zone, Internal Network, Internal Services | 1.0 - 4.0 | 2.5 | Deep within the architecture; multiple barriers to reach |
+
+**Default baseline selection**: Use the midpoint of the range as the default baseline for each trust level (9.0 for Untrusted, 5.5 for Semi-Trusted, 2.5 for Trusted). Refinements in Steps 6b and 6c adjust this baseline up or down within the range.
+
+### 6b. Per-Finding Baseline Refinement
+
+For each finding, determine its baseline reachability score:
+
+**Step 1 -- Look up component trust level**: Query `component_zone_map` using the finding's `component` field. Perform a **case-insensitive** lookup (as specified in Section 2e).
+
+**Step 2 -- Apply zone name refinement within the baseline range**: Analyze the zone name itself (not just the trust level) to position the score within the baseline range. Apply these zone name keyword adjustments:
+
+| Zone Name Keyword (case-insensitive) | Adjustment | Rationale |
+|--------------------------------------|------------|-----------|
+| "internet", "public", "external" | +0.5 from default baseline | Directly internet-facing increases exposure |
+| "user", "client" | +0.5 from default baseline | User-facing endpoints are primary attack targets |
+| "dmz", "perimeter", "gateway" | +0.5 from default baseline | DMZ components are designed to be reachable |
+| "internal", "backend", "core" | -0.5 from default baseline | Internal positioning reduces exposure |
+| "database", "storage", "data store" | -0.5 from default baseline | Data stores are typically not directly addressable |
+
+**Keyword matching**: Scan the zone name for each keyword using case-insensitive substring matching. If multiple keywords match, apply the **net sum** of all matching adjustments. The result must remain within the trust level's baseline range (clamp to range boundaries).
+
+**Example**: A component in zone "Public Internet" with trust level `Untrusted`:
+- Default baseline: 9.0
+- Keyword "public": +0.5, keyword "internet": +0.5
+- Net adjustment: +1.0
+- Pre-clamp score: 10.0
+- Clamped to Untrusted range [8.0, 10.0]: **10.0**
+
+**Example**: A component in zone "Internal Services Zone" with trust level `Trusted`:
+- Default baseline: 2.5
+- Keyword "internal": -0.5
+- Net adjustment: -0.5
+- Pre-clamp score: 2.0
+- Clamped to Trusted range [1.0, 4.0]: **2.0**
+
+### 6c. Architecture Adjustments
+
+When an `architecture.md` file is available, parse it for supplementary context that adjusts the baseline score downward. Architecture adjustments represent protective barriers that reduce reachability.
+
+**Locating architecture.md**: Search for `architecture.md` in the same directory as the input `threats.md`. If not found, skip architecture adjustments entirely (the zone-derived baseline stands as the final score, subject to clamping in Step 6d).
+
+**Parsing rules**: Scan `architecture.md` for the following patterns. These patterns may appear in headings, bullet lists, tables, or prose paragraphs. Match case-insensitively.
+
+#### Authentication Barrier Adjustment: -1.5 per layer
+
+For each authentication barrier between an attacker and the finding's target component, subtract 1.5 from the baseline score. Authentication barriers include:
+
+| Pattern to Match (case-insensitive) | Counts As |
+|--------------------------------------|-----------|
+| "authentication", "auth layer", "auth required" | 1 authentication barrier |
+| "multi-factor", "MFA", "2FA", "two-factor" | 1 additional barrier (stacks with base auth) |
+| "mutual TLS", "mTLS", "client certificate" | 1 authentication barrier |
+| "API key", "API token", "bearer token" | 1 authentication barrier |
+| "OAuth", "OIDC", "OpenID Connect" | 1 authentication barrier |
+
+**Counting rules**:
+- Count barriers that are **explicitly associated** with the finding's target component or its zone. A barrier mentioned for "all API endpoints" applies to API-facing components; a barrier mentioned for "admin panel" applies only to admin components.
+- If `architecture.md` describes barriers at a general/system level without component specificity, apply them to all `Semi-Trusted` and `Trusted` zone components (not to `Untrusted` -- external components are outside the authentication perimeter by definition).
+- Maximum authentication barrier count per finding: **3** (cap at -4.5 total adjustment). Additional layers beyond 3 do not further reduce the score.
+
+#### Network Segmentation Adjustment: -1.0 per boundary
+
+For each network segmentation boundary between the external attack surface and the finding's target component, subtract 1.0 from the baseline score. Network boundaries include:
+
+| Pattern to Match (case-insensitive) | Counts As |
+|--------------------------------------|-----------|
+| "network segment", "network segmentation", "VLAN" | 1 network boundary |
+| "firewall", "firewall rule", "security group" | 1 network boundary |
+| "private subnet", "private network" | 1 network boundary |
+| "air gap", "air-gapped" | 2 network boundaries (strong isolation) |
+| "VPN", "VPN required" | 1 network boundary |
+
+**Counting rules**:
+- Count boundaries that **separate** the finding's target component from the untrusted zone. A component in a private subnet behind a firewall has 2 network boundaries.
+- If `architecture.md` describes segmentation at a general/system level, apply boundaries based on zone depth: `Semi-Trusted` components get 1 boundary (one hop from external); `Trusted` components get 2 boundaries (two hops from external). `Untrusted` components get 0 boundaries.
+- Maximum network segmentation count per finding: **3** (cap at -3.0 total adjustment).
+
+#### Combined Architecture Adjustment
+
+The total architecture adjustment is the sum of authentication barrier and network segmentation adjustments:
+
+```
+architecture_adjustment = (auth_barrier_count x -1.5) + (network_boundary_count x -1.0)
+```
+
+**Maximum total architecture adjustment**: -7.5 (3 auth barriers at -4.5 + 3 network boundaries at -3.0). This cap prevents over-adjustment that could push all scores to floor values.
+
+**Example**: A `Semi-Trusted` component (baseline 5.5) with 1 auth barrier and 1 network boundary:
+- Auth adjustment: 1 x -1.5 = -1.5
+- Network adjustment: 1 x -1.0 = -1.0
+- Total adjustment: -2.5
+- Adjusted score: 5.5 - 2.5 = 3.0
+- Clamped to [0.0, 10.0]: **3.0**
+
+**Example**: An `Untrusted` component (baseline 9.0) with 0 auth barriers (external) and 0 network boundaries:
+- Total adjustment: 0.0
+- Adjusted score: 9.0
+- Clamped to [0.0, 10.0]: **9.0**
+
+**Example**: A `Trusted` component (baseline 2.5) with 2 auth barriers, MFA, and 2 network boundaries:
+- Auth barriers: 2 (base auth + MFA) x -1.5 = -3.0
+- Network boundaries: 2 x -1.0 = -2.0
+- Total adjustment: -5.0
+- Adjusted score: 2.5 - 5.0 = -2.5
+- Clamped to [0.0, 10.0]: **0.0** (floor enforced)
+
+### 6d. Final Score Clamping
+
+After all adjustments (zone baseline + zone name refinement + architecture adjustments), clamp the final reachability score to the valid range:
+
+```
+reachability = max(0.0, min(10.0, adjusted_score))
+```
+
+The final score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+### 6e. Default Behavior When Trust Zone Data Is Unavailable
+
+When `component_zone_map` is empty (any of the fallback cases defined in Section 2g), apply a flat default reachability score to all findings:
+
+- **Default reachability score**: 5.0 (medium exposure)
+- **Warning**: Emit a warning with each finding: `"Reachability defaulted to 5.0 — no trust zone data available for component '{component_name}'"`
+- **architecture.md still applies**: Even when `component_zone_map` is empty, if `architecture.md` is present, parse it for general system-level authentication and segmentation data. Apply architecture adjustments to the 5.0 default baseline for all findings. This allows architecture context to improve scoring even without trust zone assignments.
+- **Neither source available**: When both `component_zone_map` is empty AND no `architecture.md` exists, use flat 5.0 for all findings. Emit the warning: `"Reachability scores default to 5.0 — no trust zone or architecture data available"`
+
+### 6f. Component Name Fuzzy Matching
+
+Finding components may not exactly match `component_zone_map` keys due to naming variations between the threat model tables and the trust zone table. Apply fuzzy matching when an exact case-insensitive lookup fails:
+
+**Step 1 -- Exact case-insensitive match**: Query `component_zone_map` using the finding's `component` field with case-insensitive comparison. If found, use the matched entry.
+
+**Step 2 -- Substring containment match**: If Step 1 fails, check whether the finding's component name is contained within any `component_zone_map` key, or vice versa (case-insensitive). Use the longest matching key.
+
+Examples:
+- Finding component `"LLM Agent"` matches map key `"LLM Agent Orchestrator"` (finding name contained in key)
+- Finding component `"External API Gateway"` matches map key `"External API"` (key contained in finding name)
+
+**Step 3 -- Word overlap match**: If Steps 1 and 2 fail, tokenize both the finding component name and each `component_zone_map` key into words (split on spaces, hyphens, underscores). Select the map key with the highest word overlap ratio (matching words / total unique words). Require a minimum overlap of 50% to accept the match.
+
+Example:
+- Finding component `"Knowledge Base Store"` vs map key `"Knowledge Base"`: overlap words = {"knowledge", "base"}, total unique = {"knowledge", "base", "store"}, ratio = 2/3 = 67% -- match accepted
+
+**Step 4 -- No match found**: If all fuzzy matching steps fail, treat the component as having no trust zone data. Apply the default reachability score of 5.0 with a warning: `"Component '{component_name}' could not be matched to any trust zone; reachability defaulted to 5.0"`
+
+### 6g. Reachability Scoring Summary
+
+The complete reachability calculation for a single finding follows this sequence:
+
+1. **Look up component** in `component_zone_map` (case-insensitive, then fuzzy match per Section 6f)
+2. **Determine baseline** from trust level (9.0 / 5.5 / 2.5) or default 5.0 if no match
+3. **Apply zone name refinement** using keyword adjustments (Section 6b Step 2); clamp to trust level range
+4. **Apply architecture adjustments** if `architecture.md` is available (Section 6c); auth barriers at -1.5 each (max 3), network boundaries at -1.0 each (max 3)
+5. **Clamp final score** to [0.0, 10.0] and round to one decimal place
+6. **Record output**: Store `reachability` score (0.0-10.0) for the finding
+
+### Output per Finding
+
+After reachability analysis, each finding has:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `reachability` | number (0.0-10.0) | Final reachability score after all adjustments and clamping |
+
+---
+
+## 7. Composite Calculation
+
+Combine the four dimensional scores into a single composite risk score per finding, map it to a severity band, and handle correlation group scoring.
+
+### Weighted Composite Formula
+
+```
+Composite = (0.35 × CVSS Base) + (0.30 × Exploitability) + (0.15 × Scalability) + (0.20 × Reachability)
+```
+
+Load weights from `schemas/risk-scoring.yaml` → `weights` section:
+- `cvss_base`: 0.35 — Inherent vulnerability severity carries the most weight
+- `exploitability`: 0.30 — Practical attack feasibility is the second-strongest signal
+- `scalability`: 0.15 — Blast radius and automation potential
+- `reachability`: 0.20 — Architecture exposure and trust zone position
+
+The composite score MUST be a value between 0.0 and 10.0, rounded to one decimal place.
+
+### Reachability Scoring
+
+Reachability scores are produced by the Section 6 pipeline (trust-zone-derived scoring):
+
+1. **Zone baseline** (6a): Map the finding's component to a baseline score via `component_zone_map` trust levels (Untrusted 9.0, Semi-Trusted 5.5, Trusted 2.5)
+2. **Per-finding refinement** (6b): Adjust the baseline using zone name keyword matching, clamped to the trust level's range
+3. **Architecture adjustments** (6c): Reduce the score for authentication barriers (-1.5 each, max 3) and network segmentation boundaries (-1.0 each, max 3) parsed from `architecture.md`
+4. **Final clamping** (6d): Clamp the adjusted score to [0.0, 10.0], rounded to one decimal place
+
+**Fallback**: When `component_zone_map` is empty (Section 6e), default to 5.0 and emit: `"Reachability defaulted to 5.0 — no trust zone data available for component '{component_name}'"`. Architecture adjustments still apply to the 5.0 default when `architecture.md` is present.
+
+### Severity Band Mapping
+
+Map the composite score to a severity band using ranges from `schemas/risk-scoring.yaml` → `severity_bands`:
+
+| Severity Band | Composite Score Range | Boundary Rule |
+|---------------|-----------------------|---------------|
+| Critical | 9.0 - 10.0 | Score >= 9.0 |
+| High | 7.0 - 8.9 | Score >= 7.0 and < 9.0 |
+| Medium | 4.0 - 6.9 | Score >= 4.0 and < 7.0 |
+| Low | 0.0 - 3.9 | Score < 4.0 |
+
+**Boundary precision**: When a composite score falls exactly on a boundary value, it maps to the **higher** band: 7.0 = High, 4.0 = Medium, 9.0 = Critical. The `min` values in the schema are inclusive.
+
+**Note consolidation**: The existing `schemas/output.yaml` defines 5 bands (Critical/High/Medium/Low/Note). For composite scoring, Note is consolidated into Low (0.0-3.9) because composite scores always produce a meaningful numeric value — there is no scenario where a scored finding should be classified as informational-only.
+
+### Correlation Group Handling
+
+When Section 4a correlation groups exist in the parsed input:
+
+1. **Identify primary finding**: The first finding ID listed in the correlation group is the primary
+2. **Score the primary**: Apply full four-dimensional scoring (CVSS, exploitability, scalability, reachability) to the primary finding
+3. **Peers inherit scores**: All correlated peer findings receive the same dimensional scores, composite score, severity band, and governance fields as the primary finding
+4. **Rationale**: Correlated findings represent the same underlying issue from different perspectives. Independent scoring would create inconsistencies; inheritance ensures the group is treated as a coherent risk unit
+5. **SC-001 exemption**: Correlated peer groups are excluded from the score differentiation metric (SC-001). Peers intentionally receive identical scores; this is correct behavior, not a differentiation failure
+
+### Computation Sequence
+
+For each finding (after parsing, in order):
+
+1. Look up the finding's `category` to get the default CVSS vector
+2. Refine the CVSS vector per-threat (Section 3) → produces `cvss_base` and `cvss_vector`
+3. Assess exploitability (Section 4) → produces `exploitability`
+4. Assess scalability (Section 5) → produces `scalability`
+5. Determine reachability via Section 6 pipeline (zone baseline → per-finding refinement → architecture adjustments → clamping; falls back to 5.0 per Section 6e when no trust zone data is available) → produces `reachability`
+6. Calculate composite: `(0.35 × cvss_base) + (0.30 × exploitability) + (0.15 × scalability) + (0.20 × reachability)`
+7. Map composite to severity band
+8. If the finding is a correlation group primary: store scores for peer inheritance
+9. If the finding is a correlation group peer: copy all scores from the primary instead of computing
+
+### Output per Finding
+
+After composite calculation, each finding has these scoring fields ready for output:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `cvss_base` | number (0.0-10.0) | Section 3 |
+| `cvss_vector` | string | Section 3 |
+| `exploitability` | number (0.0-10.0) | Section 4 |
+| `scalability` | number (0.0-10.0) | Section 5 |
+| `reachability` | number (0.0-10.0) | Section 6 or default 5.0 |
+| `composite_score` | number (0.0-10.0) | This section (weighted formula) |
+| `severity_band` | Critical/High/Medium/Low | This section (band mapping) |
+
+---
+
+## 8. Governance Fields
+
+Attach remediation tracking metadata to each scored finding based on its severity band. Governance fields provide organizational accountability — who owns the risk, when it must be addressed, and what the initial disposition is. These fields are derived deterministically from the severity band assigned in Section 7, using the mappings defined in `schemas/risk-scoring.yaml` → `severity_bands`.
+
+### Field Generation Rules
+
+For each scored finding, generate four governance fields by looking up the finding's `severity_band` in the severity bands table:
+
+| Field | Type | Generation Rule |
+|-------|------|-----------------|
+| `risk_owner` | string | Default: `"Unassigned"`. This is a placeholder indicating the finding has not yet been triaged by a human reviewer. The scorer never assigns a specific owner — ownership is a human decision made during remediation planning. |
+| `remediation_sla` | string | Mapped from the `sla` property of the finding's severity band in `schemas/risk-scoring.yaml` → `severity_bands`. Represents the maximum time allowed to address the finding after scoring. |
+| `risk_disposition` | string | Mapped from the `disposition` property of the finding's severity band in `schemas/risk-scoring.yaml` → `severity_bands`. Represents the initial recommended action for the finding. |
+| `review_date` | string (YYYY-MM-DD) | Calculated as: scoring date + SLA duration. The scoring date is the date the risk scorer executes, not the date the threat model was generated. |
+
+### Severity-to-Governance Mapping
+
+Load these mappings from `schemas/risk-scoring.yaml` → `severity_bands`:
+
+| Severity Band | `remediation_sla` | `risk_disposition` | `review_date` Calculation |
+|---------------|--------------------|---------------------|---------------------------|
+| Critical | `24h` | `Mitigate` | scoring date + 1 day |
+| High | `7d` | `Mitigate` | scoring date + 7 days |
+| Medium | `30d` | `Review` | scoring date + 30 days |
+| Low | `90d` | `Review` | scoring date + 90 days |
+
+**SLA duration parsing**: Convert the `sla` string to a day count for review date calculation:
+- `"24h"` → 1 day
+- `"7d"` → 7 days
+- `"30d"` → 30 days
+- `"90d"` → 90 days
+
+### Review Date Calculation
+
+The `review_date` is the calendar date by which the finding must be reviewed or remediated:
+
+```
+review_date = scoring_date + sla_days
+```
+
+Where:
+- `scoring_date` is the current date when the risk scorer runs (format: YYYY-MM-DD)
+- `sla_days` is the day count derived from the severity band's `sla` property
+
+**Example**: If the scorer runs on 2026-03-27 and a finding has severity band `High` (SLA = 7d):
+- `review_date` = 2026-03-27 + 7 days = `2026-04-03`
+
+**Month/year boundary handling**: Standard calendar arithmetic applies. If adding days crosses a month or year boundary, use the correct calendar date (e.g., 2026-01-29 + 30 days = 2026-02-28).
+
+### Disposition Values
+
+The `risk_disposition` field uses one of four values defined in `schemas/risk-scoring.yaml` → `scored_finding.risk_disposition.enum`:
+
+| Disposition | Meaning | Assigned By |
+|-------------|---------|-------------|
+| `Mitigate` | Active remediation required within the SLA period | Severity mapping (Critical, High) |
+| `Review` | Finding requires evaluation to determine appropriate action | Severity mapping (Medium, Low) |
+| `Accept` | Risk accepted with documented justification | Human override only |
+| `Transfer` | Risk transferred to a third party (insurance, vendor responsibility) | Human override only |
+
+The scorer assigns only `Mitigate` or `Review` based on severity mapping. `Accept` and `Transfer` are valid disposition values that humans may set during remediation planning, but the scorer never generates them automatically.
+
+### Override Guidance
+
+All governance fields are defaults intended to be refined during human triage. The scorer produces deterministic initial values; organizations customize them post-scoring:
+
+- **`risk_owner`**: Replace `"Unassigned"` with the responsible team or individual during triage. Ownership assignment depends on organizational structure and is outside the scorer's scope.
+- **`remediation_sla`**: Organizations may tighten SLAs (e.g., Critical from 24h to 12h for regulated systems) or relax them with documented justification. Custom SLAs should still use duration notation (e.g., `"12h"`, `"14d"`).
+- **`risk_disposition`**: Change from the severity-mapped default when appropriate. For example, a Low-severity finding with `"Review"` may be changed to `"Accept"` if the risk is within tolerance, or a Medium finding may be escalated to `"Mitigate"` based on business context.
+- **`review_date`**: Recalculate if the SLA is overridden. The review date should always reflect the actual SLA in effect, not the original severity-mapped default.
+
+Overridden values MUST be preserved in both output formats (risk-scores.md and risk-scores.sarif). The scorer records the severity-mapped defaults; downstream tooling or manual edits apply overrides.
+
+### Correlation Group Governance
+
+Governance fields for correlation groups follow the same inheritance rule as scoring fields (Section 7):
+
+1. The **primary finding** receives governance fields derived from its severity band
+2. All **correlated peer findings** inherit the primary's governance fields identically
+3. If a human overrides governance fields on the primary, peers should reflect the same override
+
+This ensures a correlation group — which represents a single underlying risk from multiple perspectives — receives consistent remediation tracking.
+
+### Output per Finding
+
+After governance field generation, each finding has these additional fields ready for output:
+
+| Field | Type | Example Value |
+|-------|------|---------------|
+| `risk_owner` | string | `"Unassigned"` |
+| `remediation_sla` | string | `"7d"` |
+| `risk_disposition` | string | `"Mitigate"` |
+| `review_date` | string (YYYY-MM-DD) | `"2026-04-03"` |
+
+Combined with the scoring fields from Section 7, each finding now carries the complete set of fields needed for output generation (Sections 9 and 10).
+
+---
+
+## 9. Output Generation: Markdown (risk-scores.md)
+
+Generate a `risk-scores.md` file in the same directory as the input threat model. The output MUST conform to the structure defined in `templates/risk-scores.md`. All sections are required and MUST appear in the order specified below. Findings are sorted by composite score descending throughout the document.
+
+### 9a. Frontmatter
+
+Generate YAML frontmatter at the top of the file, enclosed in a fenced code block with `yaml` language identifier, itself wrapped in a YAML document separator (`---`):
+
+```yaml
+---
+schema_version: "1.0"
+date: "YYYY-MM-DD"
+source_file: "{path to input threats.md or threats.sarif}"
+classification: "confidential"
+scoring_weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+---
+```
+
+**Field generation rules**:
+
+| Field | Rule |
+|-------|------|
+| `schema_version` | Always `"1.0"` for this release |
+| `date` | ISO 8601 date when scoring was performed (the current date, format `YYYY-MM-DD`) |
+| `source_file` | Relative path from the output directory to the input file that was scored (e.g., `threats.md` or `threats.sarif`) |
+| `classification` | Always `"confidential"` unless overridden by organizational policy |
+| `scoring_weights` | The four dimension weights used in the composite formula. These are fixed at the values shown and document the formula for reproducibility |
+
+### 9b. Section 1: Executive Summary
+
+Generate the executive summary immediately after the frontmatter. This section provides a high-level risk posture snapshot for security managers who need to assess severity distribution without reading individual findings.
+
+**Content to generate**:
+
+1. **Total findings count**: The total number of scored findings (e.g., "**18 findings** scored across 8 threat categories").
+
+2. **Severity band distribution table**: A table showing the count of findings in each severity band:
+
+   ```markdown
+   | Severity | Count |
+   |----------|-------|
+   | Critical | N     |
+   | High     | N     |
+   | Medium   | N     |
+   | Low      | N     |
+   ```
+
+   Include all four severity bands even when a band has zero findings (display `0` for empty bands). Order is always Critical, High, Medium, Low (descending severity).
+
+3. **Highest-risk component identification**: Identify the component with the highest single composite score across all findings. Format as: "**Highest-risk component**: {component_name} (composite: {score}, severity: {band})". When multiple findings tie for the highest composite score, select the finding whose component appears first in alphabetical order.
+
+4. **Severity distribution narrative**: A single sentence summarizing the distribution pattern (e.g., "The majority of findings (12 of 18) fall in the Medium band, with 2 Critical findings requiring immediate attention.").
+
+**Generation rules**:
+- Counts MUST be derived by iterating over all scored findings and tallying by `severity_band`
+- The highest-risk component is determined by the maximum `composite_score` value, not by counting findings per component
+- When all findings fall in a single severity band, still include the full four-row table
+
+### 9c. Section 2: Scored Threat Table
+
+Generate a markdown table containing all scored findings. This is the primary reference table for security engineers triaging findings.
+
+**Column definitions**:
+
+| Column | Source Field | Format |
+|--------|-------------|--------|
+| ID | `id` | Finding ID as-is (e.g., `S-1`, `AG-3`) |
+| Component | `component` | Component name, truncated to 30 characters with `...` suffix if longer |
+| Threat | `threat` | Threat description, truncated to 60 characters with `...` suffix if longer |
+| CVSS | `cvss_base` | Decimal with one digit (e.g., `7.2`) |
+| Exploitability | `exploitability` | Decimal with one digit (e.g., `6.5`) |
+| Scalability | `scalability` | Decimal with one digit (e.g., `4.0`) |
+| Reachability | `reachability` | Decimal with one digit (e.g., `8.0`) |
+| Composite | `composite_score` | Decimal with one digit (e.g., `6.8`) |
+| Severity | `severity_band` | `Critical`, `High`, `Medium`, or `Low` |
+| SLA | `remediation_sla` | Duration string (e.g., `24h`, `7d`) |
+| Disposition | `risk_disposition` | `Mitigate` or `Review` |
+
+**Sort order**: Rows are sorted by `composite_score` descending (highest risk first). When two findings have equal composite scores, secondary sort by `id` in natural alphanumeric order (e.g., `S-1` before `S-2`, `AG-1` before `LLM-1`).
+
+**Truncation rules**:
+- Component names exceeding 30 characters: truncate to 27 characters and append `...` (e.g., `"LLM Agent Orchestrator Servi..."`)
+- Threat descriptions exceeding 60 characters: truncate to 57 characters and append `...` (e.g., `"Attacker injects malicious prompts to bypass guardrail..."`)
+- Truncation is applied only in the Scored Threat Table; the Dimensional Breakdown (Section 3) shows full untruncated text
+
+**Numeric formatting**: All dimension scores and composite scores are formatted with exactly one decimal place. Trailing zeros are preserved (e.g., `4.0` not `4`).
+
+**Correlation group display**: Correlated peer findings appear in the table with their own IDs but carry the primary's scores. No special notation is needed in the table -- peers are indistinguishable from independently scored findings.
+
+### 9d. Section 3: Dimensional Breakdown
+
+Generate a per-finding breakdown section that provides the full scoring rationale for each finding. This section is intended for security engineers who need to understand why a finding received its scores, not just what the scores are.
+
+**Structure**: One subsection per finding, ordered by `composite_score` descending (same order as the Scored Threat Table). Each subsection uses an H3 heading.
+
+**Per-finding subsection format**:
+
+```markdown
+### {id}: {threat_description}
+
+**Component**: {component}
+**Category**: {category}
+**Composite Score**: {composite_score} ({severity_band})
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | {cvss_base} | 0.35 | {cvss_base * 0.35} |
+| Exploitability | {exploitability} | 0.30 | {exploitability * 0.30} |
+| Scalability | {scalability} | 0.15 | {scalability * 0.15} |
+| Reachability | {reachability} | 0.20 | {reachability * 0.20} |
+| **Composite** | | | **{composite_score}** |
+
+**CVSS Vector**: `{cvss_vector}`
+
+**Scoring Rationale**:
+- **CVSS**: {1-2 sentence justification for the CVSS base score}
+- **Exploitability**: {1-2 sentence justification}
+- **Scalability**: {1-2 sentence justification}
+- **Reachability**: {1-2 sentence justification referencing the trust zone if available}
+```
+
+**Field generation rules**:
+
+| Field | Rule |
+|-------|------|
+| `{id}` | Finding ID, untruncated |
+| `{threat_description}` | Full threat description text, untruncated (no 60-character limit here) |
+| `{component}` | Full component name, untruncated |
+| `{category}` | Human-readable category name: `Spoofing`, `Tampering`, `Repudiation`, `Information Disclosure`, `Denial of Service`, `Privilege Escalation`, `Agentic Threats`, or `LLM Threats` |
+| `{composite_score}` | Decimal with one digit |
+| `{severity_band}` | `Critical`, `High`, `Medium`, or `Low` |
+| Dimension scores | Decimal with one digit |
+| Weighted values | Decimal with two digits (e.g., `2.52`, `1.95`). Calculated as score multiplied by weight |
+| `{cvss_vector}` | Full CVSS 3.1 vector string from Section 3 scoring |
+| Scoring Rationale | Brief justification drawn from the assessment performed in Sections 3-6. Each rationale line explains the key factors that determined the score for that dimension |
+
+**Correlation group display**: Correlated peer findings each get their own subsection but include an additional line after the Category line: `**Correlation Group**: Scores inherited from primary finding {primary_id}`. The dimensional table and rationale reflect the primary's assessment.
+
+**Category display mapping**:
+
+| IR Category | Display Name |
+|-------------|-------------|
+| `spoofing` | Spoofing |
+| `tampering` | Tampering |
+| `repudiation` | Repudiation |
+| `info-disclosure` | Information Disclosure |
+| `denial-of-service` | Denial of Service |
+| `privilege-escalation` | Privilege Escalation |
+| `agentic` | Agentic Threats |
+| `llm` | LLM Threats |
+
+### 9e. Section 4: Governance Fields
+
+Generate a governance tracking table that consolidates all governance metadata for remediation planning. This section provides a single-view reference for GRC teams and security managers assigning ownership and tracking remediation progress.
+
+**Table format**:
+
+```markdown
+| ID | Component | Severity | Owner | SLA | Disposition | Review Date |
+|----|-----------|----------|-------|-----|-------------|-------------|
+```
+
+**Column definitions**:
+
+| Column | Source Field | Format |
+|--------|-------------|--------|
+| ID | `id` | Finding ID as-is |
+| Component | `component` | Full component name, untruncated |
+| Severity | `severity_band` | `Critical`, `High`, `Medium`, or `Low` |
+| Owner | `risk_owner` | Default: `Unassigned` |
+| SLA | `remediation_sla` | Duration string (e.g., `24h`, `7d`, `30d`, `90d`) |
+| Disposition | `risk_disposition` | `Mitigate` or `Review` |
+| Review Date | `review_date` | ISO 8601 date (e.g., `2026-04-03`) |
+
+**Sort order**: Same as the Scored Threat Table -- `composite_score` descending, secondary sort by `id` in natural alphanumeric order.
+
+**Generation rules**:
+- Every scored finding MUST appear in this table (no findings omitted)
+- The `Owner` column always reads `Unassigned` in scorer-generated output -- ownership is a human decision made during triage (see Section 8 Override Guidance)
+- The `Review Date` is calculated per Section 8 rules: scoring date + SLA duration
+- Correlation group peers appear with their own IDs and inherit governance fields from the primary
+
+### 9f. Section 5: Scoring Methodology
+
+Generate the scoring methodology section that documents how scores in this report were calculated. This section ensures the report is self-contained and auditable without requiring access to the scorer agent definition.
+
+**Content to generate**:
+
+Reproduce the methodology content defined in `templates/risk-scores.md` Section 5, populated with the actual values used in this scoring run:
+
+1. **Scoring Dimensions**: Table listing the four dimensions (CVSS Base, Exploitability, Scalability, Reachability) with their weights and descriptions
+2. **Default Weights and Rationale**: Explanation of why each dimension receives its assigned weight
+3. **Composite Score Formula**: The weighted sum formula with the actual weights used
+4. **Severity Band Mapping**: Table mapping composite score ranges to severity bands with default SLAs and dispositions
+5. **Data Sources**: Description of inputs consumed (threat findings, trust zone data, architecture documentation, category default vectors)
+6. **Reproducibility**: Temperature 0 setting and +/- 0.5 tolerance per dimension
+
+**Generation rules**:
+- The methodology section content is static for a given schema version -- it does not vary between scoring runs
+- The weights in the formula and dimension table MUST match the `scoring_weights` values in the frontmatter
+- Severity band boundaries MUST match those defined in `schemas/risk-scoring.yaml` -> `severity_bands`
+- This section serves as an in-document reference; it does not replace the schema definitions
+
+### 9g. File Placement
+
+Write the completed `risk-scores.md` to the same directory as the input file:
+
+- If the input was `{dir}/threats.md`, write to `{dir}/risk-scores.md`
+- If the input was `{dir}/threats.sarif`, write to `{dir}/risk-scores.md`
+- If a `risk-scores.md` already exists at the target path, overwrite it (scoring is idempotent)
+
+### 9h. Consistency Requirements
+
+The markdown output MUST be consistent with the SARIF output (Section 10) on all data points:
+
+- Every finding in `risk-scores.md` MUST appear in `risk-scores.sarif` and vice versa
+- All numeric scores (dimension scores, composite scores) MUST be identical between the two formats
+- Severity band assignments MUST be identical between the two formats
+- Governance field values (owner, SLA, disposition, review date) MUST be identical between the two formats
+- Sort order in the Scored Threat Table corresponds to the order of results in the SARIF `results[]` array
+
+If any inconsistency is detected during generation, treat it as a scoring pipeline error and halt output generation with a diagnostic message identifying the mismatched finding and field.
+
+---
+
+## 10. Output Generation: SARIF (risk-scores.sarif)
+
+Generate a `risk-scores.sarif` file in the same directory as the input threat model. The output MUST conform to SARIF 2.1.0 (`$schema: https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json`) and follow the structure defined in `templates/risk-scores.sarif`. All scored findings MUST appear in the SARIF output, and all numeric values MUST be identical to those in `risk-scores.md` (Section 9h consistency mandate).
+
+**Semantic shift from threats.sarif**: In `threats.sarif`, the rule-level `security-severity` is a static category value (e.g., `"9.0"` for Critical, `"5.0"` for Medium). In `risk-scores.sarif`, the result-level `security-severity` is the per-finding composite score and the rule-level `security-severity` is the MAX composite score among all findings for that rule. Task T023 documents this shift in the SARIF reference guide.
+
+### 10a. Tool Driver Configuration
+
+Set the `tool.driver` object to identify the risk scorer as a distinct tool from the threat model generator:
+
+```json
+{
+  "tool": {
+    "driver": {
+      "name": "tachi-risk-scorer",
+      "version": "1.0",
+      "semanticVersion": "1.0",
+      "informationUri": "https://github.com/owner/tachi",
+      "supportedTaxonomies": [ ... ],
+      "rules": [ ... ]
+    }
+  }
+}
+```
+
+**Field generation rules**:
+
+| Field | Value | Notes |
+|-------|-------|-------|
+| `name` | `"tachi-risk-scorer"` | Distinguishes scored output from threat model output (`"tachi"` in threats.sarif) |
+| `version` | `"1.0"` | Matches `schemas/risk-scoring.yaml` → `schema_version` |
+| `semanticVersion` | `"1.0"` | Same as `version` |
+| `informationUri` | `"https://github.com/owner/tachi"` | Project repository URL |
+| `supportedTaxonomies` | Passthrough from source | See Section 10f (Taxonomy Passthrough) |
+| `rules` | One entry per threat category with findings | See Section 10b (Rule Definitions) |
+
+### 10b. Rule Definitions
+
+Populate `tool.driver.rules[]` with one entry per threat category that has at least one scored finding. Use the same rule IDs as `threats.sarif`. Each rule definition carries the MAX composite score among its findings.
+
+**Rule ID to category mapping** (same as Section 1b parsing):
+
+| Rule ID | Category |
+|---------|----------|
+| `tachi/stride/spoofing` | spoofing |
+| `tachi/stride/tampering` | tampering |
+| `tachi/stride/repudiation` | repudiation |
+| `tachi/stride/information-disclosure` | info-disclosure |
+| `tachi/stride/denial-of-service` | denial-of-service |
+| `tachi/stride/elevation-of-privilege` | privilege-escalation |
+| `tachi/ai/agentic-threats` | agentic |
+| `tachi/ai/llm-threats` | llm |
+
+**Per-rule structure**:
+
+```json
+{
+  "id": "tachi/stride/spoofing",
+  "shortDescription": { "text": "Identity spoofing threats" },
+  "fullDescription": { "text": "<category-level description>" },
+  "properties": {
+    "tags": ["security", "stride", "spoofing", ...],
+    "security-severity": "<max-composite-score-as-numeric-string>"
+  },
+  "relationships": [ ... ]
+}
+```
+
+**Rule-level `security-severity` calculation**:
+
+1. Collect all scored findings whose `ruleId` matches this rule
+2. Extract each finding's `composite_score`
+3. Set the rule's `security-severity` to the MAX composite score among those findings, formatted as a numeric string with one decimal place (e.g., `"8.3"`)
+4. If a category has exactly one finding, the rule-level value equals that finding's composite score
+5. If a category has no findings, omit the rule entirely from `rules[]`
+
+This is a semantic shift from `threats.sarif`, where rule-level `security-severity` is a static value representing the category's general severity class. In `risk-scores.sarif`, rule-level `security-severity` reflects the actual worst-case finding within that category.
+
+**Rule descriptions and tags**: Copy `shortDescription`, `fullDescription`, `properties.tags`, and `relationships[]` from the corresponding rule in `templates/risk-scores.sarif`. These are static per category and do not change between scoring runs.
+
+### 10c. Result Generation
+
+Generate one result object per scored finding in the `run.results[]` array. Results are ordered by `composite_score` descending (highest risk first), matching the sort order in `risk-scores.md` Section 2 (Scored Threat Table). When two findings have equal composite scores, secondary sort by finding `id` in natural alphanumeric order.
+
+**Per-result structure**:
+
+```json
+{
+  "ruleId": "<rule-id-from-category>",
+  "message": {
+    "text": "<threat-description>",
+    "markdown": "<mitigation-recommendation>"
+  },
+  "level": "<sarif-level-from-severity-band>",
+  "locations": [ ... ],
+  "partialFingerprints": { ... },
+  "properties": { ... }
+}
+```
+
+**Field generation rules**:
+
+| Field | Source | Rule |
+|-------|--------|------|
+| `ruleId` | `category` | Map IR category to rule ID using the table in Section 10b |
+| `message.text` | `threat` | Full threat description text, untruncated |
+| `message.markdown` | `mitigation` | Full mitigation recommendation, untruncated |
+| `level` | `severity_band` | Map via SARIF Level Mapping (Section 10d) |
+| `locations` | Finding location data | See Location Generation below |
+| `partialFingerprints` | Source `threats.sarif` or derived | See Section 10e (Fingerprint Preservation) |
+| `properties` | Scoring and governance fields | See Property Bag Mapping (Section 10g) |
+
+**Location generation**:
+
+Each result MUST include a `locations[]` array with one entry containing both physical and logical location:
+
+```json
+{
+  "locations": [
+    {
+      "physicalLocation": {
+        "artifactLocation": {
+          "uri": "<input-architecture-file-path>"
+        },
+        "region": {
+          "startLine": 1
+        }
+      },
+      "logicalLocations": [
+        {
+          "name": "<component-name>",
+          "fullyQualifiedName": "<trust-zone>/<component-name>",
+          "kind": "process"
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Location Field | Source | Rule |
+|----------------|--------|------|
+| `artifactLocation.uri` | Input file path | Relative path to the architecture document that was threat-modeled |
+| `region.startLine` | Fixed | Always `1` (threat findings are document-level, not line-level) |
+| `logicalLocations[0].name` | `component` | Component name from the scored finding |
+| `logicalLocations[0].fullyQualifiedName` | Trust zone + component | Format: `{trust_zone}/{component}`. If no trust zone is available, use the component name only |
+| `logicalLocations[0].kind` | `dfd_element_type` | Map from IR: `Process` -> `"process"`, `Data Store` -> `"data-store"`, `External Entity` -> `"external-entity"`. Default to `"process"` when DFD element type is unavailable |
+
+### 10d. SARIF Level Mapping
+
+Map the scored finding's `severity_band` to the SARIF `level` field using the mapping defined in `schemas/output.yaml`:
+
+| Severity Band | SARIF `level` | Rationale |
+|---------------|---------------|-----------|
+| Critical | `"error"` | Requires immediate action; blocks release |
+| High | `"error"` | Significant risk; treated as error-level in tooling |
+| Medium | `"warning"` | Moderate risk; requires attention but not blocking |
+| Low | `"note"` | Informational; tracked for completeness |
+
+This mapping is identical to the one used in `threats.sarif` for consistency across tachi SARIF outputs. The `level` field controls how SARIF consumers (GitHub Code Scanning, VS Code SARIF Viewer, etc.) display and filter results.
+
+### 10e. Fingerprint Preservation
+
+Fingerprints provide stable identifiers for alert tracking across scoring runs. Preserve all `partialFingerprints` from the source `threats.sarif` input, and derive fingerprints when parsing from `threats.md`.
+
+**Preservation rules**:
+
+| Fingerprint Key | Source | Rule |
+|-----------------|--------|------|
+| `findingId/v1` | Source finding | **Always present**. When input is `threats.sarif`, copy the value directly. When input is `threats.md`, use the finding ID (e.g., `"S-1"`, `"AG-3"`). This is the primary stable identifier for correlating findings across threat model and risk score outputs. |
+| `primaryLocationLineHash` | Source `threats.sarif` | **Preserve when available**. Copy directly from the source result's `partialFingerprints`. When input is `threats.md` (no source SARIF), omit this key entirely -- do not fabricate a hash. |
+| `correlationGroup` | Source finding | **Present on correlation group primaries only**. Copy from source `threats.sarif` if available. When input is `threats.md`, set to the correlation group identifier (e.g., `"CG-1"`) for primary findings that head a correlation group. Omit for non-correlated findings and for peer findings. |
+
+**Fingerprint integrity rule**: Never modify, regenerate, or re-hash fingerprint values that originate from `threats.sarif`. These values are used by downstream consumers (GitHub Code Scanning, alert deduplication pipelines) to track findings across runs. Altering them breaks alert continuity.
+
+### 10f. Taxonomy Passthrough
+
+Preserve all taxonomy declarations from the source input for downstream consumers that rely on OWASP and CWE classification.
+
+**Taxonomy elements to preserve**:
+
+| Element | Location in SARIF | Rule |
+|---------|-------------------|------|
+| `run.taxonomies[]` | Top-level run property | Copy the entire `taxonomies` array from the source `threats.sarif`. When input is `threats.md`, use the default taxonomy declarations from `templates/risk-scores.sarif` (OWASP 2021 and CWE 4.13). |
+| `tool.driver.supportedTaxonomies[]` | Tool driver property | Copy from source `threats.sarif`. When input is `threats.md`, use the default declarations: `[{"name": "OWASP", "index": 0}, {"name": "CWE", "index": 1}]` |
+| Rule `relationships[]` | Per-rule in `tool.driver.rules[]` | Copy the `relationships` array from the corresponding rule in the source `threats.sarif`. When input is `threats.md`, use the default relationships from `templates/risk-scores.sarif` which map each STRIDE/AI category to its primary OWASP Top 10 and CWE entries. |
+
+**Default taxonomy declarations** (used when input is `threats.md`):
+
+```json
+{
+  "taxonomies": [
+    {
+      "name": "OWASP",
+      "version": "2021",
+      "informationUri": "https://owasp.org/Top10/",
+      "organization": "OWASP Foundation",
+      "shortDescription": { "text": "OWASP Top 10 Web Application Security Risks" }
+    },
+    {
+      "name": "CWE",
+      "version": "4.13",
+      "informationUri": "https://cwe.mitre.org/",
+      "organization": "MITRE",
+      "shortDescription": { "text": "Common Weakness Enumeration" }
+    }
+  ]
+}
+```
+
+**Passthrough integrity rule**: Do not modify taxonomy versions, URIs, or organization names during passthrough. The risk scorer does not assess or update taxonomy classifications -- it preserves them for downstream tools.
+
+### 10g. Property Bag Field Mapping
+
+Each result's `properties` object carries the full scoring and governance payload. This is the primary extension point where `risk-scores.sarif` differs from `threats.sarif`.
+
+**Property bag structure**:
+
+```json
+{
+  "properties": {
+    "security-severity": "7.2",
+    "cvss-base-score": "8.1",
+    "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+    "exploitability": "7.0",
+    "scalability": "5.5",
+    "reachability": "6.0",
+    "composite-weights": "0.35/0.30/0.15/0.20",
+    "severity-band": "High",
+    "risk-owner": "Unassigned",
+    "remediation-sla": "7d",
+    "risk-disposition": "Mitigate",
+    "review-date": "2026-04-03"
+  }
+}
+```
+
+**Field mapping table**:
+
+| Property Key | IR Source Field | Format | Description |
+|--------------|----------------|--------|-------------|
+| `security-severity` | `composite_score` | Numeric string, one decimal place (e.g., `"7.2"`) | The composite risk score for this specific finding. This is the primary sort/filter key for SARIF consumers. |
+| `cvss-base-score` | `cvss_base` | Numeric string, one decimal place (e.g., `"8.1"`) | CVSS 3.1 base score from Section 3 assessment |
+| `cvss-vector` | `cvss_vector` | Full CVSS 3.1 vector string (e.g., `"CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"`) | Complete vector for auditability and independent verification |
+| `exploitability` | `exploitability` | Numeric string, one decimal place (e.g., `"7.0"`) | Exploitability assessment from Section 4 |
+| `scalability` | `scalability` | Numeric string, one decimal place (e.g., `"5.5"`) | Scalability assessment from Section 5 |
+| `reachability` | `reachability` | Numeric string, one decimal place (e.g., `"6.0"`) | Reachability assessment from Section 6 |
+| `composite-weights` | Fixed | `"0.35/0.30/0.15/0.20"` | Slash-delimited weight string (CVSS/Exploitability/Scalability/Reachability). Documents the formula used for reproducibility. Constant for schema version 1.0. |
+| `severity-band` | `severity_band` | One of: `"Critical"`, `"High"`, `"Medium"`, `"Low"` | Severity band derived from composite score per `schemas/risk-scoring.yaml` thresholds |
+| `risk-owner` | `risk_owner` | String | Default: `"Unassigned"`. Human-assigned during triage. |
+| `remediation-sla` | `remediation_sla` | Duration string: `"24h"`, `"7d"`, `"30d"`, or `"90d"` | Severity-driven SLA from `schemas/risk-scoring.yaml` -> `severity_bands` |
+| `risk-disposition` | `risk_disposition` | One of: `"Mitigate"`, `"Review"`, `"Accept"`, `"Transfer"` | Initial disposition from severity mapping. Default scoring produces `"Mitigate"` (Critical/High) or `"Review"` (Medium/Low). |
+| `review-date` | `review_date` | ISO 8601 date string (`"YYYY-MM-DD"`) | Scoring date + SLA duration, per Section 8 calculation rules |
+
+**Numeric string formatting rule**: All numeric properties (`security-severity`, `cvss-base-score`, `exploitability`, `scalability`, `reachability`) MUST be formatted as strings with exactly one decimal place. Trailing zeros are preserved (e.g., `"4.0"` not `"4"`). This matches the SARIF convention where `security-severity` is a string, and ensures consistency across all scoring properties.
+
+### 10h. Correlation Group Handling in SARIF
+
+Correlation groups receive special treatment in SARIF output. The primary finding appears as a top-level result with full scoring; peer findings do NOT appear as separate top-level results. Instead, peers are referenced via `relatedLocations` on the primary result.
+
+**Primary finding result**:
+
+The primary finding is emitted as a normal result (per Section 10c) with these additions:
+
+1. `partialFingerprints` includes the `correlationGroup` key (e.g., `"CG-1"`)
+2. `relatedLocations[]` contains one entry per correlated peer finding:
+
+```json
+{
+  "relatedLocations": [
+    {
+      "id": 0,
+      "message": {
+        "text": "<peer-finding-id>: <peer-threat-summary>"
+      },
+      "logicalLocations": [
+        {
+          "name": "<peer-component-name>",
+          "fullyQualifiedName": "<trust-zone>/<peer-component-name>",
+          "kind": "process"
+        }
+      ]
+    }
+  ]
+}
+```
+
+| Related Location Field | Source | Rule |
+|------------------------|--------|------|
+| `id` | Sequence | Zero-based index within the `relatedLocations` array |
+| `message.text` | Peer finding | Format: `"{peer_id}: {peer_threat_summary}"` (e.g., `"T-4: Data tampering via API gateway"`) |
+| `logicalLocations[0].name` | Peer `component` | Peer finding's component name |
+| `logicalLocations[0].fullyQualifiedName` | Peer trust zone + component | Format: `{trust_zone}/{component}`, same as primary location rules |
+| `logicalLocations[0].kind` | Peer `dfd_element_type` | Same mapping as primary location rules |
+
+**Peer finding handling**:
+
+- Peer findings do NOT appear as separate entries in `run.results[]`
+- All peer scores and governance fields are inherited from the primary (Section 7, Correlation Group Handling)
+- Peer finding IDs are visible only in the `relatedLocations[].message.text` of the primary result
+- The primary's `composite_score` (used as result-level `security-severity`) reflects the entire group's risk
+
+**Result count implication**: The total number of results in `run.results[]` equals the number of independently scored findings plus the number of correlation group primaries. It does NOT include peer findings. The `risk-scores.md` Scored Threat Table may show more rows than `run.results[]` has entries because the markdown format lists peers as separate rows.
+
+### 10i. File Placement
+
+Write the completed `risk-scores.sarif` to the same directory as the input file:
+
+- If the input was `{dir}/threats.md`, write to `{dir}/risk-scores.sarif`
+- If the input was `{dir}/threats.sarif`, write to `{dir}/risk-scores.sarif`
+- If a `risk-scores.sarif` already exists at the target path, overwrite it (scoring is idempotent)
+
+The SARIF file MUST be valid JSON. Use 2-space indentation for human readability.
+
+### 10j. Consistency with Markdown Output
+
+The SARIF output MUST be consistent with the markdown output (Section 9) on all data points. This is a bidirectional requirement -- Section 9h mandates consistency from the markdown side, and this subsection mandates it from the SARIF side.
+
+**Consistency checks**:
+
+| Data Point | Markdown Location | SARIF Location | Rule |
+|------------|-------------------|----------------|------|
+| Finding count | Executive Summary total | `run.results[]` length + peer count | Every finding in `risk-scores.md` MUST be accounted for in `risk-scores.sarif` (primaries as results, peers in `relatedLocations`) |
+| Composite score | Scored Threat Table "Composite" column | `result.properties["security-severity"]` | Numeric values MUST be identical (e.g., markdown `6.8` equals SARIF `"6.8"`) |
+| Dimension scores | Dimensional Breakdown table | `result.properties["cvss-base-score"]`, `["exploitability"]`, `["scalability"]`, `["reachability"]` | All four dimension scores MUST match between formats |
+| Severity band | Scored Threat Table "Severity" column | `result.properties["severity-band"]` | Band assignment MUST be identical |
+| SARIF level | (not in markdown) | `result.level` | Must be derivable from the severity band using Section 10d mapping |
+| Governance fields | Governance Fields table | `result.properties["risk-owner"]`, `["remediation-sla"]`, `["risk-disposition"]`, `["review-date"]` | All governance values MUST be identical |
+| Sort order | Scored Threat Table row order | `run.results[]` array order | Results appear in the same composite-descending order |
+| Rule-level severity | (not in markdown) | `rule.properties["security-severity"]` | Must equal MAX of the composite scores from all findings mapped to that rule |
+
+**Consistency failure handling**: If any inconsistency is detected during generation, treat it as a scoring pipeline error and halt output generation with a diagnostic message identifying the mismatched finding, field, and the values in each format. Do not write a partial or inconsistent SARIF file.

--- a/adapters/claude-code/commands/risk-score.md
+++ b/adapters/claude-code/commands/risk-score.md
@@ -1,0 +1,161 @@
+---
+description: Run quantitative risk scoring on threat model output — produces risk-scores.md and risk-scores.sarif with four-dimensional scores, composite ratings, and governance fields
+---
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+Consider user input before proceeding (if not empty).
+
+## Step 0: Parse Flags
+
+1. If `$ARGUMENTS` contains `--output-dir <path>`:
+   - Set `output_dir` to the specified path
+   - Strip `--output-dir <path>` from `$ARGUMENTS` (trim extra whitespace)
+2. Default: `output_dir = null` (outputs written to same directory as input)
+
+3. Remaining `$ARGUMENTS` is treated as the input directory path.
+4. Default input directory: current working directory (`.`)
+
+## Overview
+
+Single-command entry point for tachi quantitative risk scoring. Validates prerequisites, locates threat model output, invokes the risk-scorer agent, and writes scored output files.
+
+**Flow**: Validate → Locate Input → Score → Report
+
+**Output suite**:
+- `risk-scores.md` — scored threat table, executive summary, dimensional breakdowns, governance fields, methodology
+- `risk-scores.sarif` — SARIF 2.1.0 with per-finding composite scores in `security-severity` and scoring properties in result property bags
+
+## Step 1: Validate Prerequisites
+
+1. **Check tachi agents are installed**:
+   - Verify `.claude/agents/tachi/risk-scorer.md` exists
+   - If missing, display:
+     ```
+     TACHI RISK SCORER NOT INSTALLED
+     Run: cp -r <tachi-repo>/adapters/claude-code/agents/risk-scorer.md .claude/agents/tachi/
+     See: https://github.com/davidmatousek/tachi
+     ```
+   - Halt if missing.
+
+2. **Check input files exist**:
+   - Look for `threats.md` in the input directory
+   - If not found, look for `threats.sarif` in the input directory
+   - If neither exists, display:
+     ```
+     NO THREAT MODEL OUTPUT FOUND
+     Neither threats.md nor threats.sarif found in: {input_dir}
+     Run /threat-model first to generate threat model output.
+     ```
+   - Halt if neither exists.
+
+3. **Determine input file and format**:
+   - If `threats.md` exists: set `input_file = threats.md`, `input_format = markdown`
+   - If only `threats.sarif` exists: set `input_file = threats.sarif`, `input_format = sarif`
+   - `threats.md` is the canonical source; `threats.sarif` is the fallback
+   - Display: `Input: {input_file} ({input_format} format)`
+
+4. **Determine output directory**:
+   - If `--output-dir` was specified: use that path
+   - Otherwise: use the same directory as the input file
+   - Create output directory if it does not exist
+   - Display: `Output: {output_dir}`
+
+5. **Check for optional architecture.md**:
+   - Look for `architecture.md` in the input directory and its parent directory
+   - If found: set `architecture_path` to the resolved path (used for reachability scoring)
+   - If not found: set `architecture_path = null` (reachability will use trust zone data only, or default to 5.0)
+
+## Step 2: Run Risk Scoring
+
+1. Read the input file at `{input_file}`.
+
+2. If `architecture_path` is not null, read the architecture file.
+
+3. Invoke the `tachi-risk-scorer` agent with the following prompt:
+
+   ```
+   Score the following threat model output using your complete scoring pipeline
+   (Threat Parsing → Trust Zone Extraction → Dimensional Scoring → Composite
+   Calculation → Governance Fields → Output Generation).
+
+   Write all output files to: {output_dir}
+   - risk-scores.md
+   - risk-scores.sarif
+
+   Input format: {input_format}
+   Scoring date: {current date YYYY-MM-DD}
+
+   <threat-model-input>
+   {contents of input file}
+   </threat-model-input>
+
+   {if architecture_path is not null:}
+   <architecture-input>
+   {contents of architecture file}
+   </architecture-input>
+   ```
+
+4. Wait for the risk-scorer agent to complete all 6 pipeline phases.
+
+## Step 3: Report Results
+
+Display summary:
+
+```
+RISK SCORING COMPLETE
+Input: {input_file} ({input_format} format)
+Output: {output_dir}
+
+Files generated:
+  risk-scores.md    — Scored threat table + executive summary + methodology
+  risk-scores.sarif — SARIF 2.1.0 with quantitative scores
+
+Severity Distribution:
+  Critical: {count}    High: {count}    Medium: {count}    Low: {count}
+  Total findings scored: {total}
+
+Highest-Risk Component: {component_name} (composite: {max_composite})
+
+Next steps:
+  1. Review Critical/High findings in risk-scores.md Section 2
+  2. Assign risk owners in Section 4 (Governance Fields)
+  3. Upload risk-scores.sarif to GitHub Code Scanning (supersedes threats.sarif)
+  4. Share risk-scores.md with stakeholders for remediation planning
+```
+
+## Usage Examples
+
+```bash
+# Minimal — score threats in current directory
+/risk-score
+
+# Specify input directory
+/risk-score path/to/threat-model-output/
+
+# Custom output directory
+/risk-score path/to/threat-model-output/ --output-dir reports/risk/
+
+# Score a specific example
+/risk-score examples/agentic-app/sample-report/
+```
+
+## Quality Checklist
+
+- [ ] Risk-scorer agent installed in `.claude/agents/tachi/`
+- [ ] Input file exists (threats.md or threats.sarif)
+- [ ] Input format correctly detected (markdown canonical, SARIF fallback)
+- [ ] Architecture file located when available (improves reachability scoring)
+- [ ] Both output files generated (risk-scores.md + risk-scores.sarif)
+- [ ] All findings scored with four dimensions (CVSS, exploitability, scalability, reachability)
+- [ ] Composite scores calculated using weighted formula
+- [ ] Severity bands mapped correctly (Critical/High/Medium/Low)
+- [ ] Governance fields populated (owner, SLA, disposition, review date)
+- [ ] Scored threat table sorted by composite descending
+- [ ] SARIF output validates against SARIF 2.1.0 schema
+- [ ] SARIF fingerprints preserved from source threats.sarif
+- [ ] Scores consistent between risk-scores.md and risk-scores.sarif

--- a/docs/architecture/01_system_design/README.md
+++ b/docs/architecture/01_system_design/README.md
@@ -843,3 +843,61 @@ graph LR
 | Bash | VERSION file generation script | Lightweight, no runtime dependencies |
 | GitHub Actions YAML | CI workflow definition | Standard for GitHub CI/CD |
 | `codeql/upload-sarif@v3` | SARIF upload to Code Scanning | GitHub's official SARIF upload action |
+
+---
+
+### Feature 035: Quantitative Risk Scoring
+
+## Components
+
+### Component 1: Risk Score Command
+
+**File**: `.claude/commands/risk-score.md`
+**Type**: New file
+**Purpose**: `/risk-score` command definition — flag parsing, input validation, agent invocation, output summary. Follows the `/threat-model` command pattern.
+
+### Component 2: Risk Scorer Agent
+
+**File**: `.claude/agents/tachi/risk-scorer.md`
+**Type**: New file
+**Purpose**: Core scoring agent — parses threat findings, assesses 4 dimensions (CVSS 3.1, exploitability, scalability, reachability), calculates weighted composite, attaches governance fields, generates dual output.
+
+### Component 3: Risk Scoring Schema
+
+**File**: `schemas/risk-scoring.yaml`
+**Type**: New file
+**Purpose**: Scored finding schema extending `finding.yaml` with scoring dimensions, composite weights, category-level CVSS defaults, and severity band definitions aligned with `output.yaml`.
+
+### Component 4: Output Templates
+
+**Files**: `templates/risk-scores.md`, `templates/risk-scores.sarif`
+**Type**: New files
+**Purpose**: Markdown template (executive summary, scored threat table, methodology section) and SARIF template (extended property bag with per-finding composite scores and governance fields).
+
+### Component 5: Adapter Distribution
+
+**Files**: `adapters/claude-code/commands/risk-score.md`, `adapters/claude-code/agents/risk-scorer.md`
+**Type**: New files
+**Purpose**: Adapter copies for Claude Code distribution, following existing adapter pattern.
+
+## Data Flow
+
+```mermaid
+graph LR
+    A["/threat-model output<br>threats.md + threats.sarif"] --> B["/risk-score command"]
+    C["architecture.md<br>(optional)"] --> B
+    B --> D["risk-scorer agent"]
+    D --> E["risk-scores.md"]
+    D --> F["risk-scores.sarif"]
+```
+
+Pipeline: Parse threats → Extract trust zones → Score 4 dimensions per finding → Calculate composite + governance → Generate dual output. Input precedence: `threats.md` canonical, `threats.sarif` fallback.
+
+## Tech Stack
+
+| Technology | Purpose | Justification |
+|------------|---------|---------------|
+| Markdown | Command and agent prompt files | Follows existing tachi agent pattern |
+| YAML | Scoring schema, category defaults, weights | Consistent with `finding.yaml`/`output.yaml` |
+| SARIF 2.1.0 JSON | Machine-readable scored output | Extends existing `threats.sarif` with scoring properties |
+| CVSS 3.1 | Base scoring standard | Industry standard, NVD/GitHub Advisory Database compatible |

--- a/docs/product/02_PRD/035-quantitative-risk-scoring-2026-03-27.md
+++ b/docs/product/02_PRD/035-quantitative-risk-scoring-2026-03-27.md
@@ -1,0 +1,461 @@
+---
+prd:
+  number: "035"
+  topic: quantitative-risk-scoring
+  created: 2026-03-27
+  status: Approved
+  type: feature
+triad:
+  pm_signoff: { agent: product-manager, date: 2026-03-27, status: APPROVED_WITH_CONCERNS, notes: "Addressed architect and team-lead feedback; severity bands aligned, determinism reframed, context window risk added" }
+  architect_signoff: { agent: architect, date: 2026-03-27, status: APPROVED_WITH_CONCERNS, notes: "Feasible with caveats: reframe determinism as reproducible-within-tolerance, target CVSS 3.1, clarify SARIF file relationship, fix no-external-API wording" }
+  techlead_signoff: { agent: team-lead, date: 2026-03-27, status: APPROVED_WITH_CONCERNS, notes: "Feasible 8.5-10.5h across 3 waves; P0 scope overloaded vs precedent; recommend resolving open questions before spec; context window risk missing" }
+source:
+  idea_id: 35
+  story_id: null
+---
+
+# Quantitative Risk Scoring - Product Requirements Document
+
+**Status**: Draft
+**Created**: 2026-03-27
+**Author**: product-manager
+**Reviewers**: architect, team-lead
+**Priority**: P1
+
+---
+
+## Executive Summary
+
+### The One-Liner
+A `/risk-score` command that replaces tachi's qualitative risk ratings with quantitative scores based on CVSS, exploitability, scalability, and reachability analysis.
+
+### Problem Statement
+tachi's `/threat-model` currently produces qualitative risk ratings using a 3x3 OWASP matrix (Likelihood HIGH/MEDIUM/LOW x Impact HIGH/MEDIUM/LOW = Risk Level Critical/High/Medium/Low). While useful for initial triage, this approach is insufficient for security managers who need quantitative scores for remediation prioritization, SLA assignment, risk acceptance decisions, and executive reporting. Two threats rated "High" today are treated identically despite potentially having very different real-world risk profiles.
+
+### Proposed Solution
+A new `/risk-score` command that takes existing `/threat-model` output (`threats.md` or `threats.sarif`) and enriches each threat with four quantitative scoring dimensions -- CVSS Base, Exploitability, Scalability, and Reachability -- producing a composite score (0.0-10.0) per threat. The command also attaches risk governance fields (owner, SLA, disposition, review date) for remediation tracking.
+
+### Success Criteria
+- Security engineers can differentiate between threats that were previously rated identically
+- Scored output enables precise remediation prioritization by composite score
+- SARIF output includes CVSS scores compatible with GRC tooling import
+- Reachability analysis leverages architecture trust boundaries for context-aware scoring
+
+### Timeline
+- **Estimated effort**: 8.5-10.5 hours across 3 implementation waves (Team-Lead estimate)
+- **Next step**: `/aod.plan` after PRD approval
+
+---
+
+## Strategic Alignment
+
+### Product Vision Alignment
+**Reference**: [product-vision.md](../01_Product_Vision/product-vision.md)
+
+tachi's vision is to be "the default threat modeling toolkit for any team building agentic AI applications." Quantitative risk scoring transforms tachi from a threat identification tool into a risk management tool -- a critical capability for enterprise adoption where security managers require actionable, quantitative metrics for prioritization and reporting.
+
+### Core Value Reinforcement
+tachi already models AI-specific threats alongside STRIDE. Quantitative scoring makes these findings actionable by answering "which threats do I fix first and why?" with data-backed answers rather than qualitative judgment.
+
+---
+
+## Target Users & Personas
+
+### Primary Persona: Security Engineer
+- **Role**: Hands-on security practitioner running threat models
+- **Experience**: Intermediate-to-advanced security knowledge, familiar with CVSS
+- **Goals**: Prioritize remediation work by actual risk, not qualitative gut feel
+- **Pain Points**: Current qualitative ratings treat all "High" threats equally; no way to differentiate between a High threat that's trivially exploitable vs. one requiring complex attack chains
+- **Why This Matters**: Composite scores with dimensional breakdown let them justify remediation order to management and focus effort where risk is highest
+
+### Secondary Persona: Security Manager
+- **Role**: Manages security program, reports to CISO/executive leadership
+- **Experience**: Broad security knowledge, focused on governance and compliance
+- **Goals**: Assign remediation SLAs, make risk acceptance decisions, produce executive reports
+- **Pain Points**: Qualitative ratings don't map to SLA tiers; no governance fields for tracking remediation commitments; reporting to leadership requires quantitative metrics
+- **Why This Matters**: Risk governance fields (owner, SLA, disposition, review date) enable formal risk tracking, and quantitative scores enable executive dashboards
+
+### Tertiary Persona: Architect
+- **Role**: System architect reviewing threat model output for their architecture
+- **Experience**: Deep understanding of system architecture, moderate security knowledge
+- **Goals**: Understand which components carry the most risk based on their actual exposure
+- **Pain Points**: Current ratings don't account for trust boundary depth -- an internet-facing component and an internal-only component can receive the same risk rating
+- **Why This Matters**: Reachability analysis uses architecture trust boundaries to produce context-aware scores that reflect actual exposure
+
+---
+
+## User Stories
+
+### US-1: Quantitative Threat Scoring
+**When** I have completed a `/threat-model` run and have `threats.md` or `threats.sarif` output,
+**I want to** run `/risk-score` to calculate CVSS base + exploitability + scalability + reachability scores for each threat,
+**So I can** prioritize remediation by quantitative risk rather than qualitative gut feel.
+
+**Acceptance Criteria**:
+- **Given** a valid `threats.md` from `/threat-model`, **when** I run `/risk-score`, **then** each threat receives scores for all four dimensions (CVSS base 0.0-10.0, exploitability 0.0-10.0, scalability 0.0-10.0, reachability 0.0-10.0)
+- **Given** a valid `threats.sarif` from `/threat-model`, **when** I run `/risk-score`, **then** the same scoring applies with results in SARIF format
+- **Given** scored threats, **when** I view the composite score, **then** it is a weighted combination of the four dimensions on a 0.0-10.0 scale
+- **Given** a threat with CVSS base mapped from its category, **when** I review the CVSS assessment, **then** it references CVSS 3.1/4.0 base metrics (attack vector, attack complexity, privileges required, user interaction)
+
+**Priority**: P0
+**Effort**: L
+
+### US-2: Risk Governance Fields
+**When** I have scored threats from `/risk-score`,
+**I want to** see risk governance fields (owner, SLA, disposition, review date) attached to each threat,
+**So I can** track remediation commitments and risk acceptance decisions.
+
+**Acceptance Criteria**:
+- **Given** a scored threat with composite score >= 9.0 (Critical), **when** governance fields are generated, **then** SLA defaults to 24 hours and disposition defaults to "Mitigate"
+- **Given** a scored threat with composite score 7.0-8.9 (High), **when** governance fields are generated, **then** SLA defaults to 7 days and disposition defaults to "Mitigate"
+- **Given** a scored threat with composite score 4.0-6.9 (Medium), **when** governance fields are generated, **then** SLA defaults to 30 days and disposition defaults to "Review"
+- **Given** a scored threat with composite score < 4.0 (Low), **when** governance fields are generated, **then** SLA defaults to 90 days and disposition defaults to "Review"
+- **Given** any scored threat, **when** the owner field is generated, **then** it defaults to "Unassigned" for manual population
+
+**Priority**: P0
+**Effort**: M
+
+### US-3: Dual Output Formats
+**When** `/risk-score` completes,
+**I want to** receive output in both human-readable (`risk-scores.md`) and machine-readable (`risk-scores.sarif`) formats,
+**So I can** use scored output for reporting and integrate it with GRC tooling.
+
+**Acceptance Criteria**:
+- **Given** scored threats, **when** `risk-scores.md` is generated, **then** it contains a table sorted by composite score descending with columns: ID, Component, Threat, CVSS, Exploitability, Scalability, Reachability, Composite, Severity, SLA, Disposition
+- **Given** scored threats, **when** `risk-scores.sarif` is generated, **then** it validates against SARIF 2.1.0 schema
+- **Given** `risk-scores.sarif`, **when** imported into GitHub Code Scanning, **then** the `security-severity` property reflects the composite score (not the static mapping used today)
+- **Given** both output files, **when** I compare them, **then** all scores and governance fields are consistent between formats
+
+**Priority**: P0
+**Effort**: M
+
+### US-4: Reachability-Aware Scoring
+**When** I run `/risk-score` with an `architecture.md` that contains trust boundaries,
+**I want to** reachability scores adjusted based on component exposure,
+**So that** threats against components behind multiple trust boundaries are scored lower than internet-facing components.
+
+**Acceptance Criteria**:
+- **Given** a threat targeting a component inside a trust boundary, **when** reachability is assessed, **then** the reachability score is reduced proportionally to boundary depth
+- **Given** a threat targeting an internet-facing component with no trust boundary, **when** reachability is assessed, **then** the reachability score reflects maximum exposure
+- **Given** a threat targeting a component behind authentication + VPN, **when** reachability is assessed, **then** the reachability score is significantly lower than the same threat against a public endpoint
+- **Given** an architecture with no trust boundaries defined, **when** reachability is assessed, **then** a default medium reachability (5.0) is applied with a warning
+
+**Priority**: P1
+**Effort**: L
+
+---
+
+## Functional Requirements
+
+### Core Capabilities
+
+#### FR-1: Threat Parsing
+**Description**: Parse threat findings from `/threat-model` output files.
+
+**Inputs**: `threats.md` (markdown table format) or `threats.sarif` (SARIF 2.1.0 JSON)
+**Processing**: Extract threat ID, component, threat description, category (STRIDE/AI), existing likelihood/impact ratings
+**Outputs**: Structured threat list ready for scoring
+
+**Business Rules**:
+- Must support both input formats interchangeably
+- Must preserve all original threat metadata through the scoring pipeline
+- Must validate input exists and is parseable before scoring begins
+- If input is missing, exit with clear error: "No threat model output found. Run `/threat-model` first."
+
+#### FR-2: CVSS Base Scoring
+**Description**: Map each threat to a CVSS 3.1/4.0 base score based on threat category and description.
+
+**Scoring Approach**:
+- Map STRIDE category + threat description to CVSS base vector
+- Attack Vector (AV): Derived from component exposure (Network/Adjacent/Local/Physical)
+- Attack Complexity (AC): Derived from threat description complexity indicators
+- Privileges Required (PR): Derived from authentication requirements
+- User Interaction (UI): Derived from whether attack requires user action
+- Scope (S): Derived from whether attack crosses trust boundaries
+
+**Output**: CVSS base score 0.0-10.0 per threat
+
+#### FR-3: Exploitability Assessment
+**Description**: Assess how exploitable each threat is in practice.
+
+**Scoring Dimensions**:
+- Known exploit/technique existence (public PoCs, CVE references, MITRE ATT&CK mappings)
+- Attack complexity (single-step vs. multi-step attack chain)
+- Tooling availability (automated tools exist vs. manual-only exploitation)
+- Skill level required (script kiddie vs. advanced persistent threat)
+
+**Output**: Exploitability score 0.0-10.0 per threat
+
+#### FR-4: Scalability Assessment
+**Description**: Evaluate whether the attack can be automated against many targets.
+
+**Scoring Dimensions**:
+- Scriptability (can the attack be automated?)
+- Target scope (single target vs. mass target)
+- Resource requirements (minimal vs. significant infrastructure needed)
+- Detection difficulty (easily detected vs. stealthy at scale)
+
+**Output**: Scalability score 0.0-10.0 per threat
+
+#### FR-5: Reachability Analysis
+**Description**: Analyze trust boundaries and exposure from `architecture.md` to determine component reachability.
+
+**Scoring Dimensions**:
+- Trust boundary depth (0 = internet-facing, higher = more protected)
+- Authentication barriers (none, single-factor, multi-factor)
+- Network exposure (public internet, VPN-only, internal-only)
+- Access control complexity (open, role-based, attribute-based)
+
+**Primary Data Source**: Trust zone table in `threats.md` Section 2 (zone names, trust levels, component assignments -- already produced by `/threat-model`). Boundary depth is inferred from zone metadata, not structurally encoded.
+**Supplementary Input**: `architecture.md` Mermaid diagram for richer context (authentication barriers, network exposure details not captured in the trust zone summary)
+**Output**: Reachability score 0.0-10.0 per threat (higher = more reachable = higher risk)
+
+#### FR-6: Composite Score Calculation
+**Description**: Combine four dimensions into a single composite risk score.
+
+**Weighted Formula**:
+```
+Composite = (w1 * CVSS) + (w2 * Exploitability) + (w3 * Scalability) + (w4 * Reachability)
+```
+
+**Default Weights** (configurable):
+| Dimension | Weight | Rationale |
+|-----------|--------|-----------|
+| CVSS Base | 0.35 | Severity of the vulnerability class is the primary driver |
+| Exploitability | 0.30 | Practical exploitability determines real-world risk |
+| Scalability | 0.15 | Mass-target capability amplifies risk |
+| Reachability | 0.20 | Exposure context adjusts risk to architecture reality |
+
+**Output**: Composite score 0.0-10.0 per threat, mapped to severity bands (aligned with existing `schemas/output.yaml` CVSS ranges):
+| Composite Score | Severity | SLA Default |
+|----------------|----------|-------------|
+| 9.0 - 10.0 | Critical | 24 hours |
+| 7.0 - 8.9 | High | 7 days |
+| 4.0 - 6.9 | Medium | 30 days |
+| 0.0 - 3.9 | Low | 90 days |
+
+#### FR-7: Risk Governance Fields
+**Description**: Attach governance metadata to each scored threat.
+
+**Fields Per Threat**:
+| Field | Default | Purpose |
+|-------|---------|---------|
+| Risk Owner | "Unassigned" | Responsible party for remediation |
+| Remediation SLA | Severity-driven | Timeline for resolution |
+| Risk Disposition | Mitigate (Critical/High), Review (Medium/Low) | Action decision |
+| Review Date | SLA deadline | When accepted risks must be re-evaluated |
+
+#### FR-8: Output Generation
+**Description**: Produce scored output in dual formats.
+
+**risk-scores.md**: Human-readable markdown with:
+- Executive summary (total threats by severity band, highest-risk component)
+- Scored threat table sorted by composite score descending
+- Dimensional breakdown per threat
+- Governance fields per threat
+- Scoring methodology explanation
+- Weight configuration used
+
+**risk-scores.sarif**: Machine-readable SARIF 2.1.0 with:
+- `properties.security-severity` set to composite score (string format, e.g., "7.8")
+- `properties.cvss-base` with CVSS 3.1 base score
+- `properties.exploitability` with exploitability score
+- `properties.scalability` with scalability score
+- `properties.reachability` with reachability score
+- `properties.risk-owner`, `properties.remediation-sla`, `properties.risk-disposition`
+- `partialFingerprints.findingId/v1` preserved from source `threats.sarif` for alert continuity
+- Results sorted by composite score descending
+
+**SARIF file relationship**: `risk-scores.sarif` supersedes `threats.sarif` for GitHub Code Scanning upload. It contains the same findings with enriched scoring properties. Users should upload `risk-scores.sarif` (not both files) to avoid duplicate alerts. Finding fingerprints (`findingId/v1`) are preserved for alert tracking continuity.
+
+**Output location**: Output files are written to the same directory as the `/threat-model` output, alongside `threats.md` and `threats.sarif`.
+
+### Interface Contract
+
+**Command**: `/risk-score`
+
+**Input** (required):
+- `threats.md` OR `threats.sarif` -- from `/threat-model` output
+
+**Input** (optional):
+- `architecture.md` -- for reachability analysis of trust boundaries
+
+**Output** (produces):
+- `risk-scores.md` -- scored threat table with dimensional breakdown
+- `risk-scores.sarif` -- SARIF 2.1.0 with scoring properties
+
+**Dependencies**:
+- Requires `/threat-model` output to exist
+- Architecture input is optional but recommended for reachability accuracy
+
+---
+
+## Non-Functional Requirements
+
+### Performance
+- Scoring 50 threats: < 60 seconds
+- Scoring 200 threats: < 5 minutes
+- No external vulnerability database lookups (CVE/NVD) required -- all scoring via LLM analysis of threat descriptions (LLM API calls are inherent to tachi's agent architecture)
+
+### Reliability
+- Graceful handling of malformed threat input (skip individual threats, report errors, continue)
+- Reproducible scoring: same input produces scores within +/- 0.5 tolerance per dimension across runs (temperature 0; exact determinism not guaranteed across LLM model versions)
+- If `architecture.md` is missing, apply default reachability (5.0) with warning
+
+### Compatibility
+- SARIF output validates against SARIF 2.1.0 JSON schema
+- SARIF compatible with GitHub Code Scanning upload
+- Composite score maps to existing severity bands for backward compatibility with qualitative ratings
+
+### Extensibility
+- Scoring weights configurable (future: per-project weight profiles)
+- Additional scoring dimensions can be added without changing composite formula structure
+- Governance field defaults configurable (future: per-organization SLA policies)
+
+---
+
+## Success Metrics
+
+### Primary Metrics
+- **Score Differentiation**: Threats previously rated identically (e.g., two "High" threats) receive different composite scores in >= 80% of cases
+- **Prioritization Accuracy**: User validates that top-5 composite-scored threats match their intuitive risk ranking in >= 70% of cases
+- **SLA Coverage**: 100% of scored threats have governance fields populated
+
+### Secondary Metrics
+- **Adoption**: `/risk-score` is run after >= 50% of `/threat-model` invocations (measured by example usage patterns)
+- **Format Compliance**: `risk-scores.sarif` validates against SARIF 2.1.0 schema in 100% of runs
+
+---
+
+## Scope & Boundaries
+
+### In Scope (Phase 1)
+
+**Must Have (P0)**:
+- `/risk-score` command parsing `threats.md` and `threats.sarif`
+- CVSS base scoring per threat
+- Exploitability assessment per threat
+- Scalability assessment per threat
+- Reachability analysis using `architecture.md` trust boundaries
+- Composite score calculation with configurable weights
+- Risk governance fields (owner, SLA, disposition, review date)
+- `risk-scores.md` output with dimensional breakdown
+- `risk-scores.sarif` output validating against SARIF 2.1.0
+
+**Should Have (P1)**:
+- Scoring methodology explanation section in `risk-scores.md`
+- Executive summary with severity band distribution
+- Example output against `examples/agentic-app/`
+
+### Out of Scope (Future Phases)
+
+**Won't Have**:
+- Custom weight profiles per project (Phase 2)
+- Historical score trending across multiple runs (Phase 2)
+- Integration with external vulnerability databases (CVE/NVD lookup) (Phase 2)
+- Compensating controls analysis that adjusts scores based on existing mitigations (separate feature -- Issue B)
+- Interactive score override/adjustment UI (Phase 3)
+- Financial impact estimation (cost-of-breach modeling) (Phase 3)
+
+### Assumptions
+- LLM analysis provides sufficiently consistent CVSS mapping for threat categories
+- Trust boundary annotations in `architecture.md` Mermaid diagrams are parseable
+- Default scoring weights serve the majority of use cases
+
+### Constraints
+- **No external vulnerability database dependencies**: All scoring performed via LLM analysis; no CVE/NVD lookups required (LLM API is inherent to tachi)
+- **tachi scope**: This is a CLI/agent command, not a web service
+- **Dependency**: Requires `/threat-model` to have been run first
+
+---
+
+## Risks & Dependencies
+
+### Technical Risks
+
+**Risk 1**: CVSS mapping consistency
+- **Likelihood**: Medium
+- **Impact**: High
+- **Mitigation**: Establish mapping tables for common STRIDE/AI threat categories; use LLM with structured output format and reference examples
+- **Contingency**: Fall back to category-level default scores if per-threat mapping proves inconsistent
+
+**Risk 2**: Trust boundary parsing from Mermaid diagrams
+- **Likelihood**: Medium
+- **Impact**: Medium
+- **Mitigation**: Define supported Mermaid trust boundary syntax; fail gracefully with default reachability if parsing fails
+- **Contingency**: Accept `architecture.md` as optional input; reachability defaults to 5.0 without it
+
+**Risk 3**: Score calibration
+- **Likelihood**: High
+- **Impact**: Medium
+- **Mitigation**: Validate against `examples/agentic-app/` output; compare composite scores against security expert intuition; include calibration as an explicit task in task breakdown
+- **Contingency**: Iterate on weights and scoring rubrics based on user feedback
+
+**Risk 4**: Context window pressure
+- **Likelihood**: Medium
+- **Impact**: High
+- **Mitigation**: A 50-threat model with 4 scoring dimensions could approach 40,000-50,000 tokens. Process threats in the scoring agent with structured output format to minimize token overhead. Consider batching for large threat models (>100 findings).
+- **Contingency**: Split scoring into per-dimension sub-invocations if single-pass exceeds context limits
+
+### Dependencies
+
+**Internal Dependencies**:
+- `/threat-model` command (existing, delivered) -- provides input
+- SARIF generation reference (`adapters/claude-code/agents/references/sarif-generation.md`) -- schema guidance
+- Example architectures (`examples/`) -- validation targets
+
+**Dependency Graph**:
+```
+/threat-model (existing)
+  |
+  v
+/risk-score (this feature)
+  |
+  v
+Compensating Controls (future, Issue B)
+```
+
+---
+
+## Open Questions
+
+- [x] Should composite weights be declared in `architecture.md` frontmatter or a separate config file? - architect - 2026-03-27 - **Resolved**: Weights defined in `schemas/risk-scoring.yaml` (consistent with existing schema patterns). Phase 1 defaults hardcoded in command; separate config is Phase 2.
+- [x] Should `/risk-score` be chainable from `/threat-model` (auto-run option) or always standalone? - product-manager - 2026-03-27 - **Resolved**: Standalone command for Phase 1. Optional `--risk-score` flag on `/threat-model` for chaining deferred to Phase 2.
+- [x] What CVSS version to target: 3.1 (widely adopted) or 4.0 (newer, richer)? - architect - 2026-03-27 - **Resolved**: CVSS 3.1 primary (NVD, GitHub Advisory Database, GRC tooling compatibility). Schema structured to accept 4.0 vectors when adoption matures.
+
+---
+
+## References
+
+### Product Documentation
+- Product Vision: [product-vision.md](../01_Product_Vision/product-vision.md)
+- GitHub Issue: [#35 - Quantitative Risk Scoring](https://github.com/davidmatousek/tachi/issues/35)
+
+### Technical Documentation
+- Constitution: [constitution.md](../../.aod/memory/constitution.md)
+- SARIF Reference: `adapters/claude-code/agents/references/sarif-generation.md`
+- ADR-013: SARIF Output Format Adoption
+
+### Related PRDs
+- PRD-010: [Deduplication & Risk Rating](010-deduplication-risk-rating-2026-03-22.md) -- established the qualitative 3x3 matrix this feature enhances
+- PRD-012: [SARIF Output Generation](012-sarif-output-generation-2026-03-22.md) -- SARIF format this feature extends
+- PRD-015: [Threat Report Agent & Attack Trees](015-threat-report-agent-attack-trees-2026-03-23.md) -- narrative report that may consume scored output in future
+
+---
+
+## Approval & Sign-Off
+
+| Role | Agent | Status | Date | Comments |
+|------|-------|--------|------|----------|
+| Product Manager | product-manager | APPROVED_WITH_CONCERNS | 2026-03-27 | Addressed reviewer feedback; severity bands aligned, determinism reframed |
+| Architect | architect | APPROVED_WITH_CONCERNS | 2026-03-27 | Target CVSS 3.1; clarify SARIF relationship; reframe determinism |
+| Team Lead | team-lead | APPROVED_WITH_CONCERNS | 2026-03-27 | 8.5-10.5h estimate; P0 scope heavy vs precedent; add context window risk |
+
+---
+
+## Version History
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.0 | 2026-03-27 | product-manager | Initial PRD from GitHub Issue #35 |
+| 1.1 | 2026-03-27 | product-manager | Addressed Architect + Team-Lead review concerns: aligned severity bands with schemas/output.yaml, reframed determinism as reproducible-within-tolerance, clarified SARIF file relationship, added context window risk, resolved 3 open questions, added timeline estimate |

--- a/docs/product/02_PRD/INDEX.md
+++ b/docs/product/02_PRD/INDEX.md
@@ -1,10 +1,11 @@
 # PRD Index
 
-**Last Updated**: 2026-03-25
+**Last Updated**: 2026-03-27
 
 
 | # | Feature | PM | Architect | Team-Lead | Status | Date |
 |---|---------|----|-----------|-----------| -------|------|
+| 035 | [Quantitative Risk Scoring](035-quantitative-risk-scoring-2026-03-27.md) | ⚠ | ⚠ | ⚠ | Approved | 2026-03-27 |
 | 029 | [Agent Refactoring: Right-Size](029-agent-refactoring-right-size-2026-03-25.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-25 |
 | 024 | [Example Threat Models](024-example-threat-models-2026-03-23.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-23 |
 | 021 | [Platform Adapters](021-platform-adapters-2026-03-23.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-23 |

--- a/docs/product/_backlog/BACKLOG.md
+++ b/docs/product/_backlog/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-> Auto-generated from GitHub Issues on 2026-03-25T19:31:26Z.
+> Auto-generated from GitHub Issues on 2026-03-27T19:40:10Z.
 > Source of truth: GitHub Issues with `stage:*` labels.
 > Regenerate: `/aod.status` or `.aod/scripts/bash/backlog-regenerate.sh`
 
@@ -40,6 +40,8 @@
 
 | # | Title | State | Updated |
 |---|-------|-------|---------|
+| #36 | Feature: Compensating Controls — Detection, Recommendations, and Residual Risk | OPEN | 2026-03-27 |
+| #35 | Feature: Quantitative Risk Scoring — CVSS, Exploitability, Scalability, Reachability | OPEN | 2026-03-27 |
 | #27 | Developer Guide: Automated Threat Modeling for Your Architecture | CLOSED | 2026-03-24 |
 | #18 | Feature: Threat Infographic Agent | CLOSED | 2026-03-23 |
 | #15 | Feature 007: Threat Report Agent & Attack Trees | CLOSED | 2026-03-23 |

--- a/examples/agentic-app/sample-report/risk-scores.md
+++ b/examples/agentic-app/sample-report/risk-scores.md
@@ -1,0 +1,1069 @@
+# Risk Scores Report
+
+---
+
+```yaml
+---
+schema_version: "1.0"
+date: "2026-03-27"
+source_file: "threats.md"
+classification: "confidential"
+scoring_weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+---
+```
+
+---
+
+## 1. Executive Summary
+
+**34 findings** scored across 8 threat categories (Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, Elevation of Privilege, Agentic Threats, LLM Threats).
+
+**Highest-Risk Component**: LLM Agent Orchestrator (composite: 8.3, severity: High)
+
+| Metric | Value |
+|--------|-------|
+| Scoring date | 2026-03-27 |
+| Source file | `threats.md` |
+| Schema version | 1.0 |
+
+**Severity Distribution:**
+
+| Severity | Count | Percentage |
+|----------|-------|------------|
+| Critical | 0 | 0.0% |
+| High | 10 | 29.4% |
+| Medium | 24 | 70.6% |
+| Low | 0 | 0.0% |
+| **Total** | **34** | **100%** |
+
+The majority of findings (24 of 34) fall in the Medium band, with 10 High-severity findings requiring priority remediation within 7 days. The LLM Agent Orchestrator is the highest-risk component, reflecting its central role in processing user prompts and dispatching tool calls across trust boundaries.
+
+---
+
+## 2. Scored Threat Table
+
+Findings sorted by Composite score descending (highest risk first). Boundary values map to the higher severity band (e.g., 7.0 = High, 9.0 = Critical).
+
+| ID | Component | Threat | CVSS | Exploit. | Scale. | Reach. | Composite | Severity | SLA | Disposition |
+|----|-----------|--------|------|----------|--------|--------|-----------|----------|-----|-------------|
+| LLM-1 | LLM Agent Orchestrator | Adversarial prompts override system prompt, bypassing safe... | 9.8 | 8.8 | 7.3 | 5.5 | 8.3 | High | 7d | Mitigate |
+| S-1 | User | Attacker impersonates legitimate user by replaying or forg... | 8.2 | 7.0 | 6.8 | 9.5 | 7.9 | High | 7d | Mitigate |
+| E-2 | LLM Agent Orchestrator | Attacker escalates to admin tool access through prompt inj... | 9.1 | 7.8 | 6.3 | 5.5 | 7.6 | High | 7d | Mitigate |
+| AG-1 | LLM Agent Orchestrator | Orchestrator executes consequential actions without human ... | 9.1 | 7.8 | 6.3 | 5.5 | 7.6 | High | 7d | Mitigate |
+| E-3 | MCP Tool Server | User invokes admin tool endpoints by manipulating tool_nam... | 9.9 | 6.8 | 5.8 | 5.5 | 7.5 | High | 7d | Mitigate |
+| D-1 | Guardrails Service | Attacker floods Guardrails Service to exhaust CPU on regex... | 7.5 | 8.5 | 7.8 | 5.5 | 7.4 | High | 7d | Mitigate |
+| D-2 | LLM Agent Orchestrator | Attacker sends concurrent max-length prompts to exhaust LL... | 7.5 | 8.3 | 7.5 | 5.5 | 7.3 | High | 7d | Mitigate |
+| S-3 | LLM Agent Orchestrator | Attacker forges tool call requests to MCP Tool Server by i... | 9.8 | 6.0 | 5.5 | 5.5 | 7.2 | High | 7d | Mitigate |
+| T-3 | MCP Tool Server | Attacker manipulates JSON-RPC tool call parameters in tran... | 8.8 | 6.8 | 5.8 | 5.5 | 7.1 | High | 7d | Mitigate |
+| AG-3 | MCP Tool Server | MCP Tool Server exposes all tools to every client without ... | 9.1 | 6.3 | 5.5 | 5.5 | 7.0 | High | 7d | Mitigate |
+| S-2 | Guardrails Service | Attacker bypasses Guardrails by directly accessing Orchest... | 8.2 | 6.5 | 5.0 | 5.5 | 6.7 | Medium | 30d | Review |
+| E-1 | Guardrails Service | Attacker bypasses Guardrails via alternate route to Orches... | 8.8 | 5.8 | 4.8 | 5.5 | 6.6 | Medium | 30d | Review |
+| D-3 | MCP Tool Server | Resource exhaustion through concurrent tool calls without ... | 7.5 | 6.3 | 5.5 | 5.5 | 6.4 | Medium | 30d | Review |
+| AG-4 | MCP Tool Server | Tool call chaining enables capability escalation beyond in... | 7.5 | 6.3 | 5.5 | 5.5 | 6.4 | Medium | 30d | Review |
+| T-4 | Knowledge Base | Attacker injects malicious content into Knowledge Base via... | 7.1 | 6.5 | 5.3 | 5.5 | 6.3 | Medium | 30d | Review |
+| LLM-2 | LLM Agent Orchestrator | Indirect prompt injection via adversarial content in Knowl... | 7.1 | 6.5 | 5.3 | 5.5 | 6.3 | Medium | 30d | Review |
+| I-1 | Guardrails Service | Rejection reasons reveal internal filtering rules to attac... | 5.3 | 7.8 | 6.0 | 5.5 | 6.2 | Medium | 30d | Review |
+| T-2 | LLM Agent Orchestrator | Attacker injects malicious content by tampering with data ... | 7.1 | 6.0 | 5.0 | 5.5 | 6.1 | Medium | 30d | Review |
+| D-4 | Knowledge Base | Unbounded vector search queries with adversarial inputs ex... | 7.5 | 5.3 | 4.5 | 5.5 | 6.0 | Medium | 30d | Review |
+| I-4 | Knowledge Base | Query responses include internal metadata, embedding vecto... | 5.3 | 7.0 | 5.5 | 5.5 | 5.9 | Medium | 30d | Review |
+| T-1 | Guardrails Service | Attacker modifies validation rules at runtime without inte... | 7.1 | 5.3 | 4.3 | 5.5 | 5.8 | Medium | 30d | Review |
+| S-4 | MCP Tool Server | Attacker redirects outbound API requests by spoofing DNS o... | 7.4 | 4.5 | 4.3 | 5.5 | 5.7 | Medium | 30d | Review |
+| I-3 | MCP Tool Server | Raw External API error responses forwarded without sanitiz... | 6.5 | 5.0 | 5.0 | 5.5 | 5.6 | Medium | 30d | Review |
+| I-2 | LLM Agent Orchestrator | Verbose error messages leak internal service topology and ... | 6.5 | 4.8 | 4.5 | 5.5 | 5.5 | Medium | 30d | Review |
+| T-5 | Audit Logger | Attacker modifies or deletes audit log entries to cover tr... | 7.1 | 4.3 | 3.5 | 5.5 | 5.4 | Medium | 30d | Review |
+| D-5 | Audit Logger | High-volume logging events cause storage exhaustion disrup... | 5.3 | 5.3 | 5.0 | 5.5 | 5.3 | Medium | 30d | Review |
+| R-3 | LLM Agent Orchestrator | Orchestrator executes tool calls without logging full deci... | 5.3 | 5.0 | 5.0 | 5.5 | 5.2 | Medium | 30d | Review |
+| AG-2 | LLM Agent Orchestrator | Orchestrator operates in unbounded reasoning loop without ... | 5.3 | 5.0 | 5.0 | 5.5 | 5.2 | Medium | 30d | Review |
+| I-5 | Audit Logger | Audit logs contain sensitive data accessible beyond the se... | 6.5 | 4.0 | 3.8 | 5.5 | 5.1 | Medium | 30d | Review |
+| LLM-3 | LLM Agent Orchestrator | Systematic querying enables model extraction through disti... | 5.3 | 4.5 | 4.8 | 5.5 | 5.0 | Medium | 30d | Review |
+| R-1 | User | User denies having submitted a specific prompt without non... | 4.3 | 3.0 | 3.0 | 9.5 | 4.8 | Medium | 30d | Review |
+| R-5 | External API | External API interactions lack correlation identifiers for... | 4.3 | 2.5 | 2.8 | 9.5 | 4.6 | Medium | 30d | Review |
+| R-2 | Guardrails Service | Insufficient detail in filtering event logs prevents recon... | 4.3 | 4.3 | 3.8 | 5.5 | 4.5 | Medium | 30d | Review |
+| R-4 | MCP Tool Server | Tool executions lack requesting orchestrator context for f... | 4.3 | 3.8 | 3.5 | 5.5 | 4.3 | Medium | 30d | Review |
+
+### Column Definitions
+
+| Column | Description |
+|--------|-------------|
+| **ID** | Original finding identifier from the threat model (e.g., `S-1`, `T-2`, `AG-1`, `LLM-3`). Preserves the source finding ID without modification. |
+| **Component** | Target component name as identified in the threat model. |
+| **Threat** | Threat description, truncated to fit table width. Full description available in the Dimensional Breakdown (Section 3). |
+| **CVSS** | CVSS 3.1 base score (0.0-10.0). Derived from attack vector, attack complexity, privileges required, user interaction, scope, and CIA impact. Full vector string shown in Section 3. |
+| **Exploit.** | Exploitability score (0.0-10.0). Average of four sub-dimensions: known techniques, attack complexity, tooling availability, and skill level required. |
+| **Scale.** | Scalability score (0.0-10.0). Average of four sub-dimensions: scriptability, target scope, resource requirements, and detection difficulty. |
+| **Reach.** | Reachability score (0.0-10.0). Derived from trust zone placement: Untrusted/External = 8.0-10.0, Semi-Trusted/Application = 4.0-7.0, Trusted/Internal = 1.0-4.0. Default 5.0 when trust zone data is unavailable. |
+| **Composite** | Weighted composite score (0.0-10.0). Formula: `(0.35 x CVSS) + (0.30 x Exploit.) + (0.15 x Scale.) + (0.20 x Reach.)`. |
+| **Severity** | Severity band mapped from composite score: Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9). |
+| **SLA** | Default remediation SLA driven by severity: Critical = 24h, High = 7d, Medium = 30d, Low = 90d. |
+| **Disposition** | Default risk disposition driven by severity: Critical/High = Mitigate, Medium/Low = Review. May be overridden in the Governance Fields table (Section 4). |
+
+> **Correlated findings**: For correlation groups (Section 4a of the source threat model), the primary finding is scored independently. Correlated peer findings inherit the primary's scores to maintain group consistency. Groups: CG-1 (T-4 primary, LLM-2 peer), CG-2 (E-2 primary, AG-1 peer), CG-3 (R-3 primary, AG-2 peer), CG-4 (D-3 primary, AG-4 peer).
+
+---
+
+## 3. Dimensional Breakdown
+
+Per-finding detail showing the full scoring rationale for each dimension. One subsection per finding, ordered by composite score descending (matching Section 2 sort order).
+
+### LLM-1 -- LLM Agent Orchestrator
+
+**Threat**: Attacker submits adversarial prompts through the Guardrails Service that override the Orchestrator's system prompt, causing it to ignore safety constraints, disclose internal instructions, or produce harmful content, because user input is concatenated into the LLM prompt without structured boundary enforcement between system instructions and user content
+
+**Category**: LLM Threats | **Original Risk Level**: Critical | **Composite**: 8.3 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.8 | 0.35 | 3.43 |
+| Exploitability | 8.8 | 0.30 | 2.64 |
+| Scalability | 7.3 | 0.15 | 1.10 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **8.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 9.8 -- Direct prompt injection is a network-accessible attack requiring no authentication or user interaction. Scope is Changed because compromised orchestrator affects downstream tool server, knowledge base, and external APIs. Full CIA impact due to system prompt extraction (C:H), safety constraint bypass (I:H), and potential for uncontrolled resource consumption (A:H).
+- **Exploitability**: 8.8 -- Prompt injection is extensively documented with thousands of public examples (Known Techniques: 9). Simple text input with no special conditions (Complexity: 9). Multiple frameworks like Garak and PromptBench available (Tooling: 8). No specialized skills needed; copy-paste payloads work (Skill: 9).
+- **Scalability**: 7.3 -- Fully automatable via API calls with rotating payloads (Scriptability: 8). Affects all orchestrator instances with concatenated prompt design (Scope: 7). Minimal resources required (Resources: 8). Partially detectable by input classifiers but evasion techniques are documented (Detection: 6).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5). Not directly internet-facing; user prompts pass through the Guardrails Service first.
+
+---
+
+### S-1 -- User
+
+**Threat**: Attacker impersonates a legitimate user by replaying or forging authentication credentials when submitting prompts to the Guardrails Service, because user identity verification relies solely on bearer tokens without binding to client context such as device fingerprint or IP address
+
+**Category**: Spoofing | **Original Risk Level**: High | **Composite**: 7.9 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 8.2 | 0.35 | 2.87 |
+| Exploitability | 7.0 | 0.30 | 2.10 |
+| Scalability | 6.8 | 0.15 | 1.02 |
+| Reachability | 9.5 | 0.20 | 1.90 |
+| **Composite** | | | **7.9** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 8.2 -- Remote credential replay over HTTPS (AV:N). No special conditions for token replay (AC:L). Attacker uses stolen/forged tokens without prior auth (PR:N). No victim interaction needed (UI:N). Scope Unchanged; spoofed identity operates within the victim's authorization boundary. High confidentiality impact from accessing victim data; low integrity from submitting prompts as victim.
+- **Exploitability**: 7.0 -- Token replay and session hijacking are well-documented (Known: 8). Requires capturing a valid token first (Complexity: 7). Burp Suite, ZAP available for replay attacks (Tooling: 7). Moderate skill for HTTP auth and token interception (Skill: 6).
+- **Scalability**: 6.8 -- Token replay is easily scripted once captured (Scriptability: 8). Affects all users with bearer-token-only auth (Scope: 6). Minimal resources needed (Resources: 8). Replayed tokens are legitimate credentials; detection requires contextual analysis (Detection: 5).
+- **Reachability**: 9.5 -- User component resides in the Untrusted User Zone (baseline 9.0). The "user" keyword adds +0.5, resulting in 9.5. Directly exposed to external attackers as the system entry point.
+
+---
+
+### E-2 -- LLM Agent Orchestrator
+
+**Threat**: Attacker escalates from a standard user role to administrative capabilities by manipulating the orchestrator's tool selection logic through prompt injection, causing it to invoke privileged tool endpoints that should be restricted to administrator roles, because the Orchestrator does not enforce role-based access control on tool dispatch
+
+**Category**: Privilege Escalation | **Original Risk Level**: Critical | **Composite**: 7.6 (High)
+
+**Correlation Group**: CG-2 primary. Peer AG-1 inherits these scores.
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.1 | 0.35 | 3.19 |
+| Exploitability | 7.8 | 0.30 | 2.34 |
+| Scalability | 6.3 | 0.15 | 0.95 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.6** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 9.1 -- Remote prompt injection (AV:N). No special conditions needed (AC:L). Requires standard user account (PR:L). No additional user interaction (UI:N). Scope Changed: privilege escalation crosses user-to-admin boundary. Admin tools expose configuration and user data (C:H), enable modifications (I:H), with limited availability impact (A:L).
+- **Exploitability**: 7.8 -- Prompt injection for tool manipulation is well-documented in agentic AI research (Known: 8). Requires crafting prompts targeting tool selection; some trial-and-error (Complexity: 7). Prompt injection tools exist; tool-specific payloads need customization (Tooling: 7). Understanding of tool dispatch patterns helps but trial-and-error works (Skill: 9).
+- **Scalability**: 6.3 -- Payloads can be automated but may need per-instance tuning (Scriptability: 6). Affects all standard users where RBAC is missing (Scope: 6). Minimal resources needed (Resources: 8). Tool invocation anomalies are detectable with monitoring (Detection: 5).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5). No architecture.md adjustments.
+
+---
+
+### AG-1 -- LLM Agent Orchestrator
+
+**Threat**: LLM Agent Orchestrator executes consequential actions (external API calls via MCP Tool Server, Knowledge Base writes) without human approval gates, because no risk-tier classification distinguishes reversible read operations from irreversible write/delete/send operations, violating the principle that high-stakes agent actions require human-in-the-loop review
+
+**Category**: Agentic Threats | **Original Risk Level**: Critical | **Composite**: 7.6 (High)
+
+**Correlation Group**: Scores inherited from primary finding E-2 (CG-2).
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.1 | 0.35 | 3.19 |
+| Exploitability | 7.8 | 0.30 | 2.34 |
+| Scalability | 6.3 | 0.15 | 0.95 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.6** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 9.1 -- Scores inherited from CG-2 primary E-2. Excessive agent permissions combined with missing human oversight create the same attack surface.
+- **Exploitability**: 7.8 -- Inherited from CG-2 primary E-2.
+- **Scalability**: 6.3 -- Inherited from CG-2 primary E-2.
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone.
+
+---
+
+### E-3 -- MCP Tool Server
+
+**Threat**: Authenticated user invokes administrative tool endpoints on the MCP Tool Server by manipulating the tool_name parameter, because the server does not enforce role-based access control on tool dispatch, allowing standard users to execute privileged operations such as configuration changes and data exports
+
+**Category**: Privilege Escalation | **Original Risk Level**: Critical | **Composite**: 7.5 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.9 | 0.35 | 3.47 |
+| Exploitability | 6.8 | 0.30 | 2.04 |
+| Scalability | 5.8 | 0.15 | 0.87 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.5** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 9.9 -- Remote tool name manipulation via JSON-RPC (AV:N). Simple parameter change (AC:L). Standard user access needed (PR:L). No user interaction (UI:N). Scope Changed: escalation affects external APIs and data stores. Full CIA impact through admin tools: data export (C:H), configuration changes (I:H), service disruption capabilities (A:H).
+- **Exploitability**: 6.8 -- IDOR and parameter manipulation for privilege escalation are well-documented (Known: 7). Requires knowledge of admin tool names; enumeration needed (Complexity: 7). Standard API testing tools support parameter manipulation (Tooling: 6). Moderate skill for JSON-RPC and tool naming conventions (Skill: 7).
+- **Scalability**: 5.8 -- Tool name enumeration and exploitation can be scripted (Scriptability: 6). Affects all standard users reaching the orchestrator (Scope: 5). Minimal resources needed (Resources: 8). Role-based tool access violations are detectable (Detection: 4).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### D-1 -- Guardrails Service
+
+**Threat**: Attacker floods the Guardrails Service with high-volume prompt submissions designed to exhaust CPU on complex regex-based content filtering rules, because no rate limiting or request size caps are enforced at the entry point
+
+**Category**: Denial of Service | **Original Risk Level**: Critical | **Composite**: 7.4 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.5 | 0.35 | 2.63 |
+| Exploitability | 8.5 | 0.30 | 2.55 |
+| Scalability | 7.8 | 0.15 | 1.17 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.4** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 7.5 -- Remote flooding over HTTPS (AV:N). Simple high-volume submission (AC:L). No authentication needed (PR:N). No user interaction (UI:N). Scope Unchanged: DoS affects the Guardrails Service and its direct consumers. No data exposure or modification; high availability impact from CPU exhaustion.
+- **Exploitability**: 8.5 -- HTTP flooding and ReDoS are well-known techniques (Known: 9). Simple high-volume submission; ReDoS payloads are straightforward (Complexity: 9). Many flooding tools freely available (Tooling: 8). Low skill required; script-kiddie tools available (Skill: 8).
+- **Scalability**: 7.8 -- Trivially automatable with scripts or tools (Scriptability: 9). Affects all system users when Guardrails is down (Scope: 7). Moderate bandwidth for volumetric; minimal for ReDoS (Resources: 7). Volumetric DoS detectable but ReDoS payloads blend with normal traffic (Detection: 8).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5). Entry point for user traffic but sits behind the application boundary.
+
+---
+
+### D-2 -- LLM Agent Orchestrator
+
+**Threat**: Attacker sends concurrent requests with maximum-length prompts to the Orchestrator, exhausting LLM inference compute budget and memory, blocking legitimate requests, because no per-client rate limit or token budget cap is enforced
+
+**Category**: Denial of Service | **Original Risk Level**: Critical | **Composite**: 7.3 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.5 | 0.35 | 2.63 |
+| Exploitability | 8.3 | 0.30 | 2.49 |
+| Scalability | 7.5 | 0.15 | 1.13 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 7.5 -- Remote concurrent submission (AV:N). Simple max-length prompt submission (AC:L). No authentication needed (PR:N). No user interaction (UI:N). Scope Unchanged. High availability impact from compute and memory exhaustion.
+- **Exploitability**: 8.3 -- LLM compute exhaustion via long prompts is documented in AI security research (Known: 9). Simple concurrent max-length submission (Complexity: 8). HTTP load testing tools readily available (Tooling: 8). Low skill; understanding of token limits sufficient (Skill: 8).
+- **Scalability**: 7.5 -- Trivially automatable concurrent submission (Scriptability: 9). Affects all orchestrator users via shared compute (Scope: 7). Moderate bandwidth for concurrent max-length prompts (Resources: 6). Volumetric patterns may be detectable but max-length legitimate prompts exist (Detection: 8).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### S-3 -- LLM Agent Orchestrator
+
+**Threat**: Attacker forges tool call requests to the MCP Tool Server by impersonating the LLM Agent Orchestrator, because the JSON-RPC channel between orchestrator and tool server lacks mutual authentication
+
+**Category**: Spoofing | **Original Risk Level**: Critical | **Composite**: 7.2 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.8 | 0.35 | 3.43 |
+| Exploitability | 6.0 | 0.30 | 1.80 |
+| Scalability | 5.5 | 0.15 | 0.83 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.2** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 9.8 -- Forged JSON-RPC requests over the network (AV:N). No mutual auth means no special conditions (AC:L). No credentials needed (PR:N). No user interaction (UI:N). Scope Changed: forged calls affect tool server, external API, and data stores. High CIA from data exfiltration (C:H), state modification (I:H), with limited availability impact (A:L).
+- **Exploitability**: 6.0 -- Service impersonation via unauthenticated channels is known (Known: 6). Requires network access to internal JSON-RPC channel (Complexity: 6). JSON-RPC clients and network tools exist (Tooling: 6). Moderate skill for protocol and topology knowledge (Skill: 6).
+- **Scalability**: 5.5 -- Scriptable once protocol format is understood (Scriptability: 7). Limited to attackers with internal network access (Scope: 4). Minimal resources once positioned (Resources: 7). Unauthenticated requests from unexpected sources are detectable (Detection: 4).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5). JSON-RPC channel is internal.
+
+---
+
+### T-3 -- MCP Tool Server
+
+**Threat**: Attacker manipulates JSON-RPC tool call parameters in transit between the Orchestrator and MCP Tool Server, injecting malicious payloads such as SQL fragments or shell commands into tool arguments, because parameter integrity is not verified at the tool server boundary
+
+**Category**: Tampering | **Original Risk Level**: Critical | **Composite**: 7.1 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 8.8 | 0.35 | 3.08 |
+| Exploitability | 6.8 | 0.30 | 2.04 |
+| Scalability | 5.8 | 0.15 | 0.87 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.1** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 8.8 -- Network-level parameter manipulation (AV:N). Injection into unprotected JSON-RPC parameters is straightforward (AC:L). No auth needed for transit interception (PR:N). No user interaction (UI:N). Scope Unchanged: injected commands execute in tool server context. Low confidentiality (SQL may expose some data), high integrity (data modification, config corruption), high availability (shell commands can crash services).
+- **Exploitability**: 6.8 -- SQL and command injection are extensively documented (Known: 8). Requires network-level access for interception (Complexity: 6). SQLMap, Burp Suite available (Tooling: 8). Moderate skill for JSON-RPC structure and payload crafting (Skill: 5).
+- **Scalability**: 5.8 -- Parameter injection automatable with network interception setup (Scriptability: 6). Limited to specific orchestrator-server pairs (Scope: 5). Minimal resources once positioned (Resources: 7). Injected payloads may be detected by WAF/IDS (Detection: 5).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5). Internal JSON-RPC channel.
+
+---
+
+### AG-3 -- MCP Tool Server
+
+**Threat**: MCP Tool Server exposes all registered tools to every connected client (the LLM Agent Orchestrator) without per-agent capability scoping, violating the principle that agents should only access tools within their authorized capability set, because the tool registry does not enforce allowlists
+
+**Category**: Agentic Threats | **Original Risk Level**: Critical | **Composite**: 7.0 (High)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 9.1 | 0.35 | 3.19 |
+| Exploitability | 6.3 | 0.30 | 1.89 |
+| Scalability | 5.5 | 0.15 | 0.83 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **7.0** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 9.1 -- Remote tool access via JSON-RPC (AV:N). All tools exposed by default (AC:L). Requires authenticated agent connection (PR:L). No user interaction (UI:N). Scope Changed: unrestricted tool access affects external APIs and data stores. High confidentiality and integrity from unauthorized tool access; limited availability impact (A:L).
+- **Exploitability**: 6.3 -- Overly permissive MCP tool registries are documented in AI security research (Known: 7). Requires understanding of tool registry and names (Complexity: 6). Limited specialized tooling (Tooling: 4). Moderate skill for MCP protocol and capabilities (Skill: 7).
+- **Scalability**: 5.5 -- Tool invocation scriptable via JSON-RPC (Scriptability: 6). Affects all agent instances connected to MCP server (Scope: 5). Minimal resources (Resources: 8). Tool invocations outside expected capability set are detectable (Detection: 3).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### S-2 -- Guardrails Service
+
+**Threat**: Attacker bypasses the Guardrails Service by directly accessing the LLM Agent Orchestrator endpoint, impersonating the Guardrails Service identity, because inter-service authentication between the Guardrails Service and Orchestrator is not enforced
+
+**Category**: Spoofing | **Original Risk Level**: High | **Composite**: 6.7 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 8.2 | 0.35 | 2.87 |
+| Exploitability | 6.5 | 0.30 | 1.95 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.7** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 8.2 -- Direct network access to orchestrator (AV:N). No mutual auth means no special conditions (AC:L). No credentials needed (PR:N). No user interaction (UI:N). Scope Unchanged. High confidentiality from unfiltered orchestrator access; low integrity.
+- **Exploitability**: 6.5 -- API gateway bypass is well-documented (Known: 7). Requires network access to internal endpoint (Complexity: 6). Standard HTTP clients work (Tooling: 7). Moderate skill for internal topology (Skill: 6).
+- **Scalability**: 5.0 -- Scriptable once internal URL known (Scriptability: 6). Limited to internal network access (Scope: 4). Minimal resources (Resources: 7). Monitoring request origin at orchestrator can detect bypass (Detection: 3).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### E-1 -- Guardrails Service
+
+**Threat**: Attacker bypasses the Guardrails Service entirely by exploiting an alternate route to the LLM Agent Orchestrator (e.g., internal network access, API gateway misconfiguration), because authorization checks are only enforced at the Guardrails Service layer and not replicated at the Orchestrator
+
+**Category**: Privilege Escalation | **Original Risk Level**: High | **Composite**: 6.6 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 8.8 | 0.35 | 3.08 |
+| Exploitability | 5.8 | 0.30 | 1.74 |
+| Scalability | 4.8 | 0.15 | 0.72 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.6** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 8.8 -- Alternate route exploitation over network (AV:N). Misconfiguration or internal access exploitable without special conditions (AC:L). Some authenticated access needed (PR:L). No user interaction (UI:N). Scope Changed: bypass provides unfiltered access to orchestrator and downstream components. High CI, low A.
+- **Exploitability**: 5.8 -- API gateway misconfiguration is documented (Known: 7). Requires discovery of alternate route (Complexity: 5). Network scanning and API discovery tools available (Tooling: 5). Moderate skill for recon and gateway understanding (Skill: 6).
+- **Scalability**: 4.8 -- May require manual discovery but scriptable once found (Scriptability: 5). Limited to instances with specific misconfiguration (Scope: 4). Minimal resources once route identified (Resources: 7). Direct orchestrator access from unauthorized sources is detectable (Detection: 3).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### D-3 -- MCP Tool Server
+
+**Threat**: Attacker triggers resource exhaustion on the MCP Tool Server by causing the Orchestrator to issue a large number of concurrent tool calls, because no per-request tool call limit or concurrency cap is enforced on the tool execution path
+
+**Category**: Denial of Service | **Original Risk Level**: High | **Composite**: 6.4 (Medium)
+
+**Correlation Group**: CG-4 primary. Peer AG-4 inherits these scores.
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.5 | 0.35 | 2.63 |
+| Exploitability | 6.3 | 0.30 | 1.89 |
+| Scalability | 5.5 | 0.15 | 0.83 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.4** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 7.5 -- Remote triggering via crafted prompts (AV:N). Crafting prompts for multiple tool calls is straightforward (AC:L). Unauthenticated requests may trigger cascades (PR:N). No user interaction (UI:N). Scope Unchanged. High availability impact from tool server overload.
+- **Exploitability**: 6.3 -- Concurrent request DoS is well-documented (Known: 7). Requires understanding of prompt-to-tool-call mapping; indirect path (Complexity: 5). HTTP load testing tools available (Tooling: 7). Moderate skill for prompt crafting (Skill: 6).
+- **Scalability**: 5.5 -- Prompt submission triggering cascades is automatable (Scriptability: 7). Affects all tool server consumers (Scope: 5). Minimal resources for prompt submission (Resources: 7). Anomalous tool call volume detectable (Detection: 3).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### AG-4 -- MCP Tool Server
+
+**Threat**: Attacker manipulates the MCP Tool Server to chain individually authorized tool calls (e.g., database-query + file-export + network-send) to achieve data exfiltration that no single tool authorization would permit, because no cross-tool policy evaluates composite effects of sequential tool invocations
+
+**Category**: Agentic Threats | **Original Risk Level**: High | **Composite**: 6.4 (Medium)
+
+**Correlation Group**: Scores inherited from primary finding D-3 (CG-4).
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.5 | 0.35 | 2.63 |
+| Exploitability | 6.3 | 0.30 | 1.89 |
+| Scalability | 5.5 | 0.15 | 0.83 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.4** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 7.5 -- Scores inherited from CG-4 primary D-3. Uncontrolled tool invocation enables both resource exhaustion and permission escalation.
+- **Exploitability**: 6.3 -- Inherited from CG-4 primary D-3.
+- **Scalability**: 5.5 -- Inherited from CG-4 primary D-3.
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone.
+
+---
+
+### T-4 -- Knowledge Base
+
+**Threat**: Attacker injects malicious or misleading content into the Knowledge Base by exploiting write access through the orchestrator's data ingestion path, because input sanitization is not enforced before persisting data to the vector store
+
+**Category**: Tampering | **Original Risk Level**: High | **Composite**: 6.3 (Medium)
+
+**Correlation Group**: CG-1 primary. Peer LLM-2 inherits these scores.
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.1 | 0.35 | 2.49 |
+| Exploitability | 6.5 | 0.30 | 1.95 |
+| Scalability | 5.3 | 0.15 | 0.80 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 7.1 -- Remote content injection via ingestion API (AV:N). No special conditions (AC:L). Authenticated user access needed (PR:L). No user interaction (UI:N). Scope Unchanged. No direct data exposure (C:N); high integrity impact from knowledge base poisoning (I:H); degraded response quality (A:L).
+- **Exploitability**: 6.5 -- KB poisoning and indirect prompt injection via RAG are documented (Known: 7). Requires understanding of ingestion pipeline (Complexity: 6). Limited specialized tooling; custom scripts needed (Tooling: 6). Moderate skill for vector embeddings and RAG patterns (Skill: 7).
+- **Scalability**: 5.3 -- Content injection automatable with ingestion format knowledge (Scriptability: 5). Affects all users retrieving poisoned documents (Scope: 6). Minimal resources (Resources: 7). Content integrity checks can detect injection (Detection: 3).
+- **Reachability**: 5.5 -- Knowledge Base resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### LLM-2 -- LLM Agent Orchestrator
+
+**Threat**: Attacker exploits the RAG pipeline by injecting adversarial content into the Knowledge Base that, when retrieved by the Orchestrator during context retrieval, overrides system behavior -- causing the model to exfiltrate data from other retrieved documents or generate misleading responses (indirect prompt injection)
+
+**Category**: LLM Threats | **Original Risk Level**: High | **Composite**: 6.3 (Medium)
+
+**Correlation Group**: Scores inherited from primary finding T-4 (CG-1).
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.1 | 0.35 | 2.49 |
+| Exploitability | 6.5 | 0.30 | 1.95 |
+| Scalability | 5.3 | 0.15 | 0.80 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 7.1 -- Scores inherited from CG-1 primary T-4. Data integrity compromise in the Knowledge Base enables both persistent data corruption and runtime prompt manipulation.
+- **Exploitability**: 6.5 -- Inherited from CG-1 primary T-4.
+- **Scalability**: 5.3 -- Inherited from CG-1 primary T-4.
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone.
+
+---
+
+### I-1 -- Guardrails Service
+
+**Threat**: Guardrails Service returns detailed rejection reasons to the user that reveal internal filtering rules, regex patterns, or blocked keyword lists, enabling attackers to craft prompts that evade detection by understanding the filtering logic
+
+**Category**: Information Disclosure | **Original Risk Level**: High | **Composite**: 6.2 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 7.8 | 0.30 | 2.34 |
+| Scalability | 6.0 | 0.15 | 0.90 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.2** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Error messages returned via HTTPS (AV:N). Simply submit prompts triggering rejections (AC:L). Any user can trigger rejections (PR:N). No interaction needed (UI:N). Scope Unchanged. Low confidentiality (filtering rules exposed, not user data); low integrity (enables filter evasion); no availability impact.
+- **Exploitability**: 7.8 -- Error message information leakage is a classic vulnerability (Known: 8). Simply sending prompts and reading rejections (Complexity: 9). Standard HTTP clients suffice (Tooling: 6). Low-to-moderate skill for reading error messages and inferring rules (Skill: 8).
+- **Scalability**: 6.0 -- Automated prompt submission and rejection collection is trivially scriptable (Scriptability: 7). Affects all instances returning verbose rejections (Scope: 6). Minimal resources (Resources: 8). High volume of intentionally-rejected prompts detectable via rate analysis (Detection: 3).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### T-2 -- LLM Agent Orchestrator
+
+**Threat**: Attacker injects malicious content into the prompt context by tampering with the data flow between the Guardrails Service and the Orchestrator, because the validated prompt is not integrity-protected in transit between services
+
+**Category**: Tampering | **Original Risk Level**: High | **Composite**: 6.1 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.1 | 0.35 | 2.49 |
+| Exploitability | 6.0 | 0.30 | 1.80 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.1** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 7.1 -- MITM tampering on inter-service data flow (AV:N). No integrity protection means interception is straightforward (AC:L). Internal network access needed (PR:L). No user interaction (UI:N). Scope Unchanged. No data exposure; high integrity from altered orchestrator behavior; low availability from malformed prompts.
+- **Exploitability**: 6.0 -- MITM on unprotected inter-service channels is documented (Known: 7). Requires network-level interception access (Complexity: 5). mitmproxy, Burp Suite available (Tooling: 7). Moderate skill for interception and protocol understanding (Skill: 5).
+- **Scalability**: 5.0 -- Transit interception and modification automatable with proxy tools (Scriptability: 6). Limited to specific inter-service channel (Scope: 4). Minimal resources once positioned (Resources: 7). HMAC verification would detect; without it, harder (Detection: 3).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### D-4 -- Knowledge Base
+
+**Threat**: Attacker exhausts Knowledge Base resources by triggering unbounded vector search queries with high-dimensional adversarial inputs designed to maximize computational cost, because search queries lack result limits and complexity bounds
+
+**Category**: Denial of Service | **Original Risk Level**: Medium | **Composite**: 6.0 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.5 | 0.35 | 2.63 |
+| Exploitability | 5.3 | 0.30 | 1.59 |
+| Scalability | 4.5 | 0.15 | 0.68 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **6.0** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 7.5 -- Adversarial queries submitted remotely (AV:N). Unbounded queries need no special conditions (AC:L). No per-query authentication (PR:N). No user interaction (UI:N). Scope Unchanged. High availability impact from vector search resource exhaustion.
+- **Exploitability**: 5.3 -- Vector search DoS is an emerging concern (Known: 6). Requires crafting adversarial inputs; some ML knowledge helpful (Complexity: 5). Custom scripts needed (Tooling: 5). Moderate skill for vector search mechanics (Skill: 5).
+- **Scalability**: 4.5 -- Adversarial query submission automatable once crafted (Scriptability: 6). Affects all KB consumers (Scope: 4). Moderate resources for crafting vector payloads (Resources: 5). Anomalous query complexity detectable (Detection: 3).
+- **Reachability**: 5.5 -- Knowledge Base resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### I-4 -- Knowledge Base
+
+**Threat**: Knowledge Base returns full document contents including internal metadata, embedding vectors, and storage schema details in query responses, because field-level projection is not enforced on retrieval queries
+
+**Category**: Information Disclosure | **Original Risk Level**: High | **Composite**: 5.9 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 7.0 | 0.30 | 2.10 |
+| Scalability | 5.5 | 0.15 | 0.83 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.9** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Query responses returned over network (AV:N). Normal queries trigger disclosure (AC:L). Authenticated access through orchestrator needed (PR:L). Automatic response (UI:N). Scope Unchanged. Embedding vectors and schema details are sensitive (C:H). No integrity or availability impact.
+- **Exploitability**: 7.0 -- Over-disclosure in API responses is well-documented (Known: 7). Normal queries trigger it; no special technique (Complexity: 8). Standard API clients suffice (Tooling: 6). Low-to-moderate skill for recognizing valuable metadata (Skill: 7).
+- **Scalability**: 5.5 -- Automated query and response parsing is trivially scriptable (Scriptability: 7). Affects all queries without projection (Scope: 5). Minimal resources (Resources: 7). Individual queries look normal; volume patterns detectable (Detection: 3).
+- **Reachability**: 5.5 -- Knowledge Base resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### T-1 -- Guardrails Service
+
+**Threat**: Attacker modifies the validation rules or filtering configuration of the Guardrails Service at runtime, because configuration files are stored in a location writable by the application process without integrity verification
+
+**Category**: Tampering | **Original Risk Level**: High | **Composite**: 5.8 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.1 | 0.35 | 2.49 |
+| Exploitability | 5.3 | 0.30 | 1.59 |
+| Scalability | 4.3 | 0.15 | 0.65 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.8** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 7.1 -- Remote config modification via application process (AV:N). Writable configs accessible without special conditions (AC:L). Application-level access needed (PR:L). No user interaction (UI:N). Scope Unchanged. Modified rules bypass filtering (I:H); corrupted rules may cause errors (A:L).
+- **Exploitability**: 5.3 -- Configuration tampering is a known pattern (Known: 6). Requires application-level filesystem access (Complexity: 5). Standard file access tools suffice (Tooling: 5). Moderate skill for rule format and access (Skill: 5).
+- **Scalability**: 4.3 -- Scriptable but requires per-instance filesystem knowledge (Scriptability: 5). Affects only the specific instance (Scope: 3). Requires filesystem access (Resources: 6). Configuration integrity monitoring detects changes (Detection: 3).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### S-4 -- MCP Tool Server
+
+**Threat**: Attacker redirects the MCP Tool Server's outbound API requests to an attacker-controlled endpoint by spoofing DNS responses or compromising the External API's TLS certificate, because certificate pinning is not enforced on outbound HTTPS connections
+
+**Category**: Spoofing | **Original Risk Level**: High | **Composite**: 5.7 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.4 | 0.35 | 2.59 |
+| Exploitability | 4.5 | 0.30 | 1.35 |
+| Scalability | 4.3 | 0.15 | 0.65 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.7** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 7.4 -- DNS spoofing/TLS compromise are network attacks (AV:N). Requires privileged network position or CA compromise (AC:H). No authenticated access needed (PR:N). No user interaction (UI:N). Scope Unchanged. Attacker receives all outbound data (C:H) and can return forged responses (I:H); no availability impact.
+- **Exploitability**: 4.5 -- DNS spoofing and TLS interception are documented but require network position (Known: 7). Requires DNS infrastructure access or CA compromise (Complexity: 2). DNS spoofing tools exist (Tooling: 5). Significant skill for DNS and TLS manipulation (Skill: 4).
+- **Scalability**: 4.3 -- DNS spoofing automatable but requires per-target setup (Scriptability: 4). Limited to instances using compromised DNS/CA (Scope: 3). Requires network infrastructure access (Resources: 5). Detectable with DNSSEC and certificate monitoring (Detection: 5).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### I-3 -- MCP Tool Server
+
+**Threat**: MCP Tool Server forwards raw External API error responses to the Orchestrator without sanitization, potentially exposing third-party API keys, internal endpoint URLs, or authentication headers embedded in error payloads
+
+**Category**: Information Disclosure | **Original Risk Level**: High | **Composite**: 5.6 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 6.5 | 0.35 | 2.28 |
+| Exploitability | 5.0 | 0.30 | 1.50 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.6** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 6.5 -- Unsanitized errors forwarded over network (AV:N). Triggering errors is straightforward (AC:L). Authenticated access through orchestrator needed (PR:L). Automatic forwarding (UI:N). Scope Unchanged. API keys, URLs, and auth headers are highly sensitive (C:H); no integrity or availability impact.
+- **Exploitability**: 5.0 -- Unsanitized error forwarding is well-documented (Known: 7). Requires triggering specific error conditions (Complexity: 4). Standard API testing tools work (Tooling: 5). Moderate skill for understanding error contents (Skill: 4).
+- **Scalability**: 5.0 -- Error-triggering calls automatable but require per-API understanding (Scriptability: 5). Affects all instances forwarding unsanitized errors (Scope: 5). Minimal resources (Resources: 7). Unusual error rates and sensitive data detectable (Detection: 3).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### I-2 -- LLM Agent Orchestrator
+
+**Threat**: LLM Agent Orchestrator leaks sensitive internal state through verbose error messages when tool calls fail or context retrieval errors occur, exposing internal service topology, Knowledge Base schema details, or model configuration parameters
+
+**Category**: Information Disclosure | **Original Risk Level**: High | **Composite**: 5.5 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 6.5 | 0.35 | 2.28 |
+| Exploitability | 4.8 | 0.30 | 1.44 |
+| Scalability | 4.5 | 0.15 | 0.68 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.5** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 6.5 -- Error messages returned via HTTPS (AV:N). Malformed or edge-case inputs trigger verbose errors (AC:L). Authenticated user access needed (PR:L). Automatic error responses (UI:N). Scope Unchanged. Service topology, KB schema, and model config are highly sensitive (C:H).
+- **Exploitability**: 4.8 -- Verbose error exploitation is a classic technique (Known: 7). Requires triggering specific error conditions; not all inputs produce verbose errors (Complexity: 5). API testing and fuzzing tools available (Tooling: 4). Moderate skill for error handling patterns (Skill: 3).
+- **Scalability**: 4.5 -- Error-triggering inputs automatable via fuzzing (Scriptability: 6). Affects all instances with verbose error handling (Scope: 4). Minimal resources (Resources: 6). High error rates from single client detectable (Detection: 2).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### T-5 -- Audit Logger
+
+**Threat**: Attacker modifies or deletes audit log entries to cover tracks after a security incident, because the Audit Logger stores logs in a location writable by application processes that also generate the logs
+
+**Category**: Tampering | **Original Risk Level**: High | **Composite**: 5.4 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 7.1 | 0.35 | 2.49 |
+| Exploitability | 4.3 | 0.30 | 1.29 |
+| Scalability | 3.5 | 0.15 | 0.53 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.4** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`
+
+**Scoring Rationale**:
+- **CVSS**: 7.1 -- Remote log modification via application processes (AV:N). Writable log store accessible via same processes (AC:L). Application-level access needed (PR:L). No user interaction (UI:N). Scope Unchanged. Destroyed forensic evidence (I:H); compliance disruption (A:L).
+- **Exploitability**: 4.3 -- Log tampering is a documented post-exploitation technique (Known: 6). Requires application-level access; typically after initial compromise (Complexity: 4). Standard tools suffice (Tooling: 3). Moderate skill for log format and access (Skill: 4).
+- **Scalability**: 3.5 -- Log modification scripts simple but need per-instance knowledge (Scriptability: 4). Limited to specific log store instance (Scope: 2). Minimal resources with app access (Resources: 6). Hash chains and SIEM comparison detect tampering (Detection: 2).
+- **Reachability**: 5.5 -- Audit Logger resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### D-5 -- Audit Logger
+
+**Threat**: Attacker causes audit log storage exhaustion by triggering high-volume logging events through rapid request submission, eventually filling disk and disrupting all services that depend on log writing, because no log volume throttling or storage quota is enforced
+
+**Category**: Denial of Service | **Original Risk Level**: Medium | **Composite**: 5.3 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 5.3 | 0.30 | 1.59 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Remote rapid submission (AV:N). High-volume submission needs no special conditions (AC:L). Authenticated access needed (PR:L). No user interaction (UI:N). Scope Unchanged. High availability impact from disk exhaustion affecting dependent services.
+- **Exploitability**: 5.3 -- Log flooding is a documented DoS technique (Known: 6). Requires sustained high-volume submission; indirect path (Complexity: 5). HTTP load testing tools available (Tooling: 6). Low skill for high-volume submission (Skill: 4).
+- **Scalability**: 5.0 -- Rapid submission trivially automatable (Scriptability: 7). Affects all services on shared log store (Scope: 4). Moderate resources for sustained volume (Resources: 5). Rapid log growth detectable with monitoring (Detection: 4).
+- **Reachability**: 5.5 -- Audit Logger resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### R-3 -- LLM Agent Orchestrator
+
+**Threat**: LLM Agent Orchestrator executes tool calls and generates responses without logging the full decision chain, enabling operators or users to deny that specific actions were requested or authorized, because decision logs lack the originating user context, selected tool, parameters, and model reasoning trace
+
+**Category**: Repudiation | **Original Risk Level**: High | **Composite**: 5.2 (Medium)
+
+**Correlation Group**: CG-3 primary. Peer AG-2 inherits these scores.
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 5.0 | 0.30 | 1.50 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.2** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Repudiation exploited remotely (AV:N). Insufficient logging is a default condition (AC:L). Authenticated user access needed (PR:L). No interaction needed (UI:N). Scope Unchanged. Inability to prove attribution undermines audit trail integrity (I:H).
+- **Exploitability**: 5.0 -- Repudiation is less of a technical attack; more an accountability gap (Known: 5). Trivially exploited: perform actions and deny them (Complexity: 7). No specialized tooling needed (Tooling: 2). Anyone can deny actions when logging is insufficient (Skill: 6).
+- **Scalability**: 5.0 -- Per-incident manual exploit; not scriptable in traditional sense (Scriptability: 3). Affects all orchestrator users; any action can be denied (Scope: 6). No resources needed beyond existing access (Resources: 9). Insufficient logging is the vulnerability itself (Detection: 3).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### AG-2 -- LLM Agent Orchestrator
+
+**Threat**: LLM Agent Orchestrator operates in an unbounded reasoning loop where the LLM decides when to terminate based on its assessment of task completion, but no maximum iteration count, execution timeout, or cost cap constrains the loop, enabling an attacker to submit ambiguous prompts that cause indefinite resource consumption
+
+**Category**: Agentic Threats | **Original Risk Level**: High | **Composite**: 5.2 (Medium)
+
+**Correlation Group**: Scores inherited from primary finding R-3 (CG-3).
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 5.0 | 0.30 | 1.50 |
+| Scalability | 5.0 | 0.15 | 0.75 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.2** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Scores inherited from CG-3 primary R-3. Missing accountability controls combined with unconstrained operation create unauditable behavior.
+- **Exploitability**: 5.0 -- Inherited from CG-3 primary R-3.
+- **Scalability**: 5.0 -- Inherited from CG-3 primary R-3.
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone.
+
+---
+
+### I-5 -- Audit Logger
+
+**Threat**: Audit log entries contain sensitive data including full prompt content, user PII, and API credentials that were logged for debugging purposes, and the log store is accessible to operations staff beyond the security team
+
+**Category**: Information Disclosure | **Original Risk Level**: High | **Composite**: 5.1 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 6.5 | 0.35 | 2.28 |
+| Exploitability | 4.0 | 0.30 | 1.20 |
+| Scalability | 3.8 | 0.15 | 0.57 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.1** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 6.5 -- Remote log access by operations staff (AV:N). Reading embedded sensitive data needs no special technique (AC:L). Operations staff access sufficient (PR:L). No additional interaction (UI:N). Scope Unchanged. Full prompt content, PII, and API credentials are highly sensitive (C:H).
+- **Exploitability**: 4.0 -- Excessive logging of sensitive data is documented (Known: 6). Requires ops account access or compromise (Complexity: 4). Standard log viewing tools suffice (Tooling: 3). Low skill for authorized ops staff; moderate to compromise access (Skill: 3).
+- **Scalability**: 3.8 -- Log scraping automatable with regex patterns (Scriptability: 5). Limited to specific log store and authorized readers (Scope: 3). Requires ops-level access (Resources: 5). Log access auditing detects unusual patterns (Detection: 2).
+- **Reachability**: 5.5 -- Audit Logger resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### LLM-3 -- LLM Agent Orchestrator
+
+**Threat**: Attacker systematically queries the Orchestrator's inference endpoint to extract a functional copy of the model through distillation, because the API returns rich response data without per-user query volume limits or query pattern monitoring
+
+**Category**: LLM Threats | **Original Risk Level**: Medium | **Composite**: 5.0 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 5.3 | 0.35 | 1.86 |
+| Exploitability | 4.5 | 0.30 | 1.35 |
+| Scalability | 4.8 | 0.15 | 0.72 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **5.0** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 5.3 -- Remote systematic querying (AV:N). Requires systematic patterns and ML expertise (AC:H). Authenticated API access needed (PR:L). No interaction from others (UI:N). Scope Unchanged. Model IP theft is high confidentiality impact (C:H).
+- **Exploitability**: 4.5 -- Model extraction is documented in academic research (Known: 6). Requires systematic query design and ML expertise (Complexity: 3). Academic tools exist; no off-the-shelf extraction tools (Tooling: 5). Moderate-to-high skill for effective distillation (Skill: 4).
+- **Scalability**: 4.8 -- Systematic query submission is highly automatable (Scriptability: 7). Limited to specific model instance (Scope: 3). Significant query volume and ML compute needed (Resources: 4). Systematic patterns detectable with monitoring (Detection: 4).
+- **Reachability**: 5.5 -- LLM Agent Orchestrator resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### R-1 -- User
+
+**Threat**: User denies having submitted a specific prompt that triggered a harmful or policy-violating response, because the system does not capture non-repudiable evidence linking the authenticated user identity to the specific prompt submission
+
+**Category**: Repudiation | **Original Risk Level**: Medium | **Composite**: 4.8 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 4.3 | 0.35 | 1.51 |
+| Exploitability | 3.0 | 0.30 | 0.90 |
+| Scalability | 3.0 | 0.15 | 0.45 |
+| Reachability | 9.5 | 0.20 | 1.90 |
+| **Composite** | | | **4.8** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 4.3 -- Remote denial of submitted prompts (AV:N). Repudiation gap exists by default (AC:L). Authenticated user access needed (PR:L). No interaction needed (UI:N). Scope Unchanged. Low integrity impact from attribution gaps (I:L).
+- **Exploitability**: 3.0 -- Repudiation is a well-understood concept but not a technical exploit (Known: 3). Simply deny having submitted the prompt (Complexity: 5). No tooling needed (Tooling: 1). Minimal skill; understanding of accountability gaps helpful (Skill: 3).
+- **Scalability**: 3.0 -- Per-incident manual claim; not automatable (Scriptability: 2). Individual user accountability; not system-wide (Scope: 2). No resources needed (Resources: 8). Repudiation claims are overt; issue is proving attribution (Detection: 0).
+- **Reachability**: 9.5 -- User component resides in the Untrusted User Zone (baseline 9.0). "User" keyword adds +0.5 = 9.5. Directly accessible by external actors.
+
+---
+
+### R-5 -- External API
+
+**Threat**: External API interactions lack correlation identifiers that link API calls back to the originating user request, creating accountability gaps when external service calls produce unexpected or harmful results
+
+**Category**: Repudiation | **Original Risk Level**: Low | **Composite**: 4.6 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 4.3 | 0.35 | 1.51 |
+| Exploitability | 2.5 | 0.30 | 0.75 |
+| Scalability | 2.8 | 0.15 | 0.42 |
+| Reachability | 9.5 | 0.20 | 1.90 |
+| **Composite** | | | **4.6** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 4.3 -- External API interactions over network (AV:N). Correlation gaps exist by default (AC:L). Authenticated access through orchestrator (PR:L). Automatic API calls (UI:N). Scope Unchanged. Attribution gaps undermine forensic accountability (I:L).
+- **Exploitability**: 2.5 -- Correlation gap is more of an accountability weakness (Known: 3). Trigger API calls and exploit attribution gap afterward (Complexity: 4). No tooling needed (Tooling: 1). Minimal skill required (Skill: 2).
+- **Scalability**: 2.8 -- Per-incident exploitation; not meaningfully scriptable (Scriptability: 2). Affects only external API interaction path (Scope: 2). Minimal resources beyond existing access (Resources: 6). Correlation gap is a known architectural weakness (Detection: 1).
+- **Reachability**: 9.5 -- External API resides in the Untrusted External Services zone (baseline 9.0). "External" keyword adds +0.5 = 9.5.
+
+---
+
+### R-2 -- Guardrails Service
+
+**Threat**: Guardrails Service fails to log rejected prompts with sufficient detail to reconstruct why a prompt was blocked, enabling disputes about whether legitimate prompts were incorrectly filtered, because filtering event logs lack the original prompt content, matched rule identifier, and confidence score
+
+**Category**: Repudiation | **Original Risk Level**: Medium | **Composite**: 4.5 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 4.3 | 0.35 | 1.51 |
+| Exploitability | 4.3 | 0.30 | 1.29 |
+| Scalability | 3.8 | 0.15 | 0.57 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **4.5** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 4.3 -- Filtering disputes from remote interactions (AV:N). Insufficient logging is a default condition (AC:L). Authenticated user access needed (PR:L). No interaction (UI:N). Scope Unchanged. Inability to reconstruct decisions undermines accountability (I:L).
+- **Exploitability**: 4.3 -- Insufficient audit logging is a documented compliance weakness (Known: 4). Submit a prompt and dispute the decision (Complexity: 6). No tooling needed (Tooling: 2). Minimal skill for understanding filtering behavior (Skill: 5).
+- **Scalability**: 3.8 -- Per-incident disputes; not scriptable (Scriptability: 2). Affects all filtered prompts lacking detailed records (Scope: 4). No special resources (Resources: 7). Disputes are overt; issue is proving the decision (Detection: 2).
+- **Reachability**: 5.5 -- Guardrails Service resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+### R-4 -- MCP Tool Server
+
+**Threat**: MCP Tool Server executes tool operations including external API calls without recording the requesting orchestrator context, making it impossible to attribute tool executions to specific user requests in forensic investigations
+
+**Category**: Repudiation | **Original Risk Level**: Medium | **Composite**: 4.3 (Medium)
+
+| Dimension | Score | Weight | Weighted |
+|-----------|-------|--------|----------|
+| CVSS Base | 4.3 | 0.35 | 1.51 |
+| Exploitability | 3.8 | 0.30 | 1.14 |
+| Scalability | 3.5 | 0.15 | 0.53 |
+| Reachability | 5.5 | 0.20 | 1.10 |
+| **Composite** | | | **4.3** |
+
+**CVSS Vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N`
+
+**Scoring Rationale**:
+- **CVSS**: 4.3 -- Tool execution over JSON-RPC (AV:N). Missing context is a default condition (AC:L). Authenticated access through orchestrator (PR:L). No interaction (UI:N). Scope Unchanged. Inability to attribute executions undermines forensics (I:L).
+- **Exploitability**: 3.8 -- Insufficient attribution in microservices is a documented forensic weakness (Known: 4). Trigger tool executions that cannot be attributed (Complexity: 6). No tooling needed (Tooling: 2). Minimal skill for understanding attribution gaps (Skill: 3).
+- **Scalability**: 3.5 -- Per-incident exploitation; limited scriptability (Scriptability: 3). Affects tool executions lacking context (Scope: 3). Minimal resources (Resources: 6). Attribution gap is a known architectural weakness (Detection: 2).
+- **Reachability**: 5.5 -- MCP Tool Server resides in the Semi-Trusted Application Zone (baseline 5.5).
+
+---
+
+## 4. Governance Fields
+
+Remediation tracking metadata for each scored finding. Default values are severity-driven and intended for manual override by security managers during risk review.
+
+| ID | Severity | Owner | SLA | Disposition | Review Date |
+|----|----------|-------|-----|-------------|-------------|
+| LLM-1 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| S-1 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| E-2 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| AG-1 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| E-3 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| D-1 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| D-2 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| S-3 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| T-3 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| AG-3 | High | Unassigned | 7d | Mitigate | 2026-04-03 |
+| S-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| E-1 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| D-3 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| AG-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| T-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| LLM-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| I-1 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| T-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| D-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| I-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| T-1 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| S-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| I-3 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| I-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| T-5 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| D-5 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| R-3 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| AG-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| I-5 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| LLM-3 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| R-1 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| R-5 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| R-2 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+| R-4 | Medium | Unassigned | 30d | Review | 2026-04-26 |
+
+### Field Definitions
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| **ID** | Finding identifier matching Section 2. | Preserved from source threat model. |
+| **Severity** | Severity band from composite score. | Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9). |
+| **Owner** | Responsible party for remediation or risk acceptance. | `Unassigned` -- populate during risk review. |
+| **SLA** | Remediation deadline relative to scoring date. | Critical = 24 hours, High = 7 days, Medium = 30 days, Low = 90 days. |
+| **Disposition** | Risk treatment decision. | Critical/High = `Mitigate`, Medium/Low = `Review`. Valid values: Mitigate, Review, Accept, Transfer. |
+| **Review Date** | Date by which the disposition must be reviewed. | Scoring date + SLA duration (e.g., scoring on 2026-03-27 with 7d SLA = 2026-04-03). |
+
+### Override Guidance
+
+- **Owner**: Assign during remediation planning. Each finding should have a named owner before the SLA expires.
+- **Disposition**: Change from default when a risk acceptance or transfer decision is made. Document the justification in your risk register.
+  - `Accept` -- Risk is acknowledged and accepted at the current level. Requires documented justification and management approval.
+  - `Transfer` -- Risk is transferred to a third party (e.g., insurance, vendor SLA). Document the transfer mechanism.
+- **SLA**: Override when organizational policy defines different remediation windows. The default SLAs follow industry-standard baselines (24h/7d/30d/90d).
+- **Review Date**: Automatically recalculates when SLA is overridden.
+
+---
+
+## 5. Scoring Methodology
+
+This section documents the quantitative scoring model used to produce the risk scores in this report. All scores are derived from the threat findings identified during threat modeling and are intended to replace qualitative risk ratings with data-backed, reproducible numeric assessments.
+
+### 5.1 Scoring Dimensions
+
+Each threat finding is assessed across four independent dimensions, each producing a score on a 0.0 to 10.0 scale.
+
+| Dimension | Weight | What It Measures |
+|-----------|--------|------------------|
+| **CVSS Base** | 35% | Intrinsic severity of the vulnerability using CVSS 3.1 base metrics: attack vector, attack complexity, privileges required, user interaction, scope, and confidentiality/integrity/availability impact. Each finding includes the full CVSS vector string for auditability. |
+| **Exploitability** | 30% | Practical likelihood of exploitation based on known attack techniques, tooling availability, required skill level, and attack complexity. Higher scores indicate threats with well-documented exploit paths and readily available tooling. |
+| **Scalability** | 15% | Potential for automated, large-scale exploitation based on scriptability, breadth of target scope, resource requirements for the attacker, and difficulty of detection. Higher scores indicate threats that can be weaponized across many targets with minimal effort. |
+| **Reachability** | 20% | Exposure of the targeted component within the system's trust boundary architecture. Derived from trust zone data in the threat model and supplemented by architecture documentation when available. Higher scores indicate components directly exposed to untrusted networks. |
+
+### 5.2 Default Weights and Rationale
+
+The default weight allocation reflects the following priorities:
+
+- **CVSS Base (35%)** receives the highest weight because intrinsic vulnerability severity is the strongest predictor of potential damage. CVSS 3.1 is an industry-standard metric with well-understood interpretation.
+- **Exploitability (30%)** is weighted second because a severe vulnerability that is difficult to exploit in practice poses less immediate risk than one with known, tooled attack paths.
+- **Reachability (20%)** accounts for architectural context. A critical vulnerability behind multiple trust boundaries and authentication layers presents less operational risk than the same vulnerability on an internet-facing endpoint.
+- **Scalability (15%)** receives the lowest weight because while automation potential increases aggregate risk, it is less deterministic than the other dimensions and often correlates with exploitability.
+
+These weights are fixed for this scoring run and are recorded in the report frontmatter for reproducibility.
+
+### 5.3 Composite Score Formula
+
+The composite risk score for each finding is calculated as a weighted sum of the four dimension scores:
+
+```
+Composite = (0.35 x CVSS Base) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability)
+```
+
+The composite score is bounded to the 0.0-10.0 range. Because each dimension is independently scored on a 0.0-10.0 scale and the weights sum to 1.0, the composite inherently falls within this range.
+
+### 5.4 Severity Band Mapping
+
+Composite scores are mapped to severity bands that drive default governance actions:
+
+| Severity | Composite Score Range | Default SLA | Default Disposition |
+|----------|-----------------------|-------------|---------------------|
+| **Critical** | 9.0 -- 10.0 | 24 hours | Mitigate |
+| **High** | 7.0 -- 8.9 | 7 days | Mitigate |
+| **Medium** | 4.0 -- 6.9 | 30 days | Review |
+| **Low** | 0.0 -- 3.9 | 90 days | Review |
+
+Boundary values map to the higher band (e.g., a composite score of exactly 7.0 maps to High, not Medium). These bands are aligned with the severity classifications defined in `schemas/output.yaml` to maintain backward compatibility with existing tachi threat model output.
+
+### 5.5 Data Sources
+
+Scoring draws on the following inputs:
+
+- **Threat findings**: Parsed from `threats.md` (markdown table format) or `threats.sarif` (SARIF 2.1.0 JSON). All original threat metadata (ID, component, category, description, likelihood, impact) is preserved through the scoring pipeline.
+- **Trust zone data**: Extracted from `threats.md` Section 2 (trust zone table) as the primary source for reachability scoring. Components in Untrusted/External zones score 8.0-10.0 reachability; Semi-Trusted/Application zones score 4.0-7.0; Trusted/Internal zones score 1.0-4.0.
+- **Architecture documentation**: When `architecture.md` is available, it provides supplementary context such as authentication barriers and network exposure details that refine the baseline reachability score derived from trust zones. No `architecture.md` was available for this scoring run.
+- **Category default vectors**: CVSS 3.1 baseline vectors are defined per STRIDE threat category in `schemas/risk-scoring.yaml`. This includes tachi-specific defaults for AI threat categories (agentic and LLM) that lack standard CVSS mappings. Per-threat analysis may refine these baselines based on the specific threat description.
+
+### 5.6 Reproducibility
+
+Scoring is performed at LLM temperature 0 to maximize consistency. For the same threat model input, each dimension score is expected to be reproducible within a **+/- 0.5 tolerance** across runs. This tolerance reflects the inherent variability in LLM-based analysis and is considered acceptable for risk prioritization purposes.
+
+Factors that may cause minor score variation between runs include model version updates and non-deterministic sampling behavior at temperature 0. The composite formula, weights, and severity band mappings are deterministic -- only the per-dimension LLM assessments carry the stated tolerance.

--- a/examples/agentic-app/sample-report/risk-scores.sarif
+++ b/examples/agentic-app/sample-report/risk-scores.sarif
@@ -1,0 +1,1540 @@
+{
+  "_comment": "RISK SCORING OUTPUT (risk-scores.sarif) — NOT the threat model output (threats.sarif). This is the quantitative risk scoring SARIF produced by the /risk-score command. It extends threats.sarif with per-finding composite scores, four-dimensional risk metrics (CVSS, exploitability, scalability, reachability), and governance fields in the result property bag. Key distinction: security-severity in threats.sarif is a static category-level value; in risk-scores.sarif it is the per-finding composite score as a numeric string. Rule-level security-severity reflects the MAX composite score among that rule's findings. Producers: agents/tachi/risk-scorer.md. Schema: schemas/risk-scoring.yaml.",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tachi-risk-scorer",
+          "version": "1.0",
+          "semanticVersion": "1.0",
+          "informationUri": "https://github.com/owner/tachi",
+          "supportedTaxonomies": [
+            { "name": "OWASP", "index": 0 },
+            { "name": "CWE", "index": 1 }
+          ],
+          "rules": [
+            {
+              "id": "tachi/stride/spoofing",
+              "shortDescription": { "text": "Identity spoofing threats" },
+              "fullDescription": { "text": "Threats where an attacker pretends to be something or someone else, such as forging authentication credentials, replaying tokens, or impersonating trusted components to gain unauthorized access." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "spoofing",
+                  "authentication",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "7.9"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A07", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-287", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/tampering",
+              "shortDescription": { "text": "Data tampering threats" },
+              "fullDescription": { "text": "Threats where an attacker modifies data, code, or configuration without authorization, violating integrity guarantees and causing systems to operate on corrupted inputs or persist falsified records." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "tampering",
+                  "data-integrity",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "7.1"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A08", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-345", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/repudiation",
+              "shortDescription": { "text": "Repudiation threats" },
+              "fullDescription": { "text": "Threats where a user or system can deny having performed an action, and the system lacks sufficient evidence to prove otherwise, undermining accountability and forensic investigation." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "repudiation",
+                  "logging",
+                  "accountability",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "5.2"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A09", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-778", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/information-disclosure",
+              "shortDescription": { "text": "Information disclosure threats" },
+              "fullDescription": { "text": "Threats where sensitive information is exposed to unauthorized parties through direct data leaks, verbose error messages, side-channel observations, or insufficient access controls on stored data." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "information-disclosure",
+                  "data-exposure",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "6.2"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A01", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-200", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/denial-of-service",
+              "shortDescription": { "text": "Denial of service threats" },
+              "fullDescription": { "text": "Threats where an attacker degrades or eliminates system availability through resource exhaustion, flooding, algorithmic complexity exploitation, or cascading dependency failures." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "denial-of-service",
+                  "availability",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "7.4"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A05", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-400", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/elevation-of-privilege",
+              "shortDescription": { "text": "Privilege escalation threats" },
+              "fullDescription": { "text": "Threats where an attacker gains higher privileges than authorized, performing actions reserved for administrators, accessing other users' resources, or bypassing access control boundaries." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "elevation-of-privilege",
+                  "access-control",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "7.6"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A01", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-269", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/ai/agentic-threats",
+              "shortDescription": { "text": "AI agent autonomy and misuse threats" },
+              "fullDescription": { "text": "Threats arising from autonomous agent behavior, including uncontrolled tool use, excessive autonomy, agent-to-agent trust violations, and lack of human oversight in high-impact operations." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "ai",
+                  "agentic",
+                  "autonomy",
+                  "tool-use",
+                  "mcp"
+                ],
+                "security-severity": "7.6"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "CWE-693", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/ai/llm-threats",
+              "shortDescription": { "text": "LLM-specific threats" },
+              "fullDescription": { "text": "Threats from prompt injection vulnerabilities, data poisoning risks, and model theft in LLM-integrated components, covering direct and indirect injection, RAG pipeline manipulation, and model extraction." },
+              "properties": {
+                "tags": [
+                  "security",
+                  "ai",
+                  "llm",
+                  "prompt-injection",
+                  "data-poisoning",
+                  "model-theft"
+                ],
+                "security-severity": "8.3"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "CWE-74", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "taxonomies": [
+        {
+          "name": "OWASP",
+          "version": "2021",
+          "informationUri": "https://owasp.org/Top10/",
+          "organization": "OWASP Foundation",
+          "shortDescription": { "text": "OWASP Top 10 Web Application Security Risks" }
+        },
+        {
+          "name": "CWE",
+          "version": "4.13",
+          "informationUri": "https://cwe.mitre.org/",
+          "organization": "MITRE",
+          "shortDescription": { "text": "Common Weakness Enumeration" }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "tachi/ai/llm-threats",
+          "message": {
+            "text": "Attacker may submit adversarial prompts that override the Orchestrator's system prompt, bypassing safety constraints, because user input lacks structured boundary enforcement.",
+            "markdown": "Implement structured prompt templates with explicit delimiter tokens; deploy an input classifier for adversarial patterns; apply output filtering; implement canary tokens in system prompts."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "bc8145867ba52dd5",
+            "findingId/v1": "LLM-1"
+          },
+          "properties": {
+            "security-severity": "8.3",
+            "cvss-base-score": "9.8",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+            "exploitability": "8.8",
+            "scalability": "7.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/spoofing",
+          "message": {
+            "text": "Attacker may impersonate a legitimate user by replaying or forging authentication credentials when submitting prompts to the Guardrails Service, because user identity verification relies solely on bearer tokens without binding to client context.",
+            "markdown": "Implement token binding using DPoP (Demonstration of Proof-of-Possession) or certificate-bound access tokens; enforce session binding to client fingerprint (IP range, user-agent, TLS session); require MFA for sensitive operations; set short token lifetimes (15 minutes) with rotation."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "User", "fullyQualifiedName": "User Zone/User", "kind": "external-entity" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "cf294989f8e17183",
+            "findingId/v1": "S-1"
+          },
+          "properties": {
+            "security-severity": "7.9",
+            "cvss-base-score": "8.2",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+            "exploitability": "7.0",
+            "scalability": "6.8",
+            "reachability": "9.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/elevation-of-privilege",
+          "message": {
+            "text": "Attacker may escalate from standard user to administrative capabilities by manipulating tool selection through prompt injection, because RBAC is not enforced on tool dispatch.",
+            "markdown": "Implement RBAC policy on tool dispatch: map each tool to required permissions; validate user role against tool permission manifest before dispatch; reject unauthorized invocations with 403; enforce least privilege."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": { "text": "AG-1: Orchestrator executes consequential actions without human approval gates" },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "59650eea6f521b03",
+            "findingId/v1": "E-2",
+            "correlationGroup": "CG-2"
+          },
+          "properties": {
+            "security-severity": "7.6",
+            "cvss-base-score": "9.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "7.8",
+            "scalability": "6.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/agentic-threats",
+          "message": {
+            "text": "LLM Agent Orchestrator may execute consequential actions without human approval gates, because no risk-tier classification distinguishes reversible from irreversible operations.",
+            "markdown": "Classify operations into risk tiers: Tier 1 (read-only, auto-approve), Tier 2 (reversible writes, require confirmation), Tier 3 (irreversible external actions, require human approval with mandatory wait period)."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "ddbc56d7cbc35a3f",
+            "findingId/v1": "AG-1"
+          },
+          "properties": {
+            "security-severity": "7.6",
+            "cvss-base-score": "9.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "7.8",
+            "scalability": "6.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/elevation-of-privilege",
+          "message": {
+            "text": "Authenticated user may invoke administrative tool endpoints by manipulating the tool_name parameter, because RBAC is not enforced on tool dispatch.",
+            "markdown": "Implement RBAC policy on the MCP Tool Server mapping each tool endpoint to required permissions; validate caller role before dispatch; reject unauthorized invocations with 403."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "0e2d607fa0b581c8",
+            "findingId/v1": "E-3"
+          },
+          "properties": {
+            "security-severity": "7.5",
+            "cvss-base-score": "9.9",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H",
+            "exploitability": "6.8",
+            "scalability": "5.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/denial-of-service",
+          "message": {
+            "text": "Attacker may flood the Guardrails Service with high-volume prompt submissions to exhaust CPU on regex-based filtering, because no rate limiting or request size caps are enforced.",
+            "markdown": "Enforce per-client rate limiting at the API gateway layer; cap prompt input size at 4096 characters; implement request timeout at 10 seconds; use compiled regex with ReDoS-safe patterns; deploy auto-scaling with circuit breaker."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "15c3f25289888c15",
+            "findingId/v1": "D-1"
+          },
+          "properties": {
+            "security-severity": "7.4",
+            "cvss-base-score": "7.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "8.5",
+            "scalability": "7.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/denial-of-service",
+          "message": {
+            "text": "Attacker may send concurrent maximum-length prompts to exhaust LLM inference compute and memory, blocking legitimate requests.",
+            "markdown": "Enforce per-client rate limiting of 10 requests/minute; cap prompt input at 4096 tokens; configure request timeout at 30 seconds with circuit breaker; set memory limit at 1GB per worker."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "76996bc32d9e361b",
+            "findingId/v1": "D-2"
+          },
+          "properties": {
+            "security-severity": "7.3",
+            "cvss-base-score": "7.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "8.3",
+            "scalability": "7.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/spoofing",
+          "message": {
+            "text": "Attacker may forge tool call requests to the MCP Tool Server by impersonating the LLM Agent Orchestrator, because the JSON-RPC channel between orchestrator and tool server lacks mutual authentication.",
+            "markdown": "Implement mutual TLS (mTLS) with certificate pinning between the LLM Agent Orchestrator and MCP Tool Server; sign all JSON-RPC requests with a per-session HMAC key; validate caller identity on every tool call before dispatch."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "86044d702033aaaa",
+            "findingId/v1": "S-3"
+          },
+          "properties": {
+            "security-severity": "7.2",
+            "cvss-base-score": "9.8",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "6.0",
+            "scalability": "5.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "Attacker may manipulate JSON-RPC tool call parameters in transit, injecting malicious payloads such as SQL fragments or shell commands into tool arguments, because parameter integrity is not verified at the tool server boundary.",
+            "markdown": "Implement strict JSON schema validation on all incoming tool call parameters at the MCP Tool Server; enforce parameterized queries and command sanitization; sign JSON-RPC payloads with HMAC at the Orchestrator and verify at the Tool Server."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "e4c35caf60102681",
+            "findingId/v1": "T-3"
+          },
+          "properties": {
+            "security-severity": "7.1",
+            "cvss-base-score": "8.8",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:H/A:H",
+            "exploitability": "6.8",
+            "scalability": "5.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/agentic-threats",
+          "message": {
+            "text": "MCP Tool Server may expose all registered tools to every connected client without per-agent capability scoping, violating the principle of least privilege for tool access.",
+            "markdown": "Implement per-agent tool allowlists at the MCP Tool Server; enforce capability scoping based on originating user role; log all tool invocations with agent identity."
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "720c1c38843a2fe5",
+            "findingId/v1": "AG-3"
+          },
+          "properties": {
+            "security-severity": "7.0",
+            "cvss-base-score": "9.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "6.3",
+            "scalability": "5.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "High",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "7d",
+            "risk-disposition": "Mitigate",
+            "review-date": "2026-04-03"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/spoofing",
+          "message": {
+            "text": "Attacker may bypass the Guardrails Service by directly accessing the LLM Agent Orchestrator endpoint, impersonating the Guardrails Service identity, because inter-service authentication is not enforced.",
+            "markdown": "Enforce mutual TLS (mTLS) between Guardrails Service and LLM Agent Orchestrator; validate service identity claims using signed JWTs with audience restriction; reject requests to the Orchestrator that do not originate from an authenticated Guardrails Service instance."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "3bab618930c304c5",
+            "findingId/v1": "S-2"
+          },
+          "properties": {
+            "security-severity": "6.7",
+            "cvss-base-score": "8.2",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+            "exploitability": "6.5",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/elevation-of-privilege",
+          "message": {
+            "text": "Attacker may bypass the Guardrails Service entirely via alternate route to the Orchestrator, because authorization is only enforced at the Guardrails layer.",
+            "markdown": "Implement defense-in-depth: enforce authorization checks at both the Guardrails Service and the Orchestrator; configure network policies to restrict Orchestrator access; validate origin service identity."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "985d7f3b74246327",
+            "findingId/v1": "E-1"
+          },
+          "properties": {
+            "security-severity": "6.6",
+            "cvss-base-score": "8.8",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "5.8",
+            "scalability": "4.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/denial-of-service",
+          "message": {
+            "text": "Attacker may trigger resource exhaustion on the MCP Tool Server through concurrent tool calls, because no concurrency cap is enforced.",
+            "markdown": "Enforce a maximum of 5 concurrent tool calls per user request; implement per-tool rate limiting; configure tool execution timeout at 15 seconds; deploy circuit breaker for external API calls."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": { "text": "AG-4: Tool call chaining enables capability escalation beyond individual permissions" },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "ea4650776a79cded",
+            "findingId/v1": "D-3",
+            "correlationGroup": "CG-4"
+          },
+          "properties": {
+            "security-severity": "6.4",
+            "cvss-base-score": "7.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "6.3",
+            "scalability": "5.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/agentic-threats",
+          "message": {
+            "text": "Attacker may manipulate the MCP Tool Server to chain individually authorized tool calls to achieve data exfiltration that no single authorization would permit.",
+            "markdown": "Implement a tool chain policy engine evaluating composite effects; define forbidden tool combinations; require human approval for cross-boundary chains; enforce max chain depth of 3."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "720c1c38843a2fe5",
+            "findingId/v1": "AG-4"
+          },
+          "properties": {
+            "security-severity": "6.4",
+            "cvss-base-score": "7.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "6.3",
+            "scalability": "5.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "Attacker may inject malicious content into the Knowledge Base via the orchestrator's data ingestion path, because input sanitization is not enforced before persisting data to the vector store.",
+            "markdown": "Implement content validation and sanitization on all write operations to the Knowledge Base; enforce allowlist-based content filtering; apply integrity checksums (SHA-256) on stored records; restrict write access to an authorized ingestion pipeline."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Knowledge Base", "fullyQualifiedName": "Application Zone/Knowledge Base", "kind": "data-store" }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": { "text": "LLM-2: Indirect prompt injection via adversarial content in Knowledge Base during RAG retrieval" },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "4f934bf44aadfb00",
+            "findingId/v1": "T-4",
+            "correlationGroup": "CG-1"
+          },
+          "properties": {
+            "security-severity": "6.3",
+            "cvss-base-score": "7.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "6.5",
+            "scalability": "5.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/llm-threats",
+          "message": {
+            "text": "Attacker may exploit the RAG pipeline by injecting adversarial content into the Knowledge Base that overrides system behavior during context retrieval (indirect prompt injection).",
+            "markdown": "Sanitize retrieved document content before injection into the prompt context; implement provenance tracking; apply content integrity checks on documents before indexing."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "bc8145867ba52dd5",
+            "findingId/v1": "LLM-2"
+          },
+          "properties": {
+            "security-severity": "6.3",
+            "cvss-base-score": "7.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "6.5",
+            "scalability": "5.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/information-disclosure",
+          "message": {
+            "text": "Guardrails Service may return detailed rejection reasons revealing internal filtering rules, enabling attackers to craft prompts that evade detection.",
+            "markdown": "Return generic rejection messages to users without exposing filter rule details; log detailed rejection reasons only to the internal Audit Logger; implement separate user-facing and internal-facing error response schemas."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "2b7cc5858485093d",
+            "findingId/v1": "I-1"
+          },
+          "properties": {
+            "security-severity": "6.2",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N",
+            "exploitability": "7.8",
+            "scalability": "6.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "Attacker may inject malicious content into the prompt context by tampering with the data flow between the Guardrails Service and the Orchestrator, because the validated prompt is not integrity-protected in transit.",
+            "markdown": "Sign validated prompts with an HMAC before forwarding from Guardrails Service to Orchestrator; verify signature on receipt; reject prompts with invalid or missing signatures; encrypt the inter-service channel with TLS."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "b622281d4ca868aa",
+            "findingId/v1": "T-2"
+          },
+          "properties": {
+            "security-severity": "6.1",
+            "cvss-base-score": "7.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "6.0",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/denial-of-service",
+          "message": {
+            "text": "Attacker may exhaust Knowledge Base resources via unbounded vector search queries with adversarial high-dimensional inputs.",
+            "markdown": "Enforce maximum result count (top-k limit of 10) on all Knowledge Base queries; cap query vector dimensions; implement query timeout at 5 seconds; deploy connection pool limits."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Knowledge Base", "fullyQualifiedName": "Application Zone/Knowledge Base", "kind": "data-store" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "0de917a8d1f81eec",
+            "findingId/v1": "D-4"
+          },
+          "properties": {
+            "security-severity": "6.0",
+            "cvss-base-score": "7.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "5.3",
+            "scalability": "4.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/information-disclosure",
+          "message": {
+            "text": "Knowledge Base may return full document contents including internal metadata, embedding vectors, and storage schema details, because field-level projection is not enforced.",
+            "markdown": "Implement field-level projection on Knowledge Base query responses to return only content fields required by the Orchestrator; strip internal metadata, embedding vectors, and storage identifiers."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Knowledge Base", "fullyQualifiedName": "Application Zone/Knowledge Base", "kind": "data-store" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "8a5dd9d4db40eaaf",
+            "findingId/v1": "I-4"
+          },
+          "properties": {
+            "security-severity": "5.9",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "exploitability": "7.0",
+            "scalability": "5.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "Attacker may modify Guardrails Service validation rules at runtime, because configuration files are stored in a location writable by the application process without integrity verification.",
+            "markdown": "Store Guardrails validation rules in an immutable configuration store with cryptographic integrity verification (SHA-256 checksums); enforce read-only filesystem mounts for configuration; implement change detection alerts."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "e6bc538cbd3fe085",
+            "findingId/v1": "T-1"
+          },
+          "properties": {
+            "security-severity": "5.8",
+            "cvss-base-score": "7.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "5.3",
+            "scalability": "4.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/spoofing",
+          "message": {
+            "text": "Attacker may redirect MCP Tool Server outbound API requests to an attacker-controlled endpoint by spoofing DNS responses, because certificate pinning is not enforced on outbound HTTPS connections.",
+            "markdown": "Implement TLS certificate pinning for all outbound connections to the External API; validate DNS responses using DNSSEC; configure strict certificate chain verification; monitor for unexpected certificate changes."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "a5e9eb30090af448",
+            "findingId/v1": "S-4"
+          },
+          "properties": {
+            "security-severity": "5.7",
+            "cvss-base-score": "7.4",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:N",
+            "exploitability": "4.5",
+            "scalability": "4.3",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/information-disclosure",
+          "message": {
+            "text": "MCP Tool Server may forward raw External API error responses without sanitization, potentially exposing third-party API keys or internal endpoint URLs.",
+            "markdown": "Sanitize all External API responses before returning to the Orchestrator; strip authentication headers, internal URLs, and API keys from error payloads; implement an error response allowlist."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "6c078f5b90987fc2",
+            "findingId/v1": "I-3"
+          },
+          "properties": {
+            "security-severity": "5.6",
+            "cvss-base-score": "6.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "exploitability": "5.0",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/information-disclosure",
+          "message": {
+            "text": "LLM Agent Orchestrator may leak sensitive internal state through verbose error messages, exposing service topology, Knowledge Base schema, or model configuration.",
+            "markdown": "Implement standardized error responses that strip internal details; return generic error codes to users; route detailed error information to internal monitoring only."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "cda734dd6fbe58e9",
+            "findingId/v1": "I-2"
+          },
+          "properties": {
+            "security-severity": "5.5",
+            "cvss-base-score": "6.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "exploitability": "4.8",
+            "scalability": "4.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "Attacker may modify or delete audit log entries to cover tracks after a security incident, because the Audit Logger stores logs in a location writable by application processes.",
+            "markdown": "Deploy the Audit Logger as an append-only, immutable log store; separate write permissions from read/admin permissions; forward logs to an external SIEM within 60 seconds; implement cryptographic chaining to detect tampering."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Audit Logger", "fullyQualifiedName": "Application Zone/Audit Logger", "kind": "data-store" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "dc56897bffa6a276",
+            "findingId/v1": "T-5"
+          },
+          "properties": {
+            "security-severity": "5.4",
+            "cvss-base-score": "7.1",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "4.3",
+            "scalability": "3.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/denial-of-service",
+          "message": {
+            "text": "Attacker may cause audit log storage exhaustion through rapid request submission, disrupting services that depend on log writing.",
+            "markdown": "Implement log volume throttling with per-source rate limits; set storage quotas with automatic rotation; deploy log sampling for high-volume event sources during load spikes."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Audit Logger", "fullyQualifiedName": "Application Zone/Audit Logger", "kind": "data-store" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "53dcc0228ab127cd",
+            "findingId/v1": "D-5"
+          },
+          "properties": {
+            "security-severity": "5.3",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:N/A:H",
+            "exploitability": "5.3",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/repudiation",
+          "message": {
+            "text": "LLM Agent Orchestrator may execute tool calls and generate responses without logging the full decision chain, enabling denial of specific actions.",
+            "markdown": "Instrument the Orchestrator to emit structured decision audit events: record authenticated user ID, session ID, input prompt hash, model reasoning trace, each tool call details, final response hash, and UTC timestamp."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": { "text": "AG-2: Orchestrator operates in unbounded reasoning loop without termination constraints" },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "1bad83b9f1d04f2f",
+            "findingId/v1": "R-3",
+            "correlationGroup": "CG-3"
+          },
+          "properties": {
+            "security-severity": "5.2",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "exploitability": "5.0",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/agentic-threats",
+          "message": {
+            "text": "LLM Agent Orchestrator may operate in an unbounded reasoning loop without termination constraints, enabling indefinite resource consumption through ambiguous prompts.",
+            "markdown": "Implement mandatory termination constraints: maximum iteration count (25 iterations), execution timeout (5 minutes), and cumulative cost cap ($10 per request); add circuit breaker for repeated action patterns."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "ddbc56d7cbc35a3f",
+            "findingId/v1": "AG-2"
+          },
+          "properties": {
+            "security-severity": "5.2",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:N",
+            "exploitability": "5.0",
+            "scalability": "5.0",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/information-disclosure",
+          "message": {
+            "text": "Audit log entries may contain sensitive data including full prompt content, user PII, and API credentials, accessible to operations staff beyond the security team.",
+            "markdown": "Implement log data classification: separate sensitive fields into a restricted log tier with strict access controls; apply PII masking or tokenization; enforce role-based access to audit logs."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Audit Logger", "fullyQualifiedName": "Application Zone/Audit Logger", "kind": "data-store" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "bc274bb03ddf8fb7",
+            "findingId/v1": "I-5"
+          },
+          "properties": {
+            "security-severity": "5.1",
+            "cvss-base-score": "6.5",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "exploitability": "4.0",
+            "scalability": "3.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/llm-threats",
+          "message": {
+            "text": "Attacker may systematically query the Orchestrator's inference endpoint to extract a functional model copy through distillation, because rich response data is returned without query volume limits.",
+            "markdown": "Restrict API output to top-k predictions only; implement per-API-key query budgets with alerts; deploy query pattern analysis for systematic probing; add watermarking to model outputs."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "LLM Agent Orchestrator", "fullyQualifiedName": "Application Zone/LLM Agent Orchestrator", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "bc8145867ba52dd5",
+            "findingId/v1": "LLM-3"
+          },
+          "properties": {
+            "security-severity": "5.0",
+            "cvss-base-score": "5.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:H/PR:L/UI:N/S:U/C:H/I:N/A:N",
+            "exploitability": "4.5",
+            "scalability": "4.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/repudiation",
+          "message": {
+            "text": "User may deny having submitted a specific prompt that triggered a harmful response, because the system does not capture non-repudiable evidence linking authenticated identity to the submission.",
+            "markdown": "Implement non-repudiation controls: capture authenticated user ID, session ID, client IP, timestamp (UTC, sub-second precision), and cryptographic hash of the submitted prompt in an immutable audit record."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "User", "fullyQualifiedName": "User Zone/User", "kind": "external-entity" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "5a808890b239b615",
+            "findingId/v1": "R-1"
+          },
+          "properties": {
+            "security-severity": "4.8",
+            "cvss-base-score": "4.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+            "exploitability": "3.0",
+            "scalability": "3.0",
+            "reachability": "9.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/repudiation",
+          "message": {
+            "text": "External API interactions may lack correlation identifiers that link API calls back to the originating user request, creating accountability gaps.",
+            "markdown": "Include a unique request correlation ID in all External API calls (via HTTP header); log the correlation ID alongside the originating user request ID."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "External API", "fullyQualifiedName": "External Services/External API", "kind": "external-entity" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "af01fd610f22994d",
+            "findingId/v1": "R-5"
+          },
+          "properties": {
+            "security-severity": "4.6",
+            "cvss-base-score": "4.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+            "exploitability": "2.5",
+            "scalability": "2.8",
+            "reachability": "9.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/repudiation",
+          "message": {
+            "text": "Guardrails Service may fail to log rejected prompts with sufficient detail to reconstruct filtering decisions, enabling disputes about legitimate prompts being incorrectly blocked.",
+            "markdown": "Instrument the Guardrails Service to emit structured audit events for every filtering decision: include request correlation ID, authenticated user ID, original prompt hash, matched filter rule ID, confidence score, action taken, and UTC timestamp."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "Guardrails Service", "fullyQualifiedName": "Application Zone/Guardrails Service", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "ada85cea3b936bf4",
+            "findingId/v1": "R-2"
+          },
+          "properties": {
+            "security-severity": "4.5",
+            "cvss-base-score": "4.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+            "exploitability": "4.3",
+            "scalability": "3.8",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        },
+        {
+          "ruleId": "tachi/stride/repudiation",
+          "message": {
+            "text": "MCP Tool Server may execute tool operations without recording the requesting orchestrator context, preventing forensic attribution to specific user requests.",
+            "markdown": "Log every tool execution with: requesting orchestrator session ID, originating user ID, tool name, input parameters, execution duration, response status, External API endpoint called, and UTC timestamp."
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": { "uri": "docs/security/2026-03-25T19-49-23/threats.md" },
+                "region": { "startLine": 1 }
+              },
+              "logicalLocations": [
+                { "name": "MCP Tool Server", "fullyQualifiedName": "Application Zone/MCP Tool Server", "kind": "process" }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "c3bdb0ccc5a46449",
+            "findingId/v1": "R-4"
+          },
+          "properties": {
+            "security-severity": "4.3",
+            "cvss-base-score": "4.3",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N",
+            "exploitability": "3.8",
+            "scalability": "3.5",
+            "reachability": "5.5",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "Medium",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "30d",
+            "risk-disposition": "Review",
+            "review-date": "2026-04-26"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/schemas/finding.yaml
+++ b/schemas/finding.yaml
@@ -137,3 +137,23 @@ finding:
 # HIGH Impact      Medium            High              Critical
 # MEDIUM Impact    Low               Medium            High
 # LOW Impact       Note              Low               Medium
+
+# Scored Finding Extension (Optional)
+#
+# When quantitative risk scoring is applied via /risk-score,
+# findings are extended with additional scoring and governance
+# fields defined in schemas/risk-scoring.yaml.
+#
+# The scored_finding schema extends this finding schema with:
+#   - cvss_base (0.0-10.0): CVSS 3.1 base score
+#   - cvss_vector: Full CVSS 3.1 vector string
+#   - exploitability (0.0-10.0): Exploitability assessment
+#   - scalability (0.0-10.0): Scalability assessment
+#   - reachability (0.0-10.0): Reachability assessment
+#   - composite_score (0.0-10.0): Weighted composite
+#   - severity_band: Critical/High/Medium/Low
+#   - risk_owner, remediation_sla, risk_disposition, review_date
+#
+# See: schemas/risk-scoring.yaml for full field definitions
+# Producer: agents/tachi/risk-scorer.md
+# Output: templates/risk-scores.md, templates/risk-scores.sarif

--- a/schemas/risk-scoring.yaml
+++ b/schemas/risk-scoring.yaml
@@ -1,0 +1,102 @@
+# Risk Scoring Schema
+#
+# Extends the finding IR (finding.yaml) with four-dimensional
+# quantitative scoring, composite risk calculation, severity bands,
+# and governance fields for remediation tracking.
+#
+# Producers: agents/tachi/risk-scorer.md
+# Consumers: templates/risk-scores.md, templates/risk-scores.sarif,
+#            /risk-score command output
+#
+# Version: 1.0
+
+schema_version: "1.0"
+
+scored_finding:
+  extends: finding  # All fields from finding.yaml, plus:
+
+  cvss_base:
+    type: number
+    range: [0.0, 10.0]
+    description: "CVSS 3.1 base score"
+
+  cvss_vector:
+    type: string
+    pattern: "^CVSS:3\\.1/AV:[NALP]/AC:[LH]/PR:[NLH]/UI:[NR]/S:[UC]/C:[NLH]/I:[NLH]/A:[NLH]$"
+    description: "Full CVSS 3.1 vector string for auditability"
+
+  exploitability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Exploitability assessment score"
+
+  scalability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Scalability assessment score"
+
+  reachability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Reachability assessment score"
+
+  composite_score:
+    type: number
+    range: [0.0, 10.0]
+    description: "Weighted composite: (0.35*CVSS) + (0.30*Exploitability) + (0.15*Scalability) + (0.20*Reachability)"
+
+  severity_band:
+    type: string
+    enum: [Critical, High, Medium, Low]
+    description: >
+      Mapped from composite_score per output.yaml CVSS ranges.
+      Note: output.yaml defines 5 bands (Critical/High/Medium/Low/Note).
+      For scoring, Note is consolidated into Low (0.0-3.9) since
+      composite scores always produce a meaningful numeric value.
+
+  risk_owner:
+    type: string
+    default: "Unassigned"
+
+  remediation_sla:
+    type: string
+    description: "Severity-driven default: Critical=24h, High=7d, Medium=30d, Low=90d"
+
+  risk_disposition:
+    type: string
+    enum: [Mitigate, Review, Accept, Transfer]
+    default_mapping:
+      Critical: Mitigate
+      High: Mitigate
+      Medium: Review
+      Low: Review
+
+  review_date:
+    type: string
+    format: "YYYY-MM-DD"
+    description: "Scoring date + SLA duration"
+
+# Default CVSS 3.1 Vectors per Threat Category
+category_defaults:
+  spoofing:            "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"   # Auth bypass
+  tampering:           "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L"   # Data modification
+  repudiation:         "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"   # Audit evasion
+  info-disclosure:     "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N"   # Data exposure
+  denial-of-service:   "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H"   # Resource exhaustion
+  privilege-escalation: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H"  # Privilege gain
+  agentic:             "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L"   # Agent misuse (PR:L to avoid ceiling effect)
+  llm:                 "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"   # Prompt injection
+
+# Composite Weights
+weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+
+# Severity Bands (aligned with schemas/output.yaml)
+severity_bands:
+  Critical: { min: 9.0, max: 10.0, sla: "24h", disposition: "Mitigate" }
+  High:     { min: 7.0, max: 8.9,  sla: "7d",  disposition: "Mitigate" }
+  Medium:   { min: 4.0, max: 6.9,  sla: "30d", disposition: "Review" }
+  Low:      { min: 0.0, max: 3.9,  sla: "90d", disposition: "Review" }

--- a/specs/035-quantitative-risk-scoring/NEXT-SESSION.md
+++ b/specs/035-quantitative-risk-scoring/NEXT-SESSION.md
@@ -1,0 +1,70 @@
+# Session Continuation: Quantitative Risk Scoring
+
+**Generated**: 2026-03-27
+**Branch**: 035-quantitative-risk-scoring
+**Last Commit**: e2a088f docs: add baseball card infographic to What is tachi section (#34)
+
+## Completed This Session
+
+- P1 Architect checkpoint: APPROVED_WITH_CONCERNS (0 Critical, 2 Medium, 5 Low)
+- Addressed P1-001: Added post-parsing zero-findings exit gate to agent
+- Addressed P1-002: Added large threat model processing capacity guidance to agent pipeline overview
+- T020: Created /risk-score command definition at .claude/commands/risk-score.md
+- T021: Copied risk-scorer agent to adapters/claude-code/agents/risk-scorer.md
+- T022: Copied risk-score command to adapters/claude-code/commands/risk-score.md
+- T023: Added "Risk Scoring SARIF Extension" section to sarif-generation.md reference
+- T024: Added optional scored_finding extension reference to schemas/finding.yaml
+
+Combined with prior sessions (Waves 1-4b): T001-T024 complete (24/29 tasks).
+
+## Current State
+
+- **Phase**: implement
+- **Uncommitted**: 15 files (all feature work — no commits made yet on this branch)
+- **Tasks**: 24/29 complete (83%)
+- **Waves**: 1-5 complete, Wave 6 (Validation) pending — this is the LAST wave
+- **Checkpoint**: P1 APPROVED_WITH_CONCERNS. P2 checkpoint due after Wave 6.
+
+## P1 Checkpoint Findings (carry forward)
+
+| ID | Severity | Status | Notes |
+|----|----------|--------|-------|
+| P1-001 | Medium | RESOLVED | Zero-findings exit gate added to agent |
+| P1-002 | Medium | RESOLVED | Batching guidance added to pipeline overview |
+| P1-003 | Low | OPEN | Template governance table needs Component column (align to agent 7-col) |
+| P1-004 | Low | OPEN | Template Section 3 format differs from agent Section 9d (adopt concise) |
+| P1-005 | Low | RESOLVED | T023 semantic shift documented in SARIF reference |
+| P1-006 | Low | N/A | Template placeholders are cosmetic (reference doc) |
+| P1-007 | Low | DEFERRED | T028 must compare logical finding coverage, not raw counts |
+
+## Next Actions
+
+1. **Execute Wave 6 (Validation)** — final wave:
+   - T025: Generate example risk-scores.md against examples/agentic-app/sample-report/threats.md
+   - T026 [P]: Generate example risk-scores.sarif against same input
+   - T027: Verify score differentiation (SC-001) >= 80%
+   - T028: Verify dual-format parity (SC-005) = 100%
+   - T029: Run end-to-end /risk-score command validation
+2. **Step 5 (Final Validation)**: Architect + Code Reviewer + Security Analyst reviews
+3. **Step 6 (Security Scan)**: Run /security on changed files
+4. **Step 7 (Report Completion)**: Display implementation summary
+5. **Commit all changes** and create PR
+
+## Context Files
+
+- Spec: `specs/035-quantitative-risk-scoring/spec.md`
+- Plan: `specs/035-quantitative-risk-scoring/plan.md`
+- Tasks: `specs/035-quantitative-risk-scoring/tasks.md`
+- Agent assignments: `specs/035-quantitative-risk-scoring/agent-assignments.md`
+- P1 review: `specs/035-quantitative-risk-scoring/checkpoints/p1-review.md`
+- Agent: `.claude/agents/tachi/risk-scorer.md`
+- Command: `.claude/commands/risk-score.md`
+- Schema: `schemas/risk-scoring.yaml`
+- Templates: `templates/risk-scores.md`, `templates/risk-scores.sarif`
+- Example input: `examples/agentic-app/sample-report/threats.md`
+
+## Resume Command
+
+```bash
+claude "Resume quantitative risk scoring implementation (branch: 035-quantitative-risk-scoring). Waves 1-5 complete (24/29 tasks). Run /aod.build to continue with Wave 6 validation."
+```

--- a/specs/035-quantitative-risk-scoring/agent-assignments.md
+++ b/specs/035-quantitative-risk-scoring/agent-assignments.md
@@ -1,0 +1,146 @@
+# Agent Assignments: Quantitative Risk Scoring
+
+**Feature**: 035-quantitative-risk-scoring
+**Generated**: 2026-03-27
+**Total Tasks**: 29
+**Estimated Duration**: 5.5h (optimistic) / 7h (realistic) / 9.5h (pessimistic)
+
+## Agent Assignment Matrix
+
+| Task | Agent | Rationale |
+|------|-------|-----------|
+| T001 | `senior-backend-engineer` | Schema/YAML file creation |
+| T002 | `senior-backend-engineer` | Agent markdown file creation |
+| T003 | `senior-backend-engineer` | Template markdown file creation |
+| T004 | `senior-backend-engineer` | Agent section authoring (threat parsing) |
+| T005 | `senior-backend-engineer` | Agent section authoring (SARIF parsing) |
+| T006 | `senior-backend-engineer` | SARIF template JSON structure |
+| T007 | `senior-backend-engineer` | Agent section authoring (CVSS scoring) |
+| T008 | `senior-backend-engineer` | Agent section authoring (exploitability) |
+| T009 | `senior-backend-engineer` | Agent section authoring (scalability) |
+| T010 | `senior-backend-engineer` | Agent section authoring (composite calc) |
+| T011 | `senior-backend-engineer` | Agent section authoring (governance fields) |
+| T012 | `senior-backend-engineer` | Agent section authoring (markdown output) |
+| T013 | `senior-backend-engineer` | Agent section authoring (SARIF output) |
+| T014 | `senior-backend-engineer` | Template content population |
+| T015 | `senior-backend-engineer` | Template content population |
+| T016 | `senior-backend-engineer` | Agent section authoring (trust zones) |
+| T017 | `senior-backend-engineer` | Agent section authoring (reachability) |
+| T018 | `senior-backend-engineer` | Agent section update (composite) |
+| T019 | `senior-backend-engineer` | Template content authoring (methodology) |
+| T020 | `senior-backend-engineer` | Command markdown file creation |
+| T021 | `senior-backend-engineer` | File copy (adapter agent) |
+| T022 | `senior-backend-engineer` | File copy (adapter command) |
+| T023 | `senior-backend-engineer` | Reference doc update (SARIF) |
+| T024 | `senior-backend-engineer` | Schema file update |
+| T025 | `senior-backend-engineer` | Example output generation |
+| T026 | `senior-backend-engineer` | Example output generation |
+| T027 | `security-analyst` | Security-domain score validation |
+| T028 | `code-reviewer` | Cross-format consistency review |
+| T029 | `tester` | End-to-end command validation |
+
+## Parallel Execution Waves
+
+### Wave 1: Setup (Phase 1)
+**Duration**: ~30 min | **Gate**: Schema + skeleton files exist
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 1a | T001 | `senior-backend-engineer` | Sequential (schema first) |
+| 1b | T002 | `senior-backend-engineer` | [P] after T001 |
+| 1c | T003 | `senior-backend-engineer` | [P] after T001 |
+
+### Wave 2: Foundation (Phase 2)
+**Duration**: ~45 min | **Gate**: Agent can parse both input formats
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 2a | T004 | `senior-backend-engineer` | Sequential |
+| 2b | T005 | `senior-backend-engineer` | [P] with T004 |
+| 2c | T006 | `senior-backend-engineer` | [P] with T004 |
+
+### Wave 3: Core Scoring (Phase 3 — US1)
+**Duration**: ~1.5h | **Gate**: Agent scores all 4 dimensions + composite
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 3a | T007 | `senior-backend-engineer` | Sequential (CVSS first) |
+| 3b | T008 | `senior-backend-engineer` | [P] with T007 |
+| 3c | T009 | `senior-backend-engineer` | [P] with T007 |
+| 3d | T010 | `senior-backend-engineer` | Sequential (after T007-T009) |
+
+**MVP CHECKPOINT**: Stop and validate scoring against example data
+
+### Wave 4a: Governance + Independent Stories (Phases 4, 6, 7)
+**Duration**: ~1h | **Gate**: Governance fields, reachability, methodology all complete
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 4a-1 | T011 | `senior-backend-engineer` | Sequential (governance) |
+| 4a-2 | T016 | `senior-backend-engineer` | [P] with T011 |
+| 4a-3 | T019 | `senior-backend-engineer` | [P] with T011 |
+| 4a-4 | T017 | `senior-backend-engineer` | After T016 |
+| 4a-5 | T018 | `senior-backend-engineer` | After T010 + T017 |
+
+### Wave 4b: Output Generation (Phase 5 — US3)
+**Duration**: ~1h | **Gate**: Both output formats generate correctly
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 4b-1 | T012 | `senior-backend-engineer` | Sequential |
+| 4b-2 | T013 | `senior-backend-engineer` | After T012 |
+| 4b-3 | T014 | `senior-backend-engineer` | [P] with T012 |
+| 4b-4 | T015 | `senior-backend-engineer` | [P] with T012 |
+
+### Wave 5: Command + Integration (Phase 8)
+**Duration**: ~45 min | **Gate**: /risk-score command executes end-to-end
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 5a | T020 | `senior-backend-engineer` | Sequential (command first) |
+| 5b | T021 | `senior-backend-engineer` | [P] after T020 |
+| 5c | T022 | `senior-backend-engineer` | [P] after T020 |
+| 5d | T023 | `senior-backend-engineer` | [P] after T020 |
+| 5e | T024 | `senior-backend-engineer` | [P] after T020 |
+
+### Wave 6: Validation (Phase 9)
+**Duration**: ~1h | **Gate**: All success criteria validated
+
+| Slot | Task | Agent | Parallel |
+|------|------|-------|----------|
+| 6a | T025 | `senior-backend-engineer` | Sequential |
+| 6b | T026 | `senior-backend-engineer` | [P] with T025 |
+| 6c | T027 | `security-analyst` | After T025 |
+| 6d | T028 | `code-reviewer` | [P] with T027 |
+| 6e | T029 | `tester` | After T027 + T028 |
+
+## Quality Gates
+
+| Gate | Location | Criteria |
+|------|----------|----------|
+| G1 | After Wave 1 | Schema validates, agent skeleton has all section stubs |
+| G2 | After Wave 2 | Agent can parse threats.md and threats.sarif, template structures exist |
+| G3 | After Wave 3 | **MVP**: Agent produces 4 dimension scores + composite for all example findings |
+| G4a | After Wave 4a | Governance fields, reachability, methodology sections complete |
+| G4b | After Wave 4b | Both risk-scores.md and risk-scores.sarif generate correctly |
+| G5 | After Wave 5 | /risk-score command runs end-to-end with correct output summary |
+| G6 | After Wave 6 | SC-001 differentiation >= 80%, SC-005 parity 100%, SARIF validates |
+
+## Timeline Summary
+
+| Wave | Tasks | Duration (realistic) | Cumulative |
+|------|-------|---------------------|------------|
+| Wave 1 | 3 | 30 min | 0:30 |
+| Wave 2 | 3 | 45 min | 1:15 |
+| Wave 3 | 4 | 1:30 | 2:45 |
+| Wave 4a | 5 | 1:00 | 3:45 |
+| Wave 4b | 4 | 1:00 | 4:45 |
+| Wave 5 | 5 | 0:45 | 5:30 |
+| Wave 6 | 5 | 1:00 | 6:30 |
+| **Total** | **29** | **~6.5h** | |
+
+## Risk Notes
+
+- **Bottleneck**: T007 (CVSS scoring) is the most complex individual task — category defaults + per-threat refinement logic. Allow extra time.
+- **Wave 4 overload**: Split into 4a/4b with independent sub-waves. Orchestrator should checkpoint between 4a and 4b.
+- **Validation dependency**: T029 (end-to-end) depends on all prior tasks. If any wave runs long, validation is the first to slip.

--- a/specs/035-quantitative-risk-scoring/checklists/requirements.md
+++ b/specs/035-quantitative-risk-scoring/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Quantitative Risk Scoring
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-03-27
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+- All items pass. Spec is ready for PM review.
+- 5 user stories covering all 4 PRD user stories plus methodology documentation
+- 17 functional requirements covering all 8 PRD functional requirements
+- 9 success criteria with measurable thresholds
+- 7 edge cases identified and addressed
+- PRD open questions all resolved (CVSS 3.1, standalone command, weights in schema)

--- a/specs/035-quantitative-risk-scoring/checkpoints/p1-review.md
+++ b/specs/035-quantitative-risk-scoring/checkpoints/p1-review.md
@@ -1,0 +1,162 @@
+# P1 Checkpoint Review: Quantitative Risk Scoring
+
+**Feature**: #035 Quantitative Risk Scoring
+**Checkpoint**: P1 -- Core Functionality (Production Cutover)
+**Reviewer**: Architect
+**Date**: 2026-03-27
+**Status**: APPROVED_WITH_CONCERNS
+
+---
+
+## Review Scope
+
+Validated Waves 1-4b deliverables (T001-T019, 19/29 tasks) against spec.md (5 user stories, 17 FRs, 9 success criteria) and plan.md (6-phase architecture, schema design, data flow).
+
+**Deliverables reviewed**:
+- `schemas/risk-scoring.yaml` -- scored finding extension schema
+- `.claude/agents/tachi/risk-scorer.md` -- primary scoring agent (1,407 lines)
+- `templates/risk-scores.md` -- markdown output template (253 lines)
+- `templates/risk-scores.sarif` -- SARIF output template (439 lines)
+
+---
+
+## Findings
+
+| ID | Severity | Category | Description | Resolution |
+|----|----------|----------|-------------|------------|
+| P1-001 | Medium | Edge Case | **Empty threat model and missing input file handling not defined in agent.** Spec edge cases require: (1) zero findings exits with "No threat findings to score" and (2) missing input files exits with "No threat model output found. Run `/threat-model` first." The agent defines parsing rules and fallback for trust zones exhaustively but does not include explicit pre-scoring validation for these two terminal conditions. The command definition (T020, Wave 5) is the natural location for input existence checks, but the agent itself should define the zero-findings exit since the agent performs the parsing. | Add a post-parsing gate in the agent between Section 1 (Threat Parsing) and Section 2 (Trust Zone Extraction): if parsed findings count is zero after parsing completes, halt scoring and emit "No threat findings to score." This is agent-level logic, not command-level. The missing-input-file check belongs in the command (T020) and is out of scope for this checkpoint. |
+| P1-002 | Medium | Spec Coverage | **Large threat model handling (>100 findings, up to 200) lacks guidance in agent.** Spec edge case and SC-006 require scoring up to 200 threats within 5 minutes, with batching strategies if needed. The plan (Risk Mitigations table) mentions "Batch scoring into per-category sub-invocations if single-pass exceeds limits." The agent contains no batching strategy, chunking guidance, or performance considerations for large input sets. | Add a subsection to the Scoring Pipeline Overview (or as a note in Section 7 Composite Calculation) addressing large threat model processing: state that the scoring pipeline processes findings sequentially in a single pass; if context window pressure arises with >100 findings, the command layer (T020) may batch invocations by category. This positions the batching decision correctly (command orchestration, not agent internals) while documenting the expectation. |
+| P1-003 | Low | Template-Agent Mismatch | **Governance Fields table column mismatch between template and agent.** The template (`templates/risk-scores.md` Section 4) defines a 6-column table: `ID | Severity | Owner | SLA | Disposition | Review Date`. The agent (Section 9e) defines a 7-column table adding `Component`: `ID | Component | Severity | Owner | SLA | Disposition | Review Date`. The agent output specification is more informative (Component column aids triage), but the template and agent are inconsistent. | Align the template to match the agent's 7-column definition by adding the `Component` column to `templates/risk-scores.md` Section 4. The agent's version is the better design since Component context is essential for triage without cross-referencing Section 2. |
+| P1-004 | Low | Template Structure | **Markdown template Section 3 (Dimensional Breakdown) structure differs from agent specification.** The template defines per-finding breakdowns with separate subsection tables for each CVSS metric (AV, AC, PR, UI, S, C, I, A with Rationale columns) and separate Exploitability/Scalability sub-dimension tables. The agent Section 9d defines a simpler consolidated format with a single 4-row dimension table and bullet-point rationale. Both are valid, but they are different formats -- the template is more detailed, the agent is more concise. | Resolve by aligning to a single format. Recommendation: adopt the agent's concise format (Section 9d) as canonical since it produces output that is easier to scan at scale (20+ findings). The template's detailed CVSS metric table and sub-dimension tables can be documented as an optional "verbose" mode in a Phase 2 enhancement. Update `templates/risk-scores.md` Section 3 to match the agent's Section 9d format. |
+| P1-005 | Low | Plan Concern Tracking | **T023 security-severity semantic shift documentation -- flagged correctly in plan.md architect sign-off, addressed in agent.** The architect concern from the plan review (tasks.md architect_signoff notes) stated that T023 should document the security-severity semantic shift between threats.sarif and risk-scores.sarif. The agent (Section 10, opening paragraph) explicitly documents this shift: "In threats.sarif, the rule-level security-severity is a static category value... In risk-scores.sarif, the result-level security-severity is the per-finding composite score and the rule-level security-severity is the MAX composite score." T023 is Wave 5 work (SARIF reference guide update), but the agent already carries the architectural intent. This concern is tracked, not blocking. | No action needed at this checkpoint. T023 will propagate this documentation to `adapters/claude-code/agents/references/sarif-generation.md` during Wave 5. Verified that the agent already embeds the correct semantic description. |
+| P1-006 | Low | SARIF Compliance | **SARIF template uses placeholder strings for security-severity at rule level.** `templates/risk-scores.sarif` uses `<max-composite-score-for-spoofing-findings>` style placeholders in rule-level `security-severity` fields. This is correct template behavior (populated at generation time), but the placeholder format uses angle brackets which are not valid JSON string content. The template is a reference document, not a parseable JSON file, so this is cosmetic rather than functional. | No action required. The template is correctly documented as a structural reference. The agent (Section 10b) defines the actual generation logic. If the template is ever used for JSON validation, the placeholders would need to be replaced with example values. |
+| P1-007 | Low | Dual-Format Parity | **Markdown/SARIF result count asymmetry for correlation groups is documented but warrants validation emphasis.** Agent Section 10h correctly states that peer findings do NOT appear as separate SARIF results (they appear in relatedLocations), while the markdown Scored Threat Table lists peers as separate rows. This means `risk-scores.md` row count may differ from `risk-scores.sarif` results array length. This is architecturally correct (SARIF best practice) but the SC-005 dual-format parity success criterion ("All scores and governance fields are consistent between formats") needs to account for this structural difference during validation (T028). | Flag for T028 (Wave 6): the parity check must compare *logical* finding coverage (primaries + peers accounted for in both formats), not raw result counts. The agent documents this in Sections 10h and 10j. No change needed to the agent -- this is a validation task concern. |
+
+---
+
+## Review Criteria Assessment
+
+### 1. Architecture Alignment
+
+**PASS.** The agent pipeline faithfully implements the 6-phase flow from plan.md:
+1. Threat Parsing (Section 1) -- threats.md canonical, threats.sarif fallback
+2. Trust Zone Extraction (Section 2) -- component-to-zone mapping dictionary
+3. Dimensional Scoring (Sections 3-6) -- CVSS, exploitability, scalability, reachability
+4. Composite Calculation (Section 7) -- weighted formula, severity band mapping
+5. Governance Fields (Section 8) -- severity-driven defaults
+6. Output Generation (Sections 9-10) -- dual markdown and SARIF output
+
+The pipeline phases map 1:1 to the plan's agent pipeline definition (plan.md lines 117-128).
+
+### 2. Spec Coverage
+
+**PASS with concerns (P1-001, P1-002).** All 5 user stories and 17 functional requirements are addressed:
+
+| Requirement | Agent Section | Status |
+|-------------|--------------|--------|
+| FR-001 (parse threats.md + threats.sarif) | Sections 1a, 1b | Covered |
+| FR-002 (CVSS 3.1 base score) | Section 3 | Covered |
+| FR-003 (CVSS vector string) | Section 3 | Covered |
+| FR-004 (exploitability) | Section 4 | Covered |
+| FR-005 (scalability) | Section 5 | Covered |
+| FR-006 (reachability from trust zones) | Sections 2, 6 | Covered |
+| FR-007 (composite formula) | Section 7 | Covered |
+| FR-008 (severity bands) | Section 7 | Covered |
+| FR-009 (governance fields) | Section 8 | Covered |
+| FR-010 (risk-scores.md generation) | Section 9 | Covered |
+| FR-011 (risk-scores.sarif generation) | Section 10 | Covered |
+| FR-012 (preserve original metadata) | Section 1 | Covered |
+| FR-013 (preserve SARIF fingerprints) | Section 10e | Covered |
+| FR-014 (default reachability 5.0) | Section 6e | Covered |
+| FR-015 (graceful malformed handling) | Section 1 (Error Handling) | Covered |
+| FR-016 (input validation) | Not in agent (command-layer) | Deferred to T020 |
+| FR-017 (output co-location) | Sections 9g, 10i | Covered |
+
+Gaps: empty threat model exit (P1-001) and large model batching guidance (P1-002) are Medium severity but addressable before Wave 5.
+
+### 3. Schema Consistency
+
+**PASS.** `schemas/risk-scoring.yaml` matches plan.md Section "Schema Design" exactly:
+- All 12 scored_finding fields present with correct types and ranges
+- 8 category_defaults vectors match plan.md (including the architect-requested PR:L for agentic)
+- Weights (0.35/0.30/0.15/0.20) match plan and agent
+- Severity bands (Critical 9.0-10.0, High 7.0-8.9, Medium 4.0-6.9, Low 0.0-3.9) align with output.yaml
+- Note-to-Low consolidation documented in schema description
+
+### 4. Template Completeness
+
+**PASS with minor concerns (P1-003, P1-004).** Both templates cover all required output sections:
+
+- `templates/risk-scores.md`: Frontmatter, Executive Summary, Scored Threat Table, Dimensional Breakdown, Governance Fields, Scoring Methodology -- all present with field definitions and format specifications
+- `templates/risk-scores.sarif`: SARIF 2.1.0 skeleton with $schema, version, tool.driver, 8 rule definitions (6 STRIDE + 2 AI), taxonomy declarations, results with property bags, correlation group example with relatedLocations
+
+Two minor inconsistencies between template and agent (P1-003 governance column count, P1-004 dimensional breakdown format) -- neither blocks functionality.
+
+### 5. SARIF Compliance
+
+**PASS.** The SARIF template and agent Section 10 demonstrate correct SARIF 2.1.0 compliance:
+- `$schema` points to the official OASIS SARIF 2.1.0 schema URI
+- `version: "2.1.0"` at document root
+- `tool.driver` with name, version, semanticVersion, informationUri, rules, supportedTaxonomies
+- Results include ruleId, message (text + markdown), level, locations (physical + logical), partialFingerprints, properties
+- Taxonomy declarations (OWASP 2021, CWE 4.13) preserved with correct structure
+- Rule relationships map to taxonomy entries with correct target format
+- Fingerprint preservation rules (findingId/v1, primaryLocationLineHash, correlationGroup) are explicit
+- Correlation groups use relatedLocations pattern (SARIF-compliant, peers not duplicated as top-level results)
+
+### 6. Scoring Methodology
+
+**PASS.** All scoring components correctly implemented:
+- **CVSS defaults**: 8 category vectors with computed base scores (spoofing 8.2, tampering 7.1, repudiation 4.3, info-disclosure 6.5, DoS 7.5, privesc 9.9, agentic 9.1, llm 9.3). The agentic PR:L (architect review concern from plan.md) is correctly applied.
+- **Exploitability**: 4 sub-dimensions (known techniques, attack complexity, tooling, skill level) averaged. AI-specific guidance for 6 AI threat subtypes with baseline scores. Inversion note for complexity/skill correctly documented.
+- **Scalability**: 4 sub-dimensions (scriptability, target scope, resource requirements, detection difficulty) averaged. Resource requirements inversion correctly documented.
+- **Reachability**: 3-tier trust zone mapping (Untrusted 8.0-10.0, Semi-Trusted 4.0-7.0, Trusted 1.0-4.0) with zone name keyword refinement, architecture adjustments (-1.5/auth, -1.0/network, caps at -7.5 total), fuzzy matching, and proper fallback to 5.0.
+- **Composite formula**: `(0.35 x CVSS) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability)` matches spec FR-007 exactly.
+- **Severity bands**: Boundary precision rule (7.0 = High, 4.0 = Medium, 9.0 = Critical) matches spec edge case.
+
+### 7. Governance Fields
+
+**PASS.** SLA defaults, disposition mapping, and review date calculation all correctly defined:
+- Critical: 24h SLA, Mitigate, scoring_date + 1 day
+- High: 7d SLA, Mitigate, scoring_date + 7 days
+- Medium: 30d SLA, Review, scoring_date + 30 days
+- Low: 90d SLA, Review, scoring_date + 90 days
+- Owner defaults to "Unassigned"
+- Accept/Transfer documented as human-override-only values
+- Month/year boundary handling noted
+- Correlation group governance inheritance documented
+
+### 8. Edge Cases
+
+**PARTIAL (P1-001, P1-002).** Coverage assessment:
+
+| Edge Case (from spec) | Agent Coverage | Status |
+|------------------------|---------------|--------|
+| Malformed threat input | Section 1 Error Handling: skip + report + continue | Covered |
+| Empty threat model (zero findings) | **Not explicitly handled** -- no post-parsing zero-check | Gap (P1-001) |
+| Missing input files | Command-layer concern (T020) | Deferred appropriately |
+| Correlated findings | Section 7 Correlation Group Handling + Section 10h SARIF handling | Covered |
+| Score boundary precision | Section 7: "7.0 = High, 4.0 = Medium, 9.0 = Critical" | Covered |
+| Large threat models (>100) | **No batching/performance guidance** | Gap (P1-002) |
+| AI-specific CVSS mappings | Section 3 AI-Specific CVSS Guidance + category defaults | Covered |
+| Missing trust zones | Section 2g Fallback Behavior: default 5.0 with warning | Covered |
+
+### 9. T023 Semantic Shift Documentation
+
+**TRACKED.** The semantic shift between threats.sarif and risk-scores.sarif security-severity values is:
+- Documented in agent Section 10 (opening paragraph)
+- Documented in agent Section 10b (Rule-level security-severity calculation)
+- Referenced in tasks.md T023 description
+- Will be propagated to SARIF reference guide in Wave 5
+
+No blocking issues. The agent carries the architectural intent correctly.
+
+---
+
+## Summary
+
+The core scoring functionality is architecturally sound. The agent implements the full 6-phase pipeline with faithful adherence to the plan.md architecture, complete FR coverage (16 of 17 FRs covered in agent; FR-016 appropriately deferred to command layer), and correct SARIF 2.1.0 compliance. The schema, templates, and agent are internally consistent with two minor template-agent alignment issues (P1-003, P1-004) that are Low severity.
+
+Two Medium findings (P1-001 empty threat model exit, P1-002 large model guidance) should be addressed before Wave 5 (Command + Integration) begins, as they represent gaps between spec edge cases and agent behavior. Both are straightforward additions that do not require architectural changes.
+
+**Recommendation**: Proceed to Wave 5 after addressing P1-001 and P1-002. The five Low findings are non-blocking and can be resolved during Wave 5 work or as part of T020/T028 implementation.

--- a/specs/035-quantitative-risk-scoring/plan.md
+++ b/specs/035-quantitative-risk-scoring/plan.md
@@ -1,0 +1,357 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-27
+    status: APPROVED
+    notes: "All 17 FRs covered, 5 user stories traceable, no scope creep. SC-001 differentiation should exclude correlated peer groups."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-27
+    status: APPROVED_WITH_CONCERNS
+    notes: "Architecturally sound. Addressed: Note band consolidated into Low, input precedence (threats.md canonical), agentic CVSS default adjusted (PR:L), SARIF taxonomy preservation added."
+  techlead_signoff: null  # Added by /aod.tasks
+---
+
+# Implementation Plan: Quantitative Risk Scoring
+
+**Branch**: `035-quantitative-risk-scoring` | **Date**: 2026-03-27 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/035-quantitative-risk-scoring/spec.md`
+
+## Summary
+
+Add a `/risk-score` command and scoring agent that enriches existing `/threat-model` output with four-dimensional quantitative risk scores (CVSS 3.1, exploitability, scalability, reachability), producing `risk-scores.md` and `risk-scores.sarif` with governance fields for remediation tracking.
+
+tachi is a prompt engineering/agent orchestration toolkit — all deliverables are markdown and YAML files (commands, agents, schemas, templates). No compiled code, no build system, no database.
+
+## Technical Context
+
+**Language/Version**: Markdown + YAML (prompt engineering; no compiled code)
+**Primary Dependencies**: Claude Code agent framework (`.claude/agents/`, `.claude/commands/`)
+**Storage**: Local filesystem (markdown/YAML files co-located with threat model output)
+**Testing**: Manual validation against `examples/agentic-app/` sample report; SARIF schema validation
+**Target Platform**: Any system running Claude Code with tachi agents installed
+**Project Type**: Agent orchestration toolkit (markdown-based)
+**Performance Goals**: < 60s for 50 threats, < 5 min for 200 threats
+**Constraints**: No external API dependencies; all scoring via LLM analysis; SARIF 2.1.0 compliance
+**Scale/Scope**: Processes up to 200 threat findings per run
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. General-Purpose Architecture | PASS | `/risk-score` is domain-agnostic scoring infrastructure, not security-specific logic in core |
+| II. API-First Design | N/A | CLI command, not API endpoint — tachi is a local toolkit |
+| III. Backward Compatibility | PASS | Additive feature — new command and agent; no modification to existing `/threat-model` output |
+| IV. Concurrency & Data Integrity | N/A | Single-agent command processing one threat model at a time |
+| V. Privacy & Data Isolation | PASS | Local filesystem only; no PII in scoring output |
+| VI. Testing Excellence | PASS | Validation against example corpus; SARIF schema validation |
+| VII. Definition of Done | PASS | Will follow DoD checklist at `/aod.deliver` |
+| VIII. Observability | PASS | Clear error messages for missing input, malformed threats, missing architecture |
+| IX. Git Workflow | PASS | Feature branch `035-quantitative-risk-scoring` created |
+| X. Product-Spec Alignment | PASS | Spec has PM sign-off (APPROVED_WITH_CONCERNS) |
+| XI. SDLC Triad Collaboration | PASS | Following full Triad workflow |
+
+No violations. No complexity tracking needed.
+
+## Components
+
+### New Files
+
+| File | Purpose | Pattern Reference |
+|------|---------|-------------------|
+| `.claude/commands/risk-score.md` | Command definition — flag parsing, validation, agent invocation, output summary | `.claude/commands/threat-model.md` |
+| `.claude/agents/tachi/risk-scorer.md` | Scoring agent — threat parsing, 4-dimension scoring, composite calculation, output generation | `.claude/agents/tachi/orchestrator.md` (phases 3-4) |
+| `schemas/risk-scoring.yaml` | Scored finding schema — extends `finding.yaml` with scoring and governance fields | `schemas/finding.yaml` |
+| `templates/risk-scores.md` | Markdown output template — executive summary, scored threat table, methodology | `templates/threats.md` |
+| `templates/risk-scores.sarif` | SARIF output template — extended property bag with scoring properties | `templates/threats.sarif` |
+| `adapters/claude-code/commands/risk-score.md` | Adapter copy of command for distribution | `adapters/claude-code/commands/threat-model.md` |
+| `adapters/claude-code/agents/risk-scorer.md` | Adapter copy of agent for distribution | `adapters/claude-code/agents/orchestrator.md` |
+
+### Modified Files
+
+| File | Change | Reason |
+|------|--------|--------|
+| `adapters/claude-code/agents/references/sarif-generation.md` | Add risk-scoring SARIF property bag section | Document how `risk-scores.sarif` extends `threats.sarif` with scoring properties |
+| `schemas/finding.yaml` | Add optional scored finding extension block | Define scoring fields as optional extension (backward compatible) |
+
+### Unchanged Files (Input Dependencies)
+
+| File | Role |
+|------|------|
+| `schemas/output.yaml` | Severity band definitions (Critical 9.0-10.0, High 7.0-8.9, etc.) — consumed, not modified |
+| `.claude/agents/tachi/orchestrator.md` | Produces `threats.md`/`threats.sarif` — upstream dependency, not modified |
+| `templates/threats.md` | Existing threat model template — upstream, not modified |
+| `templates/threats.sarif` | Existing SARIF template — upstream, not modified |
+
+## Data Flow
+
+```mermaid
+graph LR
+    A["/threat-model output<br>threats.md + threats.sarif"] --> B["/risk-score command<br>risk-score.md"]
+    C["architecture.md<br>(optional)"] --> B
+    B --> D["risk-scorer agent<br>risk-scorer.md"]
+    D --> E["risk-scores.md<br>(markdown output)"]
+    D --> F["risk-scores.sarif<br>(SARIF 2.1.0 output)"]
+
+    subgraph "Scoring Pipeline"
+        D1["1. Parse threats"] --> D2["2. Extract trust zones"]
+        D2 --> D3["3. Score 4 dimensions<br>per finding"]
+        D3 --> D4["4. Calculate composite<br>+ governance fields"]
+        D4 --> D5["5. Generate dual output"]
+    end
+```
+
+### Command Flow (`/risk-score`)
+
+1. **Parse flags**: `--output-dir`, input file path
+2. **Validate**: Check `threats.md` or `threats.sarif` exists; check tachi agents installed
+3. **Locate input**: Auto-detect input format. Precedence: `threats.md` is canonical source; `threats.sarif` is fallback when markdown is unavailable
+4. **Invoke risk-scorer agent**: Pass input path, optional architecture.md path
+5. **Agent scores findings**: 4-dimension scoring → composite → governance fields
+6. **Generate output**: Write `risk-scores.md` and `risk-scores.sarif` to input directory
+7. **Display summary**: Severity band distribution, file paths, next steps
+
+### Agent Pipeline (`risk-scorer.md`)
+
+1. **Parse Phase**: Extract findings from `threats.md` (markdown tables) or `threats.sarif` (JSON). Preserve all original metadata (ID, component, category, description, mitigation, references).
+2. **Trust Zone Phase**: Extract trust zone table from `threats.md` Section 2. If available, supplement with `architecture.md` for authentication/network exposure context. Map components to reachability baseline.
+3. **Scoring Phase**: For each finding, assess four dimensions:
+   - **CVSS 3.1 Base** (0.0-10.0): Map threat category + description to CVSS vector (AV, AC, PR, UI, S, C, I, A). Use category-level default vectors as baseline, refined per-threat by description analysis. Store full vector string for auditability.
+   - **Exploitability** (0.0-10.0): Assess known technique existence, attack complexity, tooling availability, skill level required. Include AI-specific guidance for agentic/LLM categories.
+   - **Scalability** (0.0-10.0): Assess scriptability, target scope, resource requirements, detection difficulty.
+   - **Reachability** (0.0-10.0): Derive from trust zone mapping. Untrusted/External zones = 8.0-10.0, Semi-Trusted/Application = 4.0-7.0, Trusted/Internal = 1.0-4.0. Default 5.0 with warning if no trust data.
+4. **Composite Phase**: Calculate `Composite = (0.35 x CVSS) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability)`. Map to severity band. Generate governance fields (owner, SLA, disposition, review date).
+5. **Correlation Phase**: For Section 4a correlation groups, score the primary finding; correlated peers inherit the primary's scores.
+6. **Output Phase**: Generate `risk-scores.md` from template (executive summary, scored table, methodology). Generate `risk-scores.sarif` with extended property bag (`security-severity` = composite score as string, plus scoring dimension properties). Preserve SARIF fingerprints for alert continuity. Preserve SARIF taxonomies (`run.taxonomies[]`, `supportedTaxonomies[]`, rule `relationships[]`) from source `threats.sarif` to avoid feature regression.
+
+## Tech Stack
+
+| Layer | Technology | Rationale |
+|-------|-----------|-----------|
+| Command layer | Markdown command file (`.claude/commands/`) | Follows existing `/threat-model` command pattern |
+| Agent layer | Markdown agent file (`.claude/agents/tachi/`) | Follows existing threat agent pattern |
+| Schema layer | YAML schema files (`schemas/`) | Follows existing `finding.yaml` and `output.yaml` patterns |
+| Template layer | Markdown + SARIF JSON templates (`templates/`) | Follows existing `threats.md` and `threats.sarif` template patterns |
+| Distribution | Adapter copy (`adapters/claude-code/`) | Follows existing adapter distribution pattern |
+
+## Schema Design
+
+### Scored Finding Extension (`schemas/risk-scoring.yaml`)
+
+```yaml
+schema_version: "1.0"
+
+scored_finding:
+  extends: finding  # All fields from finding.yaml, plus:
+
+  cvss_base:
+    type: number
+    range: [0.0, 10.0]
+    description: "CVSS 3.1 base score"
+
+  cvss_vector:
+    type: string
+    pattern: "^CVSS:3\\.1/AV:[NALP]/AC:[LH]/PR:[NLH]/UI:[NR]/S:[UC]/C:[NLH]/I:[NLH]/A:[NLH]$"
+    description: "Full CVSS 3.1 vector string for auditability"
+
+  exploitability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Exploitability assessment score"
+
+  scalability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Scalability assessment score"
+
+  reachability:
+    type: number
+    range: [0.0, 10.0]
+    description: "Reachability assessment score"
+
+  composite_score:
+    type: number
+    range: [0.0, 10.0]
+    description: "Weighted composite: (0.35*CVSS) + (0.30*Exploitability) + (0.15*Scalability) + (0.20*Reachability)"
+
+  severity_band:
+    type: string
+    enum: [Critical, High, Medium, Low]
+    description: >
+      Mapped from composite_score per output.yaml CVSS ranges.
+      Note: output.yaml defines 5 bands (Critical/High/Medium/Low/Note).
+      For scoring, Note is consolidated into Low (0.0-3.9) since
+      composite scores always produce a meaningful numeric value.
+
+  risk_owner:
+    type: string
+    default: "Unassigned"
+
+  remediation_sla:
+    type: string
+    description: "Severity-driven default: Critical=24h, High=7d, Medium=30d, Low=90d"
+
+  risk_disposition:
+    type: string
+    enum: [Mitigate, Review, Accept, Transfer]
+    default_mapping:
+      Critical: Mitigate
+      High: Mitigate
+      Medium: Review
+      Low: Review
+
+  review_date:
+    type: string
+    format: "YYYY-MM-DD"
+    description: "Scoring date + SLA duration"
+
+# Default CVSS 3.1 Vectors per Threat Category
+category_defaults:
+  spoofing:     "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N"   # Auth bypass
+  tampering:    "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L"   # Data modification
+  repudiation:  "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N"   # Audit evasion
+  info-disclosure: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N" # Data exposure
+  denial-of-service: "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H" # Resource exhaustion
+  privilege-escalation: "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:H" # Privilege gain
+  agentic:      "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L"   # Agent misuse (PR:L to avoid ceiling effect)
+  llm:          "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"   # Prompt injection
+
+# Composite Weights
+weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+
+# Severity Bands (aligned with schemas/output.yaml)
+severity_bands:
+  Critical: { min: 9.0, max: 10.0, sla: "24h", disposition: "Mitigate" }
+  High:     { min: 7.0, max: 8.9,  sla: "7d",  disposition: "Mitigate" }
+  Medium:   { min: 4.0, max: 6.9,  sla: "30d", disposition: "Review" }
+  Low:      { min: 0.0, max: 3.9,  sla: "90d", disposition: "Review" }
+```
+
+### SARIF Property Bag Extension
+
+Per-result properties in `risk-scores.sarif`:
+
+```json
+{
+  "properties": {
+    "security-severity": "7.8",
+    "cvss-base-score": "8.1",
+    "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:U/C:H/I:H/A:N",
+    "exploitability": "7.5",
+    "scalability": "6.0",
+    "reachability": "8.0",
+    "composite-weights": "0.35/0.30/0.15/0.20",
+    "risk-owner": "Unassigned",
+    "remediation-sla": "7d",
+    "risk-disposition": "Mitigate",
+    "review-date": "2026-04-03"
+  }
+}
+```
+
+Rule-level `security-severity` set to the maximum composite score among that rule's findings.
+
+## Implementation Phases
+
+### Wave 1: Foundation (Schema + Agent Core)
+
+| Deliverable | Description |
+|-------------|-------------|
+| `schemas/risk-scoring.yaml` | Scored finding schema with category defaults, weights, severity bands |
+| `.claude/agents/tachi/risk-scorer.md` | Core scoring agent — threat parsing, 4-dimension scoring, composite calculation, dual output generation |
+| `templates/risk-scores.md` | Markdown output template with executive summary, scored threat table, methodology section |
+| `templates/risk-scores.sarif` | SARIF output template with extended property bag |
+
+**Gate**: Agent produces correct scored output for `examples/agentic-app/sample-report/threats.md`
+
+### Wave 2: Command + Integration
+
+| Deliverable | Description |
+|-------------|-------------|
+| `.claude/commands/risk-score.md` | Command definition — flag parsing, validation, agent invocation, summary |
+| `adapters/claude-code/agents/risk-scorer.md` | Adapter copy of scoring agent |
+| `adapters/claude-code/commands/risk-score.md` | Adapter copy of command |
+| `adapters/claude-code/agents/references/sarif-generation.md` | Updated with risk-scoring SARIF section |
+| `schemas/finding.yaml` | Add optional scored finding extension reference |
+
+**Gate**: `/risk-score` command end-to-end against example threat model
+
+### Wave 3: Validation + Documentation
+
+| Deliverable | Description |
+|-------------|-------------|
+| Example output: `examples/agentic-app/sample-report/risk-scores.md` | Reference scored output for validation and documentation |
+| Example output: `examples/agentic-app/sample-report/risk-scores.sarif` | Reference SARIF scored output |
+| SARIF schema validation | Validate `risk-scores.sarif` against SARIF 2.1.0 JSON schema |
+| Score differentiation check | Verify >= 80% of previously-identical-rated threats receive different composites |
+| Reproducibility check | Verify same input produces scores within +/- 0.5 per dimension |
+
+**Gate**: All success criteria from spec validated
+
+## Risk Mitigations
+
+| Risk | Mitigation | Contingency |
+|------|-----------|-------------|
+| CVSS mapping consistency for AI threats | Define tachi-specific default vectors in `risk-scoring.yaml` for agentic/LLM categories | Fall back to category-level defaults if per-threat refinement proves inconsistent |
+| Trust boundary parsing variability | Use trust zone table from `threats.md` Section 2 (already structured) as primary source | Default reachability 5.0 with warning if trust data unavailable |
+| Score clustering (most threats 5.0-7.0) | Validate against example corpus; tune category defaults if distribution is too narrow | Adjust weights or add floor/ceiling rules in Phase 2 |
+| Context window pressure (>100 findings) | Structured output format minimizes token overhead per finding | Batch scoring into per-category sub-invocations if single-pass exceeds limits |
+| Reproducibility tolerance (+/- 0.5) | Temperature 0 for all scoring; structured prompts with reference examples | Document tolerance as inherent to LLM-based analysis; exact determinism not guaranteed across model versions |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/035-quantitative-risk-scoring/
+├── plan.md              # This file
+├── research.md          # Research phase output (completed)
+├── spec.md              # Feature specification (PM approved)
+├── checklists/
+│   └── requirements.md  # Spec quality checklist
+└── tasks.md             # Task breakdown (pending)
+```
+
+### Source Code (repository root)
+
+```
+.claude/
+├── commands/
+│   └── risk-score.md           # NEW: /risk-score command definition
+└── agents/
+    └── tachi/
+        └── risk-scorer.md      # NEW: Scoring agent
+
+adapters/claude-code/
+├── commands/
+│   └── risk-score.md           # NEW: Adapter command copy
+├── agents/
+│   └── risk-scorer.md          # NEW: Adapter agent copy
+└── references/
+    └── sarif-generation.md     # MODIFIED: Add risk-scoring SARIF section
+
+schemas/
+├── finding.yaml                # MODIFIED: Add optional scored extension ref
+└── risk-scoring.yaml           # NEW: Scored finding schema + weights + bands
+
+templates/
+├── risk-scores.md              # NEW: Markdown output template
+└── risk-scores.sarif           # NEW: SARIF output template
+
+examples/agentic-app/sample-report/
+├── risk-scores.md              # NEW: Reference scored output
+└── risk-scores.sarif           # NEW: Reference SARIF scored output
+```
+
+**Structure Decision**: No compiled source code. All deliverables are markdown/YAML agent orchestration files following existing tachi patterns. The "source" directories are `.claude/commands/`, `.claude/agents/tachi/`, `schemas/`, and `templates/`.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/035-quantitative-risk-scoring/research-threat-modeling-tools.md
+++ b/specs/035-quantitative-risk-scoring/research-threat-modeling-tools.md
@@ -1,0 +1,474 @@
+# Research: Threat Modeling Tools Landscape (March 2026)
+
+## Context
+
+This research surveys the current threat modeling tools market to inform tachi's quantitative risk scoring feature. Understanding what tools exist, how they score and rank threats, what methodologies they support, and where they fall short -- particularly around AI/agentic systems -- directly informs how tachi should differentiate its approach.
+
+---
+
+## Findings
+
+### FREE / OPEN-SOURCE TOOLS
+
+---
+
+#### 1. OWASP Threat Dragon
+
+- **Creator**: OWASP Foundation
+- **Pricing**: Free, open-source (Apache 2.0)
+- **Website**: https://owasp.org/www-project-threat-dragon/
+- **Key Features**:
+  - Visual threat model diagramming (web and desktop versions)
+  - Threat recording and mitigation tracking
+  - Follows the Threat Modeling Manifesto values and principles
+- **Methodology Support**: STRIDE, LINDDUN, CIA, DIE, PLOT4ai
+- **Integration**: GitHub repository updates
+- **Target Audience**: Security practitioners using established methodologies
+- **Differentiators**: Broadest methodology support among free tools (5 frameworks); OWASP brand credibility; community-maintained
+- **Weaknesses**: Infrequent updates (a few times yearly); limited automation; no AI-assisted threat generation; no quantitative scoring beyond manual severity assignment
+
+---
+
+#### 2. Microsoft Threat Modeling Tool
+
+- **Creator**: Microsoft
+- **Pricing**: Free (closed-source)
+- **Website**: https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool
+- **Key Features**:
+  - Step-by-step guidance for non-security specialists
+  - Automated threat generation after diagramming
+  - Reporting capability
+  - Extensive documentation and training modules
+- **Methodology Support**: STRIDE-based
+- **Integration**: Azure ecosystem alignment
+- **Target Audience**: Non-security specialists; newcomers to threat modeling
+- **Differentiators**: Designed specifically for non-security personnel; Microsoft ecosystem fit; well-documented learning path
+- **Weaknesses**: Desktop-only; Windows-centric; infrequent GitHub updates; limited to STRIDE; no AI/ML threat categories; no quantitative risk scoring; Azure-biased
+- **Note**: Microsoft published a blog post in February 2026 on "Threat Modeling AI Applications" and added an AI-driven threat-playbook generator to Azure DevOps in March 2025, signaling investment in AI-era threat modeling, but this has not yet flowed into the standalone tool.
+
+---
+
+#### 3. Threagile
+
+- **Creator**: Open-source community
+- **Pricing**: Free, open-source
+- **Website**: https://threagile.io/
+- **Key Features**:
+  - YAML/JSON-based declarative threat modeling (threat-modeling-as-code)
+  - Multi-view reporting with risk color-coding
+  - Management summaries with clickable PDF links
+  - Agile-friendly workflow
+- **Methodology Support**: Custom YAML-driven (not tied to a single methodology)
+- **Integration**: IDE and YAML editor compatibility; CI/CD pipeline friendly
+- **Target Audience**: Developers comfortable with code-first approaches
+- **Differentiators**: Developer-centric "made for developers" philosophy; excellent reporting; declarative approach fits DevSecOps workflows; no GUI required
+- **Weaknesses**: Requires coding knowledge; smaller community than OWASP tools; not widely adopted in enterprise; limited to built-in rule set
+
+---
+
+#### 4. OWASP pytm
+
+- **Creator**: OWASP Foundation
+- **Pricing**: Free, open-source
+- **Website**: https://github.com/OWASP/pytm
+- **Key Features**:
+  - Threat-Modeling-as-Code in Python
+  - Define systems as Python objects (processes, data flows, boundaries)
+  - Auto-generates Data Flow Diagrams and Sequence Diagrams
+  - Auto-generates threat reports from model definitions
+  - Diagrams stay in sync with code changes
+- **Methodology Support**: STRIDE-based threat generation from model definitions
+- **Integration**: CI/CD pipelines; Python ecosystem
+- **Target Audience**: Development teams already using Python; teams wanting threat models versioned alongside code
+- **Differentiators**: True code-first threat modeling; diagrams are outputs not inputs; version-controllable; CI/CD native
+- **Weaknesses**: Python-only; steep learning curve for non-developers; limited visualization options; threat library depends on community contributions
+
+---
+
+#### 5. CAIRIS
+
+- **Creator**: Bournemouth University (Dr. Shamal Faily)
+- **Pricing**: Free, open-source (Apache 2.0)
+- **Website**: https://cairis.org/
+- **Key Features**:
+  - Integrated requirements and security analysis
+  - Auto-generates DFDs as designs evolve
+  - Attacker persona creation
+  - 12 system views (risk + architectural perspectives)
+  - Attack pattern identification and mitigation insights
+  - GDPR DPIA document generation
+  - Volere-compliant requirement specifications
+- **Methodology Support**: Multiple; attack pattern-based
+- **Integration**: REST API for toolchain integration; Docker deployment
+- **Target Audience**: Security researchers; teams needing requirements-security integration
+- **Differentiators**: Unique integration of requirements engineering with security analysis; attacker personas; 12 distinct system views; GDPR compliance document generation
+- **Weaknesses**: Academic origins make enterprise adoption challenging; complex setup; smaller user community; less intuitive UI than commercial tools
+
+---
+
+#### 6. STRIDE-GPT
+
+- **Creator**: mrwadams (open-source)
+- **Pricing**: Free, open-source
+- **Website**: https://github.com/mrwadams/stride-gpt
+- **Key Features**:
+  - AI-powered threat model generation using LLMs
+  - Attack tree generation with Mermaid diagrams
+  - Mitigation recommendations
+  - Gherkin test case generation from threats
+  - DREAD risk scoring
+  - Multi-modal input (architecture diagrams, flowcharts)
+  - GitHub repository analysis for context-aware threat models
+  - Agentic AI threat modeling with OWASP Top 10 for Agentic Applications (ASI01-ASI10)
+  - Architectural pattern detection (RAG pipelines, multi-agent systems, code execution environments, tool ecosystems)
+- **Methodology Support**: STRIDE, DREAD scoring, OWASP LLM Top 10, OWASP Top 10 for Agentic Applications, CSA MAESTRO-inspired patterns
+- **LLM Providers**: OpenAI, Anthropic Claude, Google Gemini, Mistral, Groq, Azure OpenAI, Ollama, LM Studio
+- **Integration**: Streamlit web UI; Docker deployment; local-only architecture
+- **Target Audience**: Individual security practitioners; teams exploring AI-assisted threat modeling
+- **Differentiators**: Most comprehensive AI-powered open-source threat modeler; agentic AI support is unique among free tools; multi-LLM provider support; actively maintained (v0.15, 999 GitHub stars)
+- **Weaknesses**: Single-user focused (not enterprise multi-tenant); data sent to cloud LLM providers unless using local models; Gemini safety restrictions block attack tree generation; some local LLMs produce inconsistent JSON output; no persistent storage
+
+---
+
+#### 7. Threatspec
+
+- **Creator**: Open-source community
+- **Pricing**: Free, open-source
+- **Website**: https://threatspec.org/
+- **Key Features**:
+  - Threat modeling annotations as source code comments
+  - Dynamic report and DFD generation from code annotations
+  - Bridges development and security processes
+- **Methodology Support**: Annotation-driven (methodology agnostic)
+- **Integration**: Source code integration; CI/CD pipeline compatible
+- **Target Audience**: Development teams wanting inline threat documentation
+- **Differentiators**: Unique "threat modeling as comments" approach; keeps threat models co-located with code; developer-friendly
+- **Weaknesses**: Requires developer discipline to maintain annotations; limited visualization; small community; no quantitative scoring
+
+---
+
+#### 8. AWS Threat Composer
+
+- **Creator**: AWS Labs
+- **Pricing**: Free
+- **Website**: https://awslabs.github.io/threat-composer/
+- **Key Features**:
+  - Browser-based, local storage (data never leaves the machine unless exported)
+  - Threat statement authoring (not diagram-based)
+  - JSON export for code integration
+  - Inspired by Adam Shostack's Four Question Framework
+- **Methodology Support**: STRIDE-based; Shostack's Four Question Framework
+- **Integration**: JSON export; browser-only
+- **Target Audience**: AWS developers; teams preferring structured threat statements over diagrams
+- **Differentiators**: Privacy-first (fully local); minimal footprint; structured threat statement approach
+- **Weaknesses**: No diagramming capability; no questionnaires; manual entry required; no automated threat generation; no scoring/quantification
+
+---
+
+### COMMERCIAL / ENTERPRISE TOOLS
+
+---
+
+#### 9. IriusRisk
+
+- **Creator**: IriusRisk (Barcelona, Spain)
+- **Pricing**: Free Community Edition; Commercial Enterprise (tiered by threat model volume, 5-500+; custom quote required)
+- **Website**: https://www.iriusrisk.com/
+- **Key Features**:
+  - Draw.io-based diagramming in Community Edition
+  - Security libraries with risks and countermeasures
+  - Import/export (XLS, XML)
+  - NIST, OWASP, GDPR, HIPAA compliance libraries
+  - ML/AI threat library (first of its kind)
+  - Customizable components, workflows, and rules
+  - Threat templates
+- **Methodology Support**: STRIDE, TRIKE, OCTAVE, PASTA (methodology-agnostic platform)
+- **Integration**: Custom workflow automation; extensible architecture; AWS Marketplace listing
+- **Target Audience**: Critical infrastructure; regulated industries (finance, medical devices, transport); enterprise security teams
+- **Differentiators**: Broadest methodology support among commercial tools; ML/AI threat library; methodology-agnostic; free community tier with enterprise-grade libraries
+- **Weaknesses**: Enterprise pricing opaque (quote required); community edition has limited scale; steep learning curve for full platform
+- **Market Position**: Gartner Peer Insights reviewed; G2 reviewed; leading commercial threat modeling platform
+
+---
+
+#### 10. ThreatModeler
+
+- **Creator**: ThreatModeler Software Inc.
+- **Pricing**: Commercial (quote required; no public pricing)
+- **Website**: https://threatmodeler.com/
+- **Key Features**:
+  - Unified platform: application security, IaC-Assist (infrastructure-as-code), CloudModeler
+  - Enterprise-ready models in minutes
+  - Patented automation technology
+  - AI/ML-assisted modeling
+  - Continuous threat detection (not point-in-time)
+  - 2,500+ security requirements; 180+ compliance frameworks; 1,500+ threats; 2,900+ components; 100+ protocols
+- **Methodology Support**: Multiple frameworks (specific list not published)
+- **Integration**: CI/CD pipeline native; partner ecosystem (Deloitte, EY, GuidePoint, Optiv, SHI)
+- **Target Audience**: Large enterprises; banking/finance, healthcare, manufacturing, critical infrastructure
+- **Differentiators**: Only platform unifying application + cloud + infrastructure threat modeling; BYOAI (Bring Your Own AI); patented automation; massive built-in library; code-to-cloud visibility
+- **Weaknesses**: No transparent pricing; limited public documentation on specific methodology support; complex enterprise deployment; no free tier
+
+---
+
+#### 11. SD Elements (Security Compass)
+
+- **Creator**: Security Compass
+- **Pricing**: Commercial (quote required)
+- **Website**: https://www.securitycompass.com/sdelements/
+- **Key Features**:
+  - Questionnaire-driven threat assessment
+  - Compliance-focused workflow
+  - Developer guidance built-in
+  - Extensive documentation and training modules
+  - Now includes Devici (acquired) for diagram-based modeling
+- **Methodology Support**: Compliance and control-based; NIST, FedRAMP alignment
+- **Integration**: GitHub; CI/CD pipelines; Jira; Azure DevOps
+- **Target Audience**: DoD, Military, Federal agencies; organizations seeking ATO (Authority to Operate); regulated enterprises
+- **Differentiators**: Dominant in federal/military market; compliance-first approach; acquisition of Devici adds diagram-based capability
+- **Weaknesses**: Enterprise-only pricing; compliance-heavy approach may limit agility; less suited for startup/agile environments
+
+---
+
+#### 12. Devici (Security Compass)
+
+- **Creator**: Originally independent; acquired by Security Compass
+- **Pricing**: Free tier (3 users, 3 threat models); paid Enterprise (unlimited users/models, per-user pricing, quote required)
+- **Website**: https://www.securitycompass.com/devici/
+- **Key Features**:
+  - Diagram-first threat modeling
+  - AI Diagram Assistant (text-to-DFD generation)
+  - CodeGenius (source code analysis for auto-generating initial threat models)
+  - Threat Model Health Score
+  - Devici Codex (threat and mitigation library)
+  - OTM (Open Threat Model) format support
+  - Real-time collaboration
+  - Reusable patterns, templates, version history
+  - Workflow integration (tasks to Azure DevOps or Jira)
+- **Methodology Support**: STRIDE; OTM standard
+- **Integration**: Azure DevOps; Jira; OTM interoperability
+- **Target Audience**: AppSec teams; DevSecOps engineers; collaborative security teams
+- **Differentiators**: AI-powered diagram generation from text; source-code-to-threat-model pipeline (CodeGenius); Health Score for completeness measurement; OTM standard support for interoperability
+- **Weaknesses**: Free tier limited to 3 models/3 users; recently acquired (integration with SD Elements still maturing); smaller user base than IriusRisk or ThreatModeler
+
+---
+
+#### 13. Apiiro AI Threat Modeling
+
+- **Creator**: Apiiro
+- **Pricing**: Commercial (private preview; demo required)
+- **Website**: https://apiiro.com/blog/introducing-ai-threat-modeling/
+- **Key Features**:
+  - Automated threat model generation from design documents and tickets
+  - Contextual analysis via Apiiro Data Fabric (Software Graph + Risk Graph)
+  - Evidence-based threat prioritization with architecture-specific countermeasures
+  - Seven-stage pipeline: initiation, contextual analysis, threat library reasoning, threat generation, countermeasure creation, audit trail, drift detection
+  - Audit-ready documentation
+  - Generates threat models in seconds
+  - Drift detection: validates implementation alignment with design (coming soon)
+- **Methodology Support**: STRIDE, CIA Triad, OWASP Top 10, NIST Controls, ISO 27001, CAPEC, CWE
+- **Integration**: Jira, GitHub, Azure DevOps, IDE extensions, GitHub Copilot, Cursor, MCP server, HashiCorp Vault, Okta
+- **Target Audience**: Enterprise AppSec teams; platform engineering teams; organizations needing continuous architecture-aware threat modeling
+- **Differentiators**: Architecture-grounded (uses actual Software Graph, not static diagrams); context-aware countermeasures with specific file locations and code patterns; tech-stack-aligned recommendations; noise reduction through de-prioritization of mitigated threats; graph-powered blast radius analysis; developer-native (IDE, Copilot, Cursor, MCP integration)
+- **Weaknesses**: Private preview only (not GA); drift detection not yet available; requires deep integration with organizational tooling for autonomous operation; effectiveness depends on quality of design documentation; pricing unknown
+
+---
+
+#### 14. Aristiun
+
+- **Creator**: Aristiun
+- **Pricing**: Free tier available; commercial tiers (pricing not published)
+- **Website**: https://threat-modeling.com/
+- **Key Features**:
+  - STRIDE or Risk Assessment approach
+  - Questionnaire-based workflow
+  - Example use cases
+  - Basic application diagram starter
+  - AI-powered automated threat modeling
+- **Methodology Support**: STRIDE, Risk Assessment
+- **Integration**: GitHub Marketplace
+- **Target Audience**: Organizations starting threat modeling; healthcare/regulated sectors
+- **Differentiators**: Low barrier to entry; provides starter diagrams; questionnaire approach accessible to non-experts
+- **Weaknesses**: Limited depth for mature security programs; less feature-rich than enterprise competitors
+
+---
+
+#### 15. Tutamen Threat Model Automator
+
+- **Creator**: Tutamen
+- **Pricing**: Commercial (no lock-in license)
+- **Website**: SourceForge listing
+- **Key Features**:
+  - Add threat model metadata to any software diagram
+  - Works with existing tools (Microsoft Visio, Excel)
+  - CWE-driven threat identification
+- **Methodology Support**: STRIDE, OWASP Top 10, CWE
+- **Integration**: Microsoft Visio; Microsoft Excel
+- **Target Audience**: Teams already using Visio/Excel for architecture documentation
+- **Differentiators**: Works with existing diagramming tools rather than requiring a new tool; CWE-driven
+- **Weaknesses**: Microsoft-tool dependent; less automated than newer AI-driven tools; limited community visibility
+
+---
+
+### GENERAL DIAGRAMMING TOOLS (Used for Threat Modeling)
+
+---
+
+#### 16. Draw.io / Diagrams.net
+
+- **Pricing**: Free, open-source
+- **Website**: https://www.drawio.com/
+- **Differentiator**: No signup required; GitHub, GitLab, Atlassian, Microsoft, Google integrations
+- **Limitation**: General diagramming; no threat-specific automation, libraries, or scoring
+
+#### 17. Miro
+
+- **Pricing**: Free tier (1 workspace, 3 editable boards); commercial tiers
+- **Website**: https://miro.com/
+- **Differentiator**: Best for whiteboard-to-digital transition; real-time collaboration
+- **Limitation**: Not threat-modeling-specific; no threat libraries or automation
+
+#### 18. Lucidchart
+
+- **Pricing**: Free tier (1 workspace, 60 shapes); commercial tiers
+- **Website**: https://www.lucidchart.com/
+- **Differentiator**: Role-based content suggestions; specialized network shapes
+- **Limitation**: Not threat-modeling-specific; shape limitations on free tier
+
+---
+
+### AI/AGENTIC-SPECIFIC FRAMEWORKS
+
+---
+
+#### 19. MAESTRO Framework
+
+- **Creator**: Ken Huang (DistributedApps.ai) via Cloud Security Alliance
+- **Type**: Framework/methodology (not a tool)
+- **Published**: February 2025
+- **Key Concepts**:
+  - Multi-Agent Environment, Security, Threat, Risk, and Outcome
+  - Seven-layer reference architecture for agentic AI systems
+  - Extended security categories beyond STRIDE for AI-specific threats
+  - Multi-agent focus (agent-to-agent interactions)
+  - Risk-based prioritization with agent context
+  - Continuous monitoring emphasis
+- **AI-Specific Threats Covered**: Data poisoning, model extraction, adversarial ML attacks, agent autonomy risks, agent-to-agent collusion, supply chain security, explainability gaps
+- **Compatibility**: Designed to augment (not replace) STRIDE, PASTA, LINDDUN, OCTAVE, VAST
+- **Relevance to tachi**: Directly relevant as a supplementary framework for agentic AI threat categories; tachi already extends STRIDE with AI-specific threat agents
+
+---
+
+## Comparative Analysis
+
+### Dedicated Threat Modeling Tools
+
+| Criteria | OWASP Threat Dragon | Microsoft TMT | Threagile | pytm | STRIDE-GPT | IriusRisk | ThreatModeler | SD Elements / Devici | Apiiro |
+|----------|-------------------|---------------|-----------|------|------------|-----------|---------------|---------------------|--------|
+| **Cost** | Free | Free | Free | Free | Free | Free-Enterprise | Enterprise | Enterprise | Enterprise |
+| **AI-Powered** | No | No | No | No | Yes | Partial | Partial | Partial (Devici) | Yes |
+| **Agentic AI Support** | No | No | No | No | Yes (ASI01-10) | Partial (ML/AI library) | No | No | No |
+| **Quantitative Scoring** | No | No | Risk color-coding | No | DREAD scoring | Severity levels | Severity levels | Health Score | Graph-based prioritization |
+| **Code-First** | No | No | Yes (YAML) | Yes (Python) | No | No | No | Partial (CodeGenius) | Yes (Software Graph) |
+| **Methodology Breadth** | 5 frameworks | STRIDE only | Custom | STRIDE | STRIDE+DREAD+OWASP | 4+ frameworks | Multiple | Compliance-based | 6+ frameworks |
+| **CI/CD Integration** | Limited | No | Yes | Yes | No | Yes | Yes | Yes | Yes |
+| **Enterprise Scale** | No | No | No | No | No | Yes | Yes | Yes | Yes |
+| **SARIF Output** | No | No | No | No | No | No | No | No | No |
+| **Local-First** | Yes | Yes | Yes | Yes | Yes (optional) | No | No | No | No |
+
+### Scoring/Quantification Approaches Across Tools
+
+| Tool | Scoring Method | Granularity | Automation |
+|------|---------------|-------------|------------|
+| STRIDE-GPT | DREAD (5 factors, 1-10 scale) | Per-threat | AI-generated |
+| IriusRisk | Severity levels + compliance mapping | Per-risk | Rule-based |
+| ThreatModeler | Severity classification | Per-threat | Automated |
+| Devici | Threat Model Health Score | Per-model | Algorithmic |
+| Apiiro | Graph-powered blast radius + multi-framework | Per-finding | AI + graph analysis |
+| Threagile | Risk level color-coding | Per-risk | Rule-based |
+| Microsoft TMT | Manual severity assignment | Per-threat | Manual |
+| **tachi (planned)** | CVSS-aligned composite score (likelihood x impact x exposure) | Per-finding | Formula-based with reachability |
+
+---
+
+## Market Context
+
+- The threat modeling tools market was USD 1.28 billion in 2025, projected at 14.89% CAGR through 2030.
+- Cloud-based SaaS held 67.82% market share in 2024, expanding at 15.67% CAGR.
+- OWASP released Threat Modeling Methodology v2.0 in May 2025, standardizing guidance on AI system exposure analysis and IaC mapping.
+- Generative AI integration is the dominant trend: Apiiro, STRIDE-GPT, Devici (CodeGenius), and ThreatModeler (BYOAI) all ship AI-assisted features.
+- No tool currently produces SARIF output for threat model findings -- this is a gap across the entire market.
+
+---
+
+## Key Gaps Across All Tools (tachi Opportunities)
+
+1. **No SARIF output**: No threat modeling tool produces SARIF-format findings for GitHub Code Scanning integration. tachi's dual-format output (markdown + SARIF) is unique.
+
+2. **No composite quantitative scoring**: Most tools use qualitative severity levels or simple DREAD scoring. No tool implements a composite score combining likelihood, impact, and exposure/reachability factors with CVSS alignment. tachi's planned formula-based approach fills this gap.
+
+3. **Limited agentic AI threat coverage**: Only STRIDE-GPT (via OWASP ASI01-10) and IriusRisk (ML/AI library) address AI-specific threats. The MAESTRO framework exists but has no tooling implementation. tachi's STRIDE extension with AI-specific threat agents is differentiated.
+
+4. **No local-first + enterprise-grade scoring**: Enterprise tools (IriusRisk, ThreatModeler, Apiiro) require cloud deployment. Free tools (Threagile, pytm) offer local-first but lack quantitative scoring. tachi combines local-first with quantitative scoring.
+
+5. **No threat-model-to-code-scanning pipeline**: No tool bridges threat modeling output directly into developer code scanning workflows (GitHub Code Scanning, SARIF consumers). tachi's SARIF output creates this bridge.
+
+6. **Reachability/exposure scoring absent**: No tool factors trust zone reachability or exposure surface into risk scores. tachi's planned exposure multiplier based on trust zone tables is novel.
+
+---
+
+## Recommendation
+
+### For tachi's risk scoring feature:
+
+**Primary differentiation points to emphasize**:
+- CVSS-aligned composite scoring (no other tool does this for threat model findings)
+- SARIF output for GitHub Code Scanning integration (market gap)
+- Local-first architecture with quantitative rigor (unique combination)
+- AI/agentic threat coverage built into the scoring model
+- Reachability-based exposure factor (novel approach)
+
+**Methodologies to reference/align with**:
+- STRIDE (core, already supported) -- the dominant methodology across all tools
+- DREAD (supplementary) -- familiar scoring framework; STRIDE-GPT demonstrates demand
+- OWASP Risk Rating Methodology -- widely recognized, adds credibility
+- MAESTRO (supplementary for agentic AI) -- emerging standard, signals forward-thinking
+
+**Approaches to avoid**:
+- Do not replicate IriusRisk/ThreatModeler's compliance-library approach (requires massive content investment, not aligned with tachi's methodology focus)
+- Do not build diagram-based modeling (well-served market segment)
+- Do not require cloud connectivity for scoring (local-first is a differentiator)
+
+**Further research needed**:
+- OWASP Threat Modeling Methodology v2.0 (May 2025) AI system exposure analysis guidance
+- CVSS v4.0 supplemental metric groups for threat model alignment
+- MAESTRO seven-layer architecture mapping to tachi's trust zone model
+
+---
+
+## Sources
+
+### Primary (Tier 1 -- Official Documentation)
+- [OWASP Threat Dragon](https://owasp.org/www-project-threat-dragon/)
+- [Microsoft Threat Modeling Tool](https://learn.microsoft.com/en-us/azure/security/develop/threat-modeling-tool)
+- [Threagile](https://threagile.io/)
+- [OWASP pytm](https://github.com/OWASP/pytm)
+- [CAIRIS](https://cairis.org/)
+- [STRIDE-GPT](https://github.com/mrwadams/stride-gpt)
+- [AWS Threat Composer](https://awslabs.github.io/threat-composer/)
+- [IriusRisk](https://www.iriusrisk.com/)
+- [ThreatModeler](https://threatmodeler.com/)
+- [SD Elements / Devici](https://www.securitycompass.com/devici/)
+- [Apiiro AI Threat Modeling](https://apiiro.com/blog/introducing-ai-threat-modeling/)
+- [Threatspec](https://threatspec.org/)
+- [MAESTRO Framework (CSA)](https://cloudsecurityalliance.org/blog/2025/02/06/agentic-ai-threat-modeling-framework-maestro)
+
+### Secondary (Tier 2 -- Industry Analysis)
+- [IriusRisk Blog: Recommended Threat Modeling Tools](https://www.iriusrisk.com/resources-blog/recommended-threat-modeling-tools)
+- [Gartner Peer Insights: Threat Modeling Automation](https://www.gartner.com/reviews/market/threat-modeling-automation)
+- [Mordor Intelligence: Threat Modeling Tools Market](https://www.mordorintelligence.com/industry-reports/threat-modeling-tools-market)
+- [Microsoft Security Blog: Threat Modeling AI Applications (Feb 2026)](https://www.microsoft.com/en-us/security/blog/2026/02/26/threat-modeling-ai-applications/)
+- [Apiiro Launch Announcement (Mar 2026)](https://www.globenewswire.com/news-release/2026/03/23/3260417/0/en/Apiiro-Redefines-Design-Phase-Security-with-AI-Threat-Modeling-Built-for-the-AI-Coding-Agent-Era-Preventing-Risks-Before-Code-Exists.html)
+- [Security Compass: STRIDE vs LINDDUN vs PASTA](https://www.securitycompass.com/blog/comparing-stride-linddun-pasta-threat-modeling/)
+- [Security Compass: Why We Acquired Devici](https://www.securitycompass.com/blog/devici-future-of-threat-modeling/)
+- [SecureFlag: Threat Modeling APIs (Jan 2026)](https://blog.secureflag.com/2026/01/20/introducing-threat-modeling-apis/)

--- a/specs/035-quantitative-risk-scoring/research.md
+++ b/specs/035-quantitative-risk-scoring/research.md
@@ -1,0 +1,85 @@
+# Research Summary: Quantitative Risk Scoring
+
+## Knowledge Base Findings
+- No existing KB patterns found (KB is empty)
+- No prior bug fixes or lessons learned related to risk scoring
+
+## Codebase Analysis
+
+### Similar Features
+- **Threat-Model Command** (`.claude/commands/threat-model.md`): Primary pattern to follow for command structure — flag parsing, validation, timestamped output directories, summary reporting
+- **SARIF Generation** (`adapters/claude-code/agents/references/sarif-generation.md`): Existing severity mapping table (Critical=9.0, High=8.0, Medium=5.0, Low=2.0), fingerprint generation (SHA-256 of ruleId + component), dual-location strategy
+- **Finding IR Schema** (`schemas/finding.yaml`): Current finding structure with id, category, component, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type
+- **Output Schema** (`schemas/output.yaml`): 7-section output format, CVSS severity mapping bands already defined (Critical 9.0-10.0, High 7.0-8.9, Medium 4.0-6.9, Low 0.1-3.9)
+- **Deduplication & Risk Rating** (PRD-010): Cross-agent correlation in Section 4a, OWASP 3x3 matrix — `/risk-score` consumes deduplicated output, no re-deduplication needed
+- **Threat Report Agent** (`.claude/agents/tachi/threat-report.md`): Remediation Roadmap pattern sorted by risk level, executive summary with severity distribution
+
+### Patterns to Follow
+- Command-per-workflow pattern with flag parsing and validation
+- Dual-format output (markdown + SARIF) from same IR data
+- Finding template with field-by-field guidance in agent definitions
+- Deterministic fingerprints for GitHub Code Scanning deduplication
+- Trust zone table in threats.md Section 2 as primary reachability source
+
+### Naming Conventions
+- Commands: kebab-case (`/risk-score`)
+- Agent files: kebab-case with `tachi-` prefix (e.g., `tachi/risk-scorer.md`)
+- Output files: plural kebab-case (`risk-scores.md`, `risk-scores.sarif`)
+- IR/schema fields: snake_case (`composite_score`, `risk_owner`)
+- SARIF properties: kebab-case (`security-severity`, `cvss-base`)
+
+### Utilities to Reuse
+- SARIF generation reference for property bag structure and fingerprinting
+- Orchestrator Phase 3-4 assembly patterns for finding collection and validation
+- Trust zone extraction from threats.md Section 2
+
+## Architecture Constraints
+- **No external APIs**: All scoring via LLM analysis (no CVE/NVD lookups)
+- **Finding ID immutability**: Preserve S-N/T-N identifiers from threat model
+- **Correlation preservation**: Score primaries from Section 4a; peers inherit
+- **SARIF 2.1.0 compliance**: Validate schema, update security-severity dynamically per finding
+- **Fingerprint stability**: Preserve `primaryLocationLineHash` + `findingId/v1` for GitHub dedup
+- **Dual-format parity**: risk-scores.md and risk-scores.sarif must be synchronized
+- **Output co-location**: Write alongside threats.md/threats.sarif in same directory
+- **Backward compatibility**: Composite scores map to existing Critical/High/Medium/Low bands
+- **CVSS 3.1 primary target** (ADR-013/PRD decision): Schema extensible for 4.0
+
+## Industry Research
+
+### CVSS 3.1 Automation
+- Map STRIDE categories to default CVSS vectors as baseline, refine per-threat via LLM
+- Store full CVSS vector string alongside numeric score for auditability
+- Scope (S) is most subjective metric — provide explicit guidance for LLM mapping
+- AI-specific threats (agentic, LLM) have no standard CVSS mappings — define tachi-specific defaults
+
+### Multi-Dimensional Risk Scoring
+- Weighted linear composite (PRD Pattern A) is well-established and transparent
+- Consider floor/ceiling rules: if any dimension > 9.5, composite minimum = 7.0 (High)
+- Test against examples/agentic-app/ output to verify score distribution avoids clustering
+
+### SARIF Integration
+- `security-severity` MUST be a numeric string (e.g., "7.8", not 7.8)
+- Range: 0.1-10.0 (0.0 causes GitHub to hide the finding)
+- Result-level property takes precedence over rule-level for GitHub display
+- Rule-level security-severity should reflect max composite among that rule's findings
+
+### Exploitability Frameworks
+- Align with OWASP Likelihood Factors: discovery ease, exploit ease, awareness, detection
+- EPSS requires CVE IDs — not applicable Phase 1 (note for Phase 2)
+- AI-specific: prompt injection = trivially exploitable; model poisoning = high skill required
+
+### Reachability Analysis
+- Map trust zone levels to base reachability scores (Untrusted=9.0, Semi-Trusted=5.0, Trusted=2.0)
+- Adjust with architecture.md supplementary data (auth barriers -1.5, network segmentation -1.0)
+- Zone name fuzzy matching needed for non-standard naming
+- Default 5.0 when architecture.md missing (per PRD)
+
+## Recommendations for Spec
+- Define tachi-specific CVSS 3.1 default vectors for all 8 threat categories (6 STRIDE + 2 AI)
+- Specify scoring agent as single-pass: Parse → Score (4 dimensions) → Generate output
+- Mandate CVSS vector string storage alongside numeric score for auditability
+- Include floor/ceiling rule consideration for extreme single-dimension scores
+- Specify trust zone-to-reachability mapping table with fuzzy matching for zone names
+- Address context window risk: structured output format, potential batching for >100 findings
+- Ensure risk-scores.sarif supersedes threats.sarif for GitHub upload (same fingerprints)
+- Include reproducibility validation: same input within +/- 0.5 per dimension at temperature 0

--- a/specs/035-quantitative-risk-scoring/spec.md
+++ b/specs/035-quantitative-risk-scoring/spec.md
@@ -1,0 +1,194 @@
+---
+prd_reference: docs/product/02_PRD/035-quantitative-risk-scoring-2026-03-27.md
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-27
+    status: APPROVED_WITH_CONCERNS
+    notes: "All 4 PRD user stories covered, 17 FRs traceable to PRD. Minor concerns: US-4 reachability ranges are more prescriptive than PRD (treat as norms with tolerance); SC-001 differentiation metric should clarify exclusion of correlated peer groups."
+  architect_signoff: null  # Added by /aod.project-plan
+  techlead_signoff: null   # Added by /aod.tasks
+---
+
+# Feature Specification: Quantitative Risk Scoring
+
+**Feature Branch**: `035-quantitative-risk-scoring`
+**Created**: 2026-03-27
+**Status**: Draft
+**PRD Reference**: `docs/product/02_PRD/035-quantitative-risk-scoring-2026-03-27.md`
+**Input**: User description: "A /risk-score command that replaces qualitative risk ratings with quantitative scores based on CVSS, exploitability, scalability, and reachability analysis"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Quantitative Threat Scoring (Priority: P0)
+
+As a security engineer who has completed a `/threat-model` run, I want to run `/risk-score` to calculate four-dimensional quantitative scores for each threat finding, so I can prioritize remediation by data-backed risk rather than qualitative gut feel.
+
+**Why this priority**: Core value proposition. Without quantitative scoring, the feature delivers no differentiation over the existing qualitative OWASP 3x3 matrix. Every other capability (governance fields, output formats, reachability) builds on this foundation.
+
+**Independent Test**: Can be fully tested by running `/risk-score` against `examples/agentic-app/` threat model output and verifying each finding receives four numeric scores and a composite score on a 0.0-10.0 scale.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid `threats.md` from `/threat-model`, **When** I run `/risk-score`, **Then** each threat finding receives scores for all four dimensions: CVSS base (0.0-10.0), exploitability (0.0-10.0), scalability (0.0-10.0), and reachability (0.0-10.0)
+2. **Given** a valid `threats.sarif` from `/threat-model`, **When** I run `/risk-score`, **Then** the same four-dimensional scoring applies with equivalent results regardless of input format
+3. **Given** scored threats, **When** I view the composite score, **Then** it is a weighted combination of the four dimensions on a 0.0-10.0 scale using default weights (CVSS 35%, Exploitability 30%, Scalability 15%, Reachability 20%)
+4. **Given** a threat finding with CVSS base mapping, **When** I review the CVSS assessment, **Then** it includes CVSS 3.1 base metrics (attack vector, attack complexity, privileges required, user interaction, scope) and the full CVSS vector string for auditability
+5. **Given** two threat findings that previously received identical qualitative ratings (e.g., both "High"), **When** I compare their composite scores, **Then** they receive different composite scores in at least 80% of such cases
+6. **Given** the same threat model input run twice, **When** I compare dimension scores across runs, **Then** each dimension score is within +/- 0.5 tolerance (reproducibility at temperature 0)
+
+---
+
+### User Story 2 - Risk Governance Fields (Priority: P0)
+
+As a security manager, I want risk governance fields (owner, SLA, disposition, review date) attached to each scored threat, so I can track remediation commitments and risk acceptance decisions.
+
+**Why this priority**: Governance fields transform scored findings into actionable remediation tracking items. Without them, quantitative scores remain informational rather than operational — blocking the key security manager workflow.
+
+**Independent Test**: Can be fully tested by verifying governance fields are populated for every scored threat and that SLA defaults align with severity bands.
+
+**Acceptance Scenarios**:
+
+1. **Given** a scored threat with composite score >= 9.0 (Critical), **When** governance fields are generated, **Then** SLA defaults to 24 hours and disposition defaults to "Mitigate"
+2. **Given** a scored threat with composite score 7.0-8.9 (High), **When** governance fields are generated, **Then** SLA defaults to 7 days and disposition defaults to "Mitigate"
+3. **Given** a scored threat with composite score 4.0-6.9 (Medium), **When** governance fields are generated, **Then** SLA defaults to 30 days and disposition defaults to "Review"
+4. **Given** a scored threat with composite score < 4.0 (Low), **When** governance fields are generated, **Then** SLA defaults to 90 days and disposition defaults to "Review"
+5. **Given** any scored threat, **When** the owner field is generated, **Then** it defaults to "Unassigned" for manual population
+6. **Given** any scored threat, **When** the review date is generated, **Then** it is calculated as the scoring date plus the SLA duration
+
+---
+
+### User Story 3 - Dual Output Formats (Priority: P0)
+
+As a security engineer, I want scored output in both human-readable markdown and machine-readable SARIF formats, so I can use scored findings for reporting and integrate them with GRC tooling and GitHub Code Scanning.
+
+**Why this priority**: Output generation is the delivery mechanism for all scoring work. Without dual outputs, scores remain inaccessible to downstream consumers (GRC tools, GitHub, dashboards). Tied to P0 because all three persona workflows depend on output availability.
+
+**Independent Test**: Can be fully tested by validating `risk-scores.md` contains a sorted scored threat table and `risk-scores.sarif` validates against the SARIF 2.1.0 JSON schema.
+
+**Acceptance Scenarios**:
+
+1. **Given** scored threats, **When** `risk-scores.md` is generated, **Then** it contains a table sorted by composite score descending with columns: ID, Component, Threat, CVSS, Exploitability, Scalability, Reachability, Composite, Severity, SLA, Disposition
+2. **Given** scored threats, **When** `risk-scores.md` is generated, **Then** it includes an executive summary with total threats by severity band and highest-risk component
+3. **Given** scored threats, **When** `risk-scores.md` is generated, **Then** it includes a scoring methodology section documenting the weights and formula used
+4. **Given** scored threats, **When** `risk-scores.sarif` is generated, **Then** it validates against the SARIF 2.1.0 JSON schema
+5. **Given** `risk-scores.sarif`, **When** the `security-severity` property is examined, **Then** it reflects the composite score as a numeric string (e.g., "7.8") per finding, not a static category-level mapping
+6. **Given** `risk-scores.sarif`, **When** finding fingerprints are examined, **Then** `partialFingerprints.findingId/v1` values are preserved from the source `threats.sarif` for alert tracking continuity
+7. **Given** both output files, **When** I compare them, **Then** all scores and governance fields are consistent between formats
+8. **Given** scored output, **When** I check the output location, **Then** `risk-scores.md` and `risk-scores.sarif` are written to the same directory as the input `threats.md`/`threats.sarif`
+
+---
+
+### User Story 4 - Reachability-Aware Scoring (Priority: P1)
+
+As an architect reviewing threat model output, I want reachability scores adjusted based on component exposure within trust boundaries, so that threats against well-protected internal components score lower than threats against internet-facing components.
+
+**Why this priority**: Reachability adds architecture-aware context that differentiates this tool from generic CVSS calculators. Ranked P1 because core scoring (P0) functions with default reachability (5.0) — reachability enhancement improves accuracy but is not blocking.
+
+**Independent Test**: Can be fully tested by running `/risk-score` against a threat model with trust boundaries defined and verifying that internet-facing component threats score higher reachability than internal component threats.
+
+**Acceptance Scenarios**:
+
+1. **Given** a threat targeting a component in an Untrusted/External zone, **When** reachability is assessed, **Then** the reachability score reflects maximum exposure (8.0-10.0)
+2. **Given** a threat targeting a component in a Semi-Trusted/Application zone, **When** reachability is assessed, **Then** the reachability score reflects moderate exposure (4.0-7.0)
+3. **Given** a threat targeting a component in a Trusted/Internal zone behind authentication and network segmentation, **When** reachability is assessed, **Then** the reachability score is significantly lower (1.0-4.0) than the same threat against a public endpoint
+4. **Given** an architecture with no trust boundaries defined (no trust zone table in threats.md and no architecture.md), **When** reachability is assessed, **Then** a default medium reachability (5.0) is applied with a warning message
+5. **Given** trust zone data from `threats.md` Section 2, **When** reachability is calculated, **Then** the trust zone table is the primary data source for component-to-zone mapping
+6. **Given** supplementary data from `architecture.md`, **When** reachability is calculated, **Then** additional context (authentication barriers, network exposure details) adjusts the baseline zone-derived score
+
+---
+
+### User Story 5 - Scoring Methodology Documentation (Priority: P1)
+
+As a security manager preparing executive reports, I want a clear explanation of how scores are calculated included in the output, so I can justify prioritization decisions and explain the scoring model to stakeholders.
+
+**Why this priority**: Transparency builds trust in the scoring system and enables security managers to defend prioritization decisions. Important for adoption but not required for core functionality.
+
+**Independent Test**: Can be fully tested by verifying `risk-scores.md` includes a methodology section that explains the four dimensions, their weights, and the composite formula.
+
+**Acceptance Scenarios**:
+
+1. **Given** scored output, **When** I read the methodology section in `risk-scores.md`, **Then** it explains each scoring dimension (CVSS, exploitability, scalability, reachability) and what each measures
+2. **Given** scored output, **When** I read the methodology section, **Then** it documents the weights used and the composite formula
+3. **Given** scored output, **When** I read the methodology section, **Then** it explains the severity band mapping (composite score ranges to Critical/High/Medium/Low)
+
+---
+
+### Edge Cases
+
+- **Malformed threat input**: What happens when individual threat entries in `threats.md` are malformed or missing required fields? The system must skip malformed entries, report them as errors, and continue scoring valid entries.
+- **Empty threat model**: What happens when `threats.md` or `threats.sarif` contains zero threat findings? The system must exit with a clear message: "No threat findings to score."
+- **Missing input files**: What happens when neither `threats.md` nor `threats.sarif` exists? The system must exit with: "No threat model output found. Run `/threat-model` first."
+- **Correlated findings**: What happens when Section 4a contains correlation groups? Primary findings receive full scoring; correlated peers inherit the primary's scores to maintain group consistency.
+- **Score boundary precision**: What happens when a composite score falls exactly on a severity band boundary (e.g., exactly 7.0)? The boundary value maps to the higher band (7.0 = High, 4.0 = Medium, 9.0 = Critical).
+- **Large threat models (>100 findings)**: What happens with large threat models? The system must handle up to 200 threats within the 5-minute performance target, using batching strategies if needed to manage context window constraints.
+- **AI-specific threat categories**: What happens for agentic and LLM threat categories that have no standard CVSS mappings? The system must apply tachi-specific default CVSS vectors for these categories, documented in the methodology section.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST parse threat findings from both `threats.md` (markdown table format) and `threats.sarif` (SARIF 2.1.0 JSON), extracting threat ID, component, category, description, likelihood, impact, and existing risk level
+- **FR-002**: System MUST map each threat finding to a CVSS 3.1 base score (0.0-10.0) using attack vector, attack complexity, privileges required, user interaction, and scope metrics derived from the threat category and description
+- **FR-003**: System MUST store the full CVSS 3.1 vector string (e.g., `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`) alongside the numeric base score for auditability
+- **FR-004**: System MUST assess exploitability (0.0-10.0) for each threat based on known exploit/technique existence, attack complexity, tooling availability, and skill level required
+- **FR-005**: System MUST assess scalability (0.0-10.0) for each threat based on scriptability, target scope, resource requirements, and detection difficulty
+- **FR-006**: System MUST assess reachability (0.0-10.0) for each threat using trust zone data from `threats.md` Section 2 as primary source, supplemented by `architecture.md` when available
+- **FR-007**: System MUST calculate a composite risk score (0.0-10.0) per threat using the weighted formula: `Composite = (0.35 x CVSS) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability)`
+- **FR-008**: System MUST map composite scores to severity bands: Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9) — aligned with existing `schemas/output.yaml` CVSS ranges
+- **FR-009**: System MUST attach governance fields to each scored threat: Risk Owner (default "Unassigned"), Remediation SLA (severity-driven), Risk Disposition (Mitigate for Critical/High, Review for Medium/Low), and Review Date (scoring date + SLA duration)
+- **FR-010**: System MUST generate `risk-scores.md` containing an executive summary, scored threat table sorted by composite score descending, dimensional breakdown per threat, governance fields, and scoring methodology explanation
+- **FR-011**: System MUST generate `risk-scores.sarif` validating against SARIF 2.1.0 schema, with `security-severity` set to the composite score per finding, and scoring properties in the result property bag
+- **FR-012**: System MUST preserve all original threat metadata (ID, component, category, description, mitigation, references) through the scoring pipeline without modification
+- **FR-013**: System MUST preserve SARIF fingerprints (`partialFingerprints.findingId/v1` and `primaryLocationLineHash`) from the source `threats.sarif` for GitHub Code Scanning alert continuity
+- **FR-014**: System MUST apply default medium reachability (5.0) with a warning when trust zone data is unavailable (no Section 2 in threats.md and no architecture.md)
+- **FR-015**: System MUST gracefully handle malformed threat entries by skipping individual findings, reporting errors, and continuing to score remaining valid findings
+- **FR-016**: System MUST validate that input files exist and are parseable before scoring begins, exiting with a clear error message if validation fails
+- **FR-017**: System MUST write output files to the same directory as the input `threats.md`/`threats.sarif`
+
+### Key Entities
+
+- **Scored Finding**: A threat finding enriched with four dimensional scores (CVSS base, exploitability, scalability, reachability), a composite score, a severity band, and governance fields. Extends the existing finding IR without modifying original fields.
+- **Scoring Dimensions**: Four independent assessment axes (CVSS base, exploitability, scalability, reachability) each producing a 0.0-10.0 score. Combined via weighted formula into a composite score.
+- **Governance Record**: Per-threat remediation tracking metadata comprising risk owner, remediation SLA, risk disposition, and review date. Defaults are severity-driven; intended for manual override by security managers.
+- **Severity Band**: Classification of composite scores into four tiers (Critical, High, Medium, Low) with associated default SLA and disposition values. Aligned with existing tachi severity bands.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Score Differentiation — Threats previously rated identically (e.g., two "High" threats) receive different composite scores in >= 80% of such cases when validated against `examples/agentic-app/` output
+- **SC-002**: Prioritization Accuracy — Top-5 composite-scored threats match intuitive risk ranking (validated by security-knowledgeable reviewer) in >= 70% of cases
+- **SC-003**: SLA Coverage — 100% of scored threats have all governance fields populated (owner, SLA, disposition, review date)
+- **SC-004**: Format Compliance — `risk-scores.sarif` validates against SARIF 2.1.0 JSON schema in 100% of runs
+- **SC-005**: Dual-Format Parity — All scores and governance fields are consistent between `risk-scores.md` and `risk-scores.sarif` in 100% of runs
+- **SC-006**: Performance — Scoring completes within 60 seconds for 50 threats and within 5 minutes for 200 threats
+- **SC-007**: Reproducibility — Same input produces dimension scores within +/- 0.5 tolerance across runs at temperature 0
+- **SC-008**: Backward Compatibility — Composite severity bands map to existing Critical/High/Medium/Low classifications used by `schemas/output.yaml`
+- **SC-009**: Alert Continuity — SARIF fingerprints are preserved, enabling `risk-scores.sarif` to supersede `threats.sarif` for GitHub Code Scanning without creating duplicate alerts
+
+## Assumptions
+
+- LLM analysis provides sufficiently consistent CVSS mapping for threat categories to achieve the +/- 0.5 reproducibility target at temperature 0
+- Trust zone annotations in existing `threats.md` Section 2 provide sufficient data for meaningful reachability differentiation
+- Default scoring weights (35/30/15/20) serve the majority of use cases without per-project customization (Phase 1)
+- The existing `/threat-model` deduplication (Section 4a) is complete — `/risk-score` does not need to re-deduplicate
+- AI-specific threat categories (agentic, LLM) can be meaningfully mapped to CVSS 3.1 vectors using tachi-specific defaults
+- Output file co-location (same directory as threat model output) is the expected workflow; no separate output directory configuration is needed for Phase 1
+
+## Out of Scope
+
+- Custom weight profiles per project (Phase 2)
+- Historical score trending across multiple runs (Phase 2)
+- Integration with external vulnerability databases such as CVE/NVD (Phase 2)
+- Compensating controls analysis adjusting scores based on existing mitigations (separate feature)
+- Optional `--risk-score` flag on `/threat-model` for command chaining (Phase 2)
+- Interactive score override/adjustment UI (Phase 3)
+- Financial impact estimation / cost-of-breach modeling (Phase 3)
+
+## Dependencies
+
+- `/threat-model` command output (`threats.md` and/or `threats.sarif`) must exist as input
+- SARIF 2.1.0 schema compliance for output validation
+- `schemas/output.yaml` severity band definitions for backward compatibility alignment
+- `examples/agentic-app/` threat model output for validation and calibration testing

--- a/specs/035-quantitative-risk-scoring/tasks.md
+++ b/specs/035-quantitative-risk-scoring/tasks.md
@@ -1,0 +1,284 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-27
+    status: APPROVED
+    notes: "All 5 user stories covered, 17 FRs traceable, no scope creep. MVP (Phases 1-3) delivers core value. Recommend reproducibility spot-check during T029."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-27
+    status: APPROVED_WITH_CONCERNS
+    notes: "All plan deliverables covered. Medium: T023 should document security-severity semantic shift between threats.sarif and risk-scores.sarif. Low: minor task description clarity improvements."
+  techlead_signoff:
+    agent: team-lead
+    date: 2026-03-27
+    status: APPROVED_WITH_CONCERNS
+    notes: "Feasible 5.5-9.5h across 6 waves. Low: Wave 4 overloaded (consider 4a/4b split during orchestration). Low: T014+T015 can run earlier in Wave 4."
+---
+
+# Tasks: Quantitative Risk Scoring
+
+**Input**: Design documents from `/specs/035-quantitative-risk-scoring/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md
+
+**Tests**: Not explicitly requested in spec. Validation tasks in final phase cover acceptance criteria.
+
+**Organization**: Tasks grouped by user story for independent implementation. All deliverables are markdown/YAML files (agent orchestration toolkit — no compiled code).
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story (US1-US5 from spec.md)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Schema Foundation)
+
+**Purpose**: Create the scoring schema that all subsequent work depends on
+
+- [X] T001 Create scored finding schema at schemas/risk-scoring.yaml with fields: cvss_base, cvss_vector, exploitability, scalability, reachability, composite_score, severity_band, risk_owner, remediation_sla, risk_disposition, review_date. Include category_defaults (8 CVSS vectors for STRIDE+AI categories), weights (0.35/0.30/0.15/0.20), and severity_bands aligned with schemas/output.yaml
+- [X] T002 [P] Create risk-scorer agent skeleton at .claude/agents/tachi/risk-scorer.md with frontmatter, overview, and section stubs for: Threat Parsing, Trust Zone Extraction, CVSS Scoring, Exploitability Assessment, Scalability Assessment, Reachability Analysis, Composite Calculation, Governance Fields, Output Generation (markdown), Output Generation (SARIF)
+- [X] T003 [P] Create risk-scores.md output template at templates/risk-scores.md with section stubs: frontmatter, Executive Summary, Scored Threat Table, Dimensional Breakdown, Governance Fields, Scoring Methodology
+
+---
+
+## Phase 2: Foundational (Threat Parsing + Template Structure)
+
+**Purpose**: Core parsing capability that ALL user stories depend on — MUST complete before story work begins
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T004 Write Threat Parsing section in .claude/agents/tachi/risk-scorer.md — define parsing rules for threats.md (extract findings from STRIDE Tables Sections 3-4, AI Threat Tables, and Correlated Findings Section 4a). Specify field extraction: id, component, category, threat, likelihood, impact, risk_level, mitigation, references, dfd_element_type. Include input precedence rule: threats.md canonical, threats.sarif fallback
+- [X] T005 [P] Write SARIF Parsing section in .claude/agents/tachi/risk-scorer.md — define parsing rules for threats.sarif (extract results array, preserve partialFingerprints, extract rule metadata). Map SARIF fields to finding IR fields
+- [X] T006 [P] Create risk-scores.sarif output template at templates/risk-scores.sarif with SARIF 2.1.0 skeleton: $schema, version, runs array with tool.driver (name, version, rules with extended properties), results array with property bag placeholders for scoring dimensions and governance fields. Preserve taxonomy declarations pattern from templates/threats.sarif
+
+**Checkpoint**: Parsing foundation ready — agent can read threat model input in both formats
+
+---
+
+## Phase 3: User Story 1 — Quantitative Threat Scoring (Priority: P0) MVP
+
+**Goal**: Each threat finding receives four dimensional scores (CVSS 3.1, exploitability, scalability, reachability) and a weighted composite score on a 0.0-10.0 scale
+
+**Independent Test**: Run scoring agent against examples/agentic-app/sample-report/threats.md and verify each finding has 4 dimension scores + composite + CVSS vector string
+
+### Implementation for User Story 1
+
+- [X] T007 [US1] Write CVSS 3.1 Base Scoring section in .claude/agents/tachi/risk-scorer.md — define scoring methodology: load category defaults from schemas/risk-scoring.yaml, refine per-threat based on description analysis (attack vector, attack complexity, privileges required, user interaction, scope, confidentiality, integrity, availability). Include AI-specific guidance for agentic and llm categories. Output: cvss_base (0.0-10.0) and cvss_vector string per finding
+- [X] T008 [P] [US1] Write Exploitability Assessment section in .claude/agents/tachi/risk-scorer.md — define four sub-dimensions: known exploit/technique existence (0-10), attack complexity (0-10), tooling availability (0-10), skill level required (0-10). Include AI-specific guidance: prompt injection = trivially exploitable, model poisoning = high skill. Output: exploitability score (0.0-10.0) per finding
+- [X] T009 [P] [US1] Write Scalability Assessment section in .claude/agents/tachi/risk-scorer.md — define four sub-dimensions: scriptability (0-10), target scope (0-10), resource requirements (0-10), detection difficulty (0-10). Output: scalability score (0.0-10.0) per finding
+- [X] T010 [US1] Write Composite Calculation section in .claude/agents/tachi/risk-scorer.md — define weighted formula: Composite = (0.35 x CVSS) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability). Map composite to severity band per schemas/risk-scoring.yaml. Note: reachability defaults to 5.0 until US4 implementation; this enables US1 to be independently testable. Include correlation group handling: score primaries, peers inherit
+
+**Checkpoint**: Agent can score all four dimensions for any threat finding and produce a composite score
+
+---
+
+## Phase 4: User Story 2 — Risk Governance Fields (Priority: P0)
+
+**Goal**: Each scored threat has governance metadata (owner, SLA, disposition, review date) for remediation tracking
+
+**Independent Test**: Verify all scored findings have governance fields populated with correct severity-driven defaults
+
+### Implementation for User Story 2
+
+- [X] T011 [US2] Write Governance Fields section in .claude/agents/tachi/risk-scorer.md — define field generation rules: risk_owner defaults to "Unassigned", remediation_sla mapped from severity band (Critical=24h, High=7d, Medium=30d, Low=90d), risk_disposition mapped from severity (Critical/High=Mitigate, Medium/Low=Review), review_date calculated as scoring date + SLA duration. Reference severity_bands from schemas/risk-scoring.yaml
+
+**Checkpoint**: Every scored finding has all four governance fields populated
+
+---
+
+## Phase 5: User Story 3 — Dual Output Formats (Priority: P0)
+
+**Goal**: Scored findings rendered in both human-readable risk-scores.md and machine-readable risk-scores.sarif with consistent data
+
+**Independent Test**: Generate both outputs; verify risk-scores.md contains sorted scored table and risk-scores.sarif validates against SARIF 2.1.0 schema
+
+### Implementation for User Story 3
+
+- [X] T012 [US3] Write Markdown Output Generation section in .claude/agents/tachi/risk-scorer.md — define output structure: executive summary (total by severity band, highest-risk component), scored threat table sorted by composite descending (columns: ID, Component, Threat, CVSS, Exploitability, Scalability, Reachability, Composite, Severity, SLA, Disposition), dimensional breakdown per finding. Reference templates/risk-scores.md for structure
+- [X] T013 [US3] Write SARIF Output Generation section in .claude/agents/tachi/risk-scorer.md — define SARIF generation rules: set security-severity to composite score as numeric string per finding, add property bag (cvss-base-score, cvss-vector, exploitability, scalability, reachability, composite-weights, risk-owner, remediation-sla, risk-disposition, review-date). Preserve findingId/v1 and primaryLocationLineHash from source threats.sarif. Preserve taxonomies (run.taxonomies[], supportedTaxonomies[], rule relationships[]). Set rule-level security-severity to max composite among that rule's findings. Reference templates/risk-scores.sarif for structure
+- [X] T014 [P] [US3] Populate risk-scores.md template at templates/risk-scores.md with complete section content: frontmatter format, executive summary layout, scored threat table column definitions, dimensional breakdown format, governance fields display, methodology section placeholder
+- [X] T015 [P] [US3] Populate risk-scores.sarif template at templates/risk-scores.sarif with complete SARIF structure: tool.driver with risk-scorer name and rule definitions for 8 categories, results array schema with full property bag, taxonomy preservation pattern, fingerprint fields
+
+**Checkpoint**: Agent can produce both output formats with consistent scores and governance fields
+
+---
+
+## Phase 6: User Story 4 — Reachability-Aware Scoring (Priority: P1)
+
+**Goal**: Reachability scores adjusted based on component trust zone exposure, differentiating internet-facing from well-protected components
+
+**Independent Test**: Run scoring against a threat model with trust boundaries; verify Untrusted zone components score reachability 8.0-10.0 and Trusted zone components score 1.0-4.0
+
+### Implementation for User Story 4
+
+- [X] T016 [US4] Write Trust Zone Extraction section in .claude/agents/tachi/risk-scorer.md — define parsing rules for threats.md Section 2 trust zone table: extract zone names, trust levels (Untrusted/Semi-Trusted/Trusted), component-to-zone assignments. Build component-to-zone mapping dictionary
+- [X] T017 [US4] Write Reachability Scoring section in .claude/agents/tachi/risk-scorer.md — define zone-to-reachability baseline mapping: Untrusted/External=8.0-10.0, Semi-Trusted/Application=4.0-7.0, Trusted/Internal=1.0-4.0. Include zone name fuzzy matching for non-standard naming. Apply default 5.0 with warning when no trust data available. Include supplementary architecture.md parsing: adjust baseline with authentication barriers (-1.5 per layer), network segmentation (-1.0 per boundary)
+- [X] T018 [US4] Update Composite Calculation section in .claude/agents/tachi/risk-scorer.md — replace default reachability (5.0) with trust-zone-derived reachability scores from T017. Ensure composite formula uses actual reachability when available, falls back to 5.0 when not
+
+**Checkpoint**: Reachability scores reflect actual architecture trust boundaries
+
+---
+
+## Phase 7: User Story 5 — Scoring Methodology Documentation (Priority: P1)
+
+**Goal**: risk-scores.md includes a clear methodology section explaining scoring dimensions, weights, and formula
+
+**Independent Test**: Verify methodology section explains all four dimensions, documents weights, and includes the composite formula and severity band mapping
+
+### Implementation for User Story 5
+
+- [X] T019 [US5] Write Methodology section content in templates/risk-scores.md — add section explaining: four scoring dimensions with descriptions of what each measures, default weights with rationale (CVSS 35%, Exploitability 30%, Scalability 15%, Reachability 20%), composite formula, severity band mapping table, data sources (threats.md trust zones, architecture.md), reproducibility note (+/- 0.5 tolerance)
+
+**Checkpoint**: Output includes transparent scoring methodology for stakeholder review
+
+---
+
+## Phase 8: Command + Integration
+
+**Purpose**: Wire the agent into the command layer and distribution adapters
+
+- [X] T020 Create /risk-score command definition at .claude/commands/risk-score.md — define: frontmatter with description, flag parsing (input file path, --output-dir), validation (check threats.md or threats.sarif exists, check tachi agents installed), input precedence (threats.md canonical, threats.sarif fallback), agent invocation of risk-scorer, output summary (severity band distribution, file paths, next steps). Follow .claude/commands/threat-model.md pattern
+- [X] T021 [P] Copy .claude/agents/tachi/risk-scorer.md to adapters/claude-code/agents/risk-scorer.md for distribution
+- [X] T022 [P] Copy .claude/commands/risk-score.md to adapters/claude-code/commands/risk-score.md for distribution
+- [X] T023 [P] Update adapters/claude-code/agents/references/sarif-generation.md — add "Risk Scoring SARIF Extension" section documenting: extended property bag schema for risk-scores.sarif, security-severity as composite score (numeric string), fingerprint preservation rules, taxonomy preservation, rule-level vs result-level security-severity
+- [X] T024 Update schemas/finding.yaml — add optional scored_finding extension reference block at end of file pointing to schemas/risk-scoring.yaml for scoring field definitions. Preserve backward compatibility (extension is optional)
+
+---
+
+## Phase 9: Validation + Example Output
+
+**Purpose**: Validate against success criteria and produce reference output
+
+- [X] T025 Generate example risk-scores.md by running /risk-score against examples/agentic-app/sample-report/threats.md — save output to examples/agentic-app/sample-report/risk-scores.md. Verify: executive summary present, scored table sorted by composite descending, all governance fields populated, methodology section included
+- [X] T026 [P] Generate example risk-scores.sarif by running /risk-score against examples/agentic-app/sample-report/threats.md — save output to examples/agentic-app/sample-report/risk-scores.sarif. Verify: validates against SARIF 2.1.0 schema, security-severity is numeric string per finding, fingerprints preserved from threats.sarif, taxonomies preserved
+- [X] T027 Verify score differentiation (SC-001): compare composite scores for findings that had identical qualitative ratings in threats.md — confirm >= 80% receive different composite scores (exclude correlated peer groups from measurement)
+- [X] T028 Verify dual-format parity (SC-005): compare all scores and governance fields between risk-scores.md and risk-scores.sarif — confirm 100% consistency
+- [X] T029 Run end-to-end /risk-score command validation: execute full command flow (flag parsing → validation → scoring → output → summary) against example input and verify completion summary displays correct severity band distribution
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 (schema + agent skeleton must exist) — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 (parsing foundation). No dependencies on other stories
+- **US2 (Phase 4)**: Depends on Phase 3 (needs composite scores to map governance fields)
+- **US3 (Phase 5)**: Depends on Phase 3 + Phase 4 (needs scored findings with governance fields to render)
+- **US4 (Phase 6)**: Can start after Phase 2 (independent reachability scoring). Integrates into composite in T018
+- **US5 (Phase 7)**: Can start after Phase 1 (template exists). No code dependencies
+- **Command + Integration (Phase 8)**: Depends on Phases 3-7 (agent must be complete before command wraps it)
+- **Validation (Phase 9)**: Depends on Phase 8 (command must be functional for end-to-end testing)
+
+### User Story Dependencies
+
+- **US1 (P0)**: Start after Foundational — independent, core scoring
+- **US2 (P0)**: Start after US1 — needs severity bands from composite scores
+- **US3 (P0)**: Start after US2 — needs governance fields for complete output
+- **US4 (P1)**: Start after Foundational — independent reachability work, integrates into composite after US1
+- **US5 (P1)**: Start after Setup — template content only, no code dependency
+
+### Parallel Opportunities
+
+- T002 + T003 in Phase 1 (different files)
+- T005 + T006 in Phase 2 (different files/sections)
+- T008 + T009 in Phase 3 (independent scoring dimensions)
+- T014 + T015 in Phase 5 (different template files)
+- T021 + T022 + T023 in Phase 8 (independent adapter copies)
+- T025 + T026 in Phase 9 (different output formats)
+- US4 (Phase 6) and US5 (Phase 7) can run in parallel with US2-US3
+
+---
+
+## Parallel Example: Wave Execution
+
+```
+Wave 1 (Phase 1 — Setup):
+  T001: schemas/risk-scoring.yaml
+  T002: .claude/agents/tachi/risk-scorer.md (skeleton)     [P]
+  T003: templates/risk-scores.md (stubs)                    [P]
+
+Wave 2 (Phase 2 — Foundation):
+  T004: Agent parsing section (threats.md)
+  T005: Agent parsing section (threats.sarif)               [P]
+  T006: templates/risk-scores.sarif                         [P]
+
+Wave 3 (Phase 3 — US1 Core Scoring):
+  T007: CVSS scoring section
+  T008: Exploitability section                              [P]
+  T009: Scalability section                                 [P]
+  T010: Composite calculation
+
+Wave 4 (Phases 4+5+6+7 — US2/US3/US4/US5):
+  T011: Governance fields (US2)
+  T016: Trust zone extraction (US4)                         [P]
+  T019: Methodology content (US5)                           [P]
+  → then T012+T013 (US3 output gen, depends on T011)
+  → then T014+T015 (US3 templates)                          [P]
+  → then T017+T018 (US4 reachability scoring)
+
+Wave 5 (Phase 8 — Command + Integration):
+  T020: Command definition
+  T021+T022+T023: Adapter copies + SARIF ref update         [P]
+  T024: finding.yaml update
+
+Wave 6 (Phase 9 — Validation):
+  T025+T026: Example output generation                      [P]
+  T027: Score differentiation check
+  T028: Dual-format parity check
+  T029: End-to-end command validation
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (schema + skeleton)
+2. Complete Phase 2: Foundation (parsing)
+3. Complete Phase 3: US1 (four-dimension scoring + composite)
+4. **STOP and VALIDATE**: Score example threat model, verify 4 dimensions per finding
+5. Core value delivered — quantitative scores differentiate previously-identical threats
+
+### Incremental Delivery
+
+1. Setup + Foundation → parsing ready
+2. Add US1 → scoring works with default reachability (5.0) → **MVP**
+3. Add US2 → governance fields attach to every scored finding
+4. Add US3 → dual output generation (risk-scores.md + risk-scores.sarif)
+5. Add US4 → reachability uses actual trust boundaries
+6. Add US5 → methodology section documents scoring approach
+7. Command + Integration → /risk-score command wraps everything
+8. Validation → verify all success criteria
+
+---
+
+## Summary
+
+| Metric | Value |
+|--------|-------|
+| Total tasks | 29 |
+| Phase 1 (Setup) | 3 tasks |
+| Phase 2 (Foundation) | 3 tasks |
+| Phase 3 (US1 - Scoring) | 4 tasks |
+| Phase 4 (US2 - Governance) | 1 task |
+| Phase 5 (US3 - Output) | 4 tasks |
+| Phase 6 (US4 - Reachability) | 3 tasks |
+| Phase 7 (US5 - Methodology) | 1 task |
+| Phase 8 (Command) | 5 tasks |
+| Phase 9 (Validation) | 5 tasks |
+| Parallel opportunities | 6 wave groups with [P] parallelism |
+| Estimated waves | 6 execution waves |
+| MVP scope | Phases 1-3 (10 tasks) |
+
+## Notes
+
+- All deliverables are markdown/YAML files — no compilation, no build system
+- Agent file (.claude/agents/tachi/risk-scorer.md) is the primary deliverable containing scoring logic
+- Template files define output structure; agent file defines how to populate them
+- Adapter copies are identical to source files (straight copy for distribution)
+- Validation tasks require running the actual /risk-score command against example data

--- a/templates/risk-scores.md
+++ b/templates/risk-scores.md
@@ -1,0 +1,252 @@
+# Risk Scores Report
+
+<!--
+  Canonical output template for tachi risk scoring reports.
+
+  Schema version : 1.0
+  Schema file    : schemas/risk-scoring.yaml
+  Finding schema : schemas/finding.yaml
+
+  Producers      : agents/tachi/risk-scorer.md
+  Consumers      : Security engineers, security managers, GRC tools
+
+  Every generated risk scoring output MUST conform to this structure.
+  All sections are required. Sections must appear in the order listed.
+-->
+
+---
+
+```yaml
+---
+schema_version: "1.0"
+date: "YYYY-MM-DD"
+source_file: "{path to input threats.md or threats.sarif}"
+classification: "confidential"
+scoring_weights:
+  cvss_base: 0.35
+  exploitability: 0.30
+  scalability: 0.15
+  reachability: 0.20
+---
+```
+
+**Frontmatter fields:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `schema_version` | string | Risk scoring schema version. Always `"1.0"` for this release. |
+| `date` | string | ISO 8601 date when scoring was performed. Format: `YYYY-MM-DD`. |
+| `source_file` | string | Path to the input threat model file that was scored. |
+| `classification` | string | Data classification label. Default: `confidential`. |
+| `scoring_weights` | object | Weights used for composite calculation. Documents the formula for reproducibility. |
+
+---
+
+## 1. Executive Summary
+
+**{total_findings}** threats scored | **{critical_count}** Critical | **{high_count}** High | **{medium_count}** Medium | **{low_count}** Low
+
+**Highest-Risk Component**: {highest_risk_component} — {highest_risk_component_finding_count} finding(s), max composite {highest_risk_component_max_composite}
+
+| Metric | Value |
+|--------|-------|
+| Scoring date | {date} |
+| Source file | `{source_file}` |
+| Schema version | {schema_version} |
+
+**Severity Distribution:**
+
+| Severity | Count | Percentage |
+|----------|-------|------------|
+| Critical | {critical_count} | {critical_pct}% |
+| High | {high_count} | {high_pct}% |
+| Medium | {medium_count} | {medium_pct}% |
+| Low | {low_count} | {low_pct}% |
+| **Total** | **{total_findings}** | **100%** |
+
+> When trust zone data is unavailable, a default reachability score of 5.0 is applied. If this condition was triggered, note it here: {reachability_warning}
+
+---
+
+## 2. Scored Threat Table
+
+Findings sorted by Composite score descending (highest risk first). Boundary values map to the higher severity band (e.g., 7.0 = High, 9.0 = Critical).
+
+| ID | Component | Threat | CVSS | Exploit. | Scale. | Reach. | Composite | Severity | SLA | Disposition |
+|----|-----------|--------|------|----------|--------|--------|-----------|----------|-----|-------------|
+| {id} | {component} | {threat} | {cvss_base} | {exploitability} | {scalability} | {reachability} | {composite_score} | {severity_band} | {remediation_sla} | {risk_disposition} |
+
+### Column Definitions
+
+| Column | Description |
+|--------|-------------|
+| **ID** | Original finding identifier from the threat model (e.g., `S-1`, `T-2`, `AG-1`, `LLM-3`). Preserves the source finding ID without modification. |
+| **Component** | Target component name as identified in the threat model. |
+| **Threat** | Threat description, truncated to fit table width. Full description available in the Dimensional Breakdown (Section 3). |
+| **CVSS** | CVSS 3.1 base score (0.0-10.0). Derived from attack vector, attack complexity, privileges required, user interaction, scope, and CIA impact. Full vector string shown in Section 3. |
+| **Exploit.** | Exploitability score (0.0-10.0). Average of four sub-dimensions: known techniques, attack complexity, tooling availability, and skill level required. |
+| **Scale.** | Scalability score (0.0-10.0). Average of four sub-dimensions: scriptability, target scope, resource requirements, and detection difficulty. |
+| **Reach.** | Reachability score (0.0-10.0). Derived from trust zone placement: Untrusted/External = 8.0-10.0, Semi-Trusted/Application = 4.0-7.0, Trusted/Internal = 1.0-4.0. Default 5.0 when trust zone data is unavailable. |
+| **Composite** | Weighted composite score (0.0-10.0). Formula: `(0.35 x CVSS) + (0.30 x Exploit.) + (0.15 x Scale.) + (0.20 x Reach.)`. |
+| **Severity** | Severity band mapped from composite score: Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9). |
+| **SLA** | Default remediation SLA driven by severity: Critical = 24h, High = 7d, Medium = 30d, Low = 90d. |
+| **Disposition** | Default risk disposition driven by severity: Critical/High = Mitigate, Medium/Low = Review. May be overridden in the Governance Fields table (Section 4). |
+
+> **Correlated findings**: For correlation groups (Section 4a of the source threat model), the primary finding is scored independently. Correlated peer findings inherit the primary's scores to maintain group consistency.
+
+---
+
+## 3. Dimensional Breakdown
+
+Per-finding detail showing the full scoring rationale for each dimension. One subsection per finding, ordered by composite score descending (matching Section 2 sort order).
+
+### {id} — {component}
+
+**Threat**: {threat_full_description}
+
+**Category**: {category} | **Original Risk Level**: {original_risk_level} | **Composite**: {composite_score} ({severity_band})
+
+#### CVSS 3.1 Base
+
+**Score**: {cvss_base} | **Vector**: `{cvss_vector}`
+
+| Metric | Value | Rationale |
+|--------|-------|-----------|
+| Attack Vector (AV) | {av_value} | {av_rationale} |
+| Attack Complexity (AC) | {ac_value} | {ac_rationale} |
+| Privileges Required (PR) | {pr_value} | {pr_rationale} |
+| User Interaction (UI) | {ui_value} | {ui_rationale} |
+| Scope (S) | {s_value} | {s_rationale} |
+| Confidentiality (C) | {c_value} | {c_rationale} |
+| Integrity (I) | {i_value} | {i_rationale} |
+| Availability (A) | {a_value} | {a_rationale} |
+
+#### Exploitability
+
+**Score**: {exploitability} (average of sub-dimensions)
+
+| Sub-Dimension | Score | Rationale |
+|---------------|-------|-----------|
+| Known Techniques | {exploit_known_techniques} | {exploit_known_techniques_rationale} |
+| Attack Complexity | {exploit_attack_complexity} | {exploit_attack_complexity_rationale} |
+| Tooling Availability | {exploit_tooling_availability} | {exploit_tooling_availability_rationale} |
+| Skill Level | {exploit_skill_level} | {exploit_skill_level_rationale} |
+
+#### Scalability
+
+**Score**: {scalability} (average of sub-dimensions)
+
+| Sub-Dimension | Score | Rationale |
+|---------------|-------|-----------|
+| Scriptability | {scale_scriptability} | {scale_scriptability_rationale} |
+| Target Scope | {scale_target_scope} | {scale_target_scope_rationale} |
+| Resource Requirements | {scale_resource_requirements} | {scale_resource_requirements_rationale} |
+| Detection Difficulty | {scale_detection_difficulty} | {scale_detection_difficulty_rationale} |
+
+#### Reachability
+
+**Score**: {reachability} | **Trust Zone**: {trust_zone} ({trust_level})
+
+{reachability_rationale}
+
+---
+
+*Repeat the above block for each scored finding, ordered by composite score descending.*
+
+---
+
+## 4. Governance Fields
+
+Remediation tracking metadata for each scored finding. Default values are severity-driven and intended for manual override by security managers during risk review.
+
+| ID | Severity | Owner | SLA | Disposition | Review Date |
+|----|----------|-------|-----|-------------|-------------|
+| {id} | {severity_band} | {risk_owner} | {remediation_sla} | {risk_disposition} | {review_date} |
+
+### Field Definitions
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| **ID** | Finding identifier matching Section 2. | Preserved from source threat model. |
+| **Severity** | Severity band from composite score. | Critical (9.0-10.0), High (7.0-8.9), Medium (4.0-6.9), Low (0.0-3.9). |
+| **Owner** | Responsible party for remediation or risk acceptance. | `Unassigned` — populate during risk review. |
+| **SLA** | Remediation deadline relative to scoring date. | Critical = 24 hours, High = 7 days, Medium = 30 days, Low = 90 days. |
+| **Disposition** | Risk treatment decision. | Critical/High = `Mitigate`, Medium/Low = `Review`. Valid values: Mitigate, Review, Accept, Transfer. |
+| **Review Date** | Date by which the disposition must be reviewed. | Scoring date + SLA duration (e.g., scoring on 2026-03-27 with 7d SLA = 2026-04-03). |
+
+### Override Guidance
+
+- **Owner**: Assign during remediation planning. Each finding should have a named owner before the SLA expires.
+- **Disposition**: Change from default when a risk acceptance or transfer decision is made. Document the justification in your risk register.
+  - `Accept` — Risk is acknowledged and accepted at the current level. Requires documented justification and management approval.
+  - `Transfer` — Risk is transferred to a third party (e.g., insurance, vendor SLA). Document the transfer mechanism.
+- **SLA**: Override when organizational policy defines different remediation windows. The default SLAs follow industry-standard baselines (24h/7d/30d/90d).
+- **Review Date**: Automatically recalculates when SLA is overridden.
+
+---
+
+## 5. Scoring Methodology
+
+This section documents the quantitative scoring model used to produce the risk scores in this report. All scores are derived from the threat findings identified during threat modeling and are intended to replace qualitative risk ratings with data-backed, reproducible numeric assessments.
+
+### 5.1 Scoring Dimensions
+
+Each threat finding is assessed across four independent dimensions, each producing a score on a 0.0 to 10.0 scale.
+
+| Dimension | Weight | What It Measures |
+|-----------|--------|------------------|
+| **CVSS Base** | 35% | Intrinsic severity of the vulnerability using CVSS 3.1 base metrics: attack vector, attack complexity, privileges required, user interaction, scope, and confidentiality/integrity/availability impact. Each finding includes the full CVSS vector string for auditability. |
+| **Exploitability** | 30% | Practical likelihood of exploitation based on known attack techniques, tooling availability, required skill level, and attack complexity. Higher scores indicate threats with well-documented exploit paths and readily available tooling. |
+| **Scalability** | 15% | Potential for automated, large-scale exploitation based on scriptability, breadth of target scope, resource requirements for the attacker, and difficulty of detection. Higher scores indicate threats that can be weaponized across many targets with minimal effort. |
+| **Reachability** | 20% | Exposure of the targeted component within the system's trust boundary architecture. Derived from trust zone data in the threat model and supplemented by architecture documentation when available. Higher scores indicate components directly exposed to untrusted networks. |
+
+### 5.2 Default Weights and Rationale
+
+The default weight allocation reflects the following priorities:
+
+- **CVSS Base (35%)** receives the highest weight because intrinsic vulnerability severity is the strongest predictor of potential damage. CVSS 3.1 is an industry-standard metric with well-understood interpretation.
+- **Exploitability (30%)** is weighted second because a severe vulnerability that is difficult to exploit in practice poses less immediate risk than one with known, tooled attack paths.
+- **Reachability (20%)** accounts for architectural context. A critical vulnerability behind multiple trust boundaries and authentication layers presents less operational risk than the same vulnerability on an internet-facing endpoint.
+- **Scalability (15%)** receives the lowest weight because while automation potential increases aggregate risk, it is less deterministic than the other dimensions and often correlates with exploitability.
+
+These weights are fixed for this scoring run and are recorded in the report frontmatter for reproducibility.
+
+### 5.3 Composite Score Formula
+
+The composite risk score for each finding is calculated as a weighted sum of the four dimension scores:
+
+```
+Composite = (0.35 x CVSS Base) + (0.30 x Exploitability) + (0.15 x Scalability) + (0.20 x Reachability)
+```
+
+The composite score is bounded to the 0.0-10.0 range. Because each dimension is independently scored on a 0.0-10.0 scale and the weights sum to 1.0, the composite inherently falls within this range.
+
+### 5.4 Severity Band Mapping
+
+Composite scores are mapped to severity bands that drive default governance actions:
+
+| Severity | Composite Score Range | Default SLA | Default Disposition |
+|----------|-----------------------|-------------|---------------------|
+| **Critical** | 9.0 -- 10.0 | 24 hours | Mitigate |
+| **High** | 7.0 -- 8.9 | 7 days | Mitigate |
+| **Medium** | 4.0 -- 6.9 | 30 days | Review |
+| **Low** | 0.0 -- 3.9 | 90 days | Review |
+
+Boundary values map to the higher band (e.g., a composite score of exactly 7.0 maps to High, not Medium). These bands are aligned with the severity classifications defined in `schemas/output.yaml` to maintain backward compatibility with existing tachi threat model output.
+
+### 5.5 Data Sources
+
+Scoring draws on the following inputs:
+
+- **Threat findings**: Parsed from `threats.md` (markdown table format) or `threats.sarif` (SARIF 2.1.0 JSON). All original threat metadata (ID, component, category, description, likelihood, impact) is preserved through the scoring pipeline.
+- **Trust zone data**: Extracted from `threats.md` Section 2 (trust zone table) as the primary source for reachability scoring. Components in Untrusted/External zones score 8.0-10.0 reachability; Semi-Trusted/Application zones score 4.0-7.0; Trusted/Internal zones score 1.0-4.0.
+- **Architecture documentation**: When `architecture.md` is available, it provides supplementary context such as authentication barriers and network exposure details that refine the baseline reachability score derived from trust zones.
+- **Category default vectors**: CVSS 3.1 baseline vectors are defined per STRIDE threat category in `schemas/risk-scoring.yaml`. This includes tachi-specific defaults for AI threat categories (agentic and LLM) that lack standard CVSS mappings. Per-threat analysis may refine these baselines based on the specific threat description.
+
+When trust zone data is unavailable (no Section 2 in `threats.md` and no `architecture.md`), a default reachability score of 5.0 is applied with a warning in the output.
+
+### 5.6 Reproducibility
+
+Scoring is performed at LLM temperature 0 to maximize consistency. For the same threat model input, each dimension score is expected to be reproducible within a **+/- 0.5 tolerance** across runs. This tolerance reflects the inherent variability in LLM-based analysis and is considered acceptable for risk prioritization purposes.
+
+Factors that may cause minor score variation between runs include model version updates and non-deterministic sampling behavior at temperature 0. The composite formula, weights, and severity band mappings are deterministic -- only the per-dimension LLM assessments carry the stated tolerance.

--- a/templates/risk-scores.sarif
+++ b/templates/risk-scores.sarif
@@ -1,0 +1,439 @@
+{
+  "_comment": "RISK SCORING OUTPUT (risk-scores.sarif) — NOT the threat model output (threats.sarif). This is the quantitative risk scoring SARIF produced by the /risk-score command. It extends threats.sarif with per-finding composite scores, four-dimensional risk metrics (CVSS, exploitability, scalability, reachability), and governance fields in the result property bag. Key distinction: security-severity in threats.sarif is a static category-level value; in risk-scores.sarif it is the per-finding composite score as a numeric string. Rule-level security-severity reflects the MAX composite score among that rule's findings. Producers: agents/tachi/risk-scorer.md. Schema: schemas/risk-scoring.yaml.",
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "tachi-risk-scorer",
+          "version": "1.0",
+          "semanticVersion": "1.0",
+          "informationUri": "https://github.com/owner/tachi",
+          "supportedTaxonomies": [
+            { "name": "OWASP", "index": 0 },
+            { "name": "CWE", "index": 1 }
+          ],
+          "rules": [
+            {
+              "id": "tachi/stride/spoofing",
+              "shortDescription": {
+                "text": "Identity spoofing threats"
+              },
+              "fullDescription": {
+                "text": "Threats where an attacker pretends to be something or someone else, such as forging authentication credentials, replaying tokens, or impersonating trusted components to gain unauthorized access."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "spoofing",
+                  "authentication",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-spoofing-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A07", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-287", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/tampering",
+              "shortDescription": {
+                "text": "Data tampering threats"
+              },
+              "fullDescription": {
+                "text": "Threats where an attacker modifies data, code, or configuration without authorization, violating integrity guarantees and causing systems to operate on corrupted inputs or persist falsified records."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "tampering",
+                  "data-integrity",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-tampering-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A08", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-345", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/repudiation",
+              "shortDescription": {
+                "text": "Repudiation threats"
+              },
+              "fullDescription": {
+                "text": "Threats where a user or system can deny having performed an action, and the system lacks sufficient evidence to prove otherwise, undermining accountability and forensic investigation."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "repudiation",
+                  "logging",
+                  "accountability",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-repudiation-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A09", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-778", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/information-disclosure",
+              "shortDescription": {
+                "text": "Information disclosure threats"
+              },
+              "fullDescription": {
+                "text": "Threats where sensitive information is exposed to unauthorized parties through direct data leaks, verbose error messages, side-channel observations, or insufficient access controls on stored data."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "information-disclosure",
+                  "data-exposure",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-information-disclosure-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A01", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-200", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/denial-of-service",
+              "shortDescription": {
+                "text": "Denial of service threats"
+              },
+              "fullDescription": {
+                "text": "Threats where an attacker degrades or eliminates system availability through resource exhaustion, flooding, algorithmic complexity exploitation, or cascading dependency failures."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "denial-of-service",
+                  "availability",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-denial-of-service-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A05", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-400", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/stride/elevation-of-privilege",
+              "shortDescription": {
+                "text": "Privilege escalation threats"
+              },
+              "fullDescription": {
+                "text": "Threats where an attacker gains higher privileges than authorized, performing actions reserved for administrators, accessing other users' resources, or bypassing access control boundaries."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "stride",
+                  "elevation-of-privilege",
+                  "access-control",
+                  "owasp",
+                  "cwe"
+                ],
+                "security-severity": "<max-composite-score-for-elevation-of-privilege-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "A01", "toolComponent": { "name": "OWASP" } },
+                  "kinds": ["relevant"]
+                },
+                {
+                  "target": { "id": "CWE-269", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/ai/agentic-threats",
+              "shortDescription": {
+                "text": "AI agent autonomy and misuse threats"
+              },
+              "fullDescription": {
+                "text": "Threats arising from autonomous agent behavior, including uncontrolled tool use, excessive autonomy, agent-to-agent trust violations, and lack of human oversight in high-impact operations."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "ai",
+                  "agentic",
+                  "autonomy",
+                  "tool-use",
+                  "mcp"
+                ],
+                "security-severity": "<max-composite-score-for-agentic-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "CWE-693", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            },
+            {
+              "id": "tachi/ai/llm-threats",
+              "shortDescription": {
+                "text": "LLM-specific threats"
+              },
+              "fullDescription": {
+                "text": "Threats from prompt injection vulnerabilities, data poisoning risks, and model theft in LLM-integrated components, covering direct and indirect injection, RAG pipeline manipulation, and model extraction."
+              },
+              "properties": {
+                "tags": [
+                  "security",
+                  "ai",
+                  "llm",
+                  "prompt-injection",
+                  "data-poisoning",
+                  "model-theft"
+                ],
+                "security-severity": "<max-composite-score-for-llm-findings>"
+              },
+              "relationships": [
+                {
+                  "target": { "id": "CWE-74", "toolComponent": { "name": "CWE" } },
+                  "kinds": ["relevant"]
+                }
+              ]
+            }
+          ]
+        }
+      },
+      "taxonomies": [
+        {
+          "name": "OWASP",
+          "version": "2021",
+          "informationUri": "https://owasp.org/Top10/",
+          "organization": "OWASP Foundation",
+          "shortDescription": { "text": "OWASP Top 10 Web Application Security Risks" }
+        },
+        {
+          "name": "CWE",
+          "version": "4.13",
+          "informationUri": "https://cwe.mitre.org/",
+          "organization": "MITRE",
+          "shortDescription": { "text": "Common Weakness Enumeration" }
+        }
+      ],
+      "results": [
+        {
+          "ruleId": "tachi/stride/spoofing",
+          "message": {
+            "text": "<threat-description-from-source-finding>",
+            "markdown": "<mitigation-recommendation-from-source-finding>"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<input-architecture-file-path>"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "<component-name-from-finding>",
+                  "fullyQualifiedName": "<trust-zone>/<component-name>",
+                  "kind": "process"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "<preserved-from-source-threats-sarif>",
+            "findingId/v1": "S-1"
+          },
+          "properties": {
+            "security-severity": "<composite-score-as-numeric-string>",
+            "cvss-base-score": "<cvss-base-score-as-numeric-string>",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:L/A:N",
+            "exploitability": "<exploitability-score-as-numeric-string>",
+            "scalability": "<scalability-score-as-numeric-string>",
+            "reachability": "<reachability-score-as-numeric-string>",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "<Critical|High|Medium|Low>",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "<severity-driven-sla-eg-24h-7d-30d-90d>",
+            "risk-disposition": "<Mitigate|Review>",
+            "review-date": "<scoring-date-plus-sla-duration-YYYY-MM-DD>"
+          }
+        },
+        {
+          "ruleId": "tachi/ai/agentic-threats",
+          "message": {
+            "text": "<threat-description-from-source-finding>",
+            "markdown": "<mitigation-recommendation-from-source-finding>"
+          },
+          "level": "warning",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<input-architecture-file-path>"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "<component-name-from-finding>",
+                  "fullyQualifiedName": "<trust-zone>/<component-name>",
+                  "kind": "process"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "<preserved-from-source-threats-sarif>",
+            "findingId/v1": "AG-1"
+          },
+          "properties": {
+            "security-severity": "<composite-score-as-numeric-string>",
+            "cvss-base-score": "<cvss-base-score-as-numeric-string>",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L",
+            "exploitability": "<exploitability-score-as-numeric-string>",
+            "scalability": "<scalability-score-as-numeric-string>",
+            "reachability": "<reachability-score-as-numeric-string>",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "<Critical|High|Medium|Low>",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "<severity-driven-sla-eg-24h-7d-30d-90d>",
+            "risk-disposition": "<Mitigate|Review>",
+            "review-date": "<scoring-date-plus-sla-duration-YYYY-MM-DD>"
+          }
+        },
+        {
+          "_comment": "Correlation group example: primary finding with relatedLocations pointing to correlated peer findings. Peers do NOT appear as separate top-level results; they are referenced via relatedLocations on the primary. All peers inherit the primary's scores and governance fields.",
+          "ruleId": "tachi/stride/tampering",
+          "message": {
+            "text": "<threat-description-for-correlation-group-primary>",
+            "markdown": "<mitigation-recommendation-for-correlation-group-primary>"
+          },
+          "level": "error",
+          "locations": [
+            {
+              "physicalLocation": {
+                "artifactLocation": {
+                  "uri": "<input-architecture-file-path>"
+                },
+                "region": {
+                  "startLine": 1
+                }
+              },
+              "logicalLocations": [
+                {
+                  "name": "<primary-component-name>",
+                  "fullyQualifiedName": "<trust-zone>/<primary-component-name>",
+                  "kind": "process"
+                }
+              ]
+            }
+          ],
+          "relatedLocations": [
+            {
+              "id": 0,
+              "message": {
+                "text": "<correlated-peer-finding-id>: <peer-threat-summary>"
+              },
+              "logicalLocations": [
+                {
+                  "name": "<peer-component-name-1>",
+                  "fullyQualifiedName": "<trust-zone>/<peer-component-name-1>",
+                  "kind": "process"
+                }
+              ]
+            },
+            {
+              "id": 1,
+              "message": {
+                "text": "<correlated-peer-finding-id>: <peer-threat-summary>"
+              },
+              "logicalLocations": [
+                {
+                  "name": "<peer-component-name-2>",
+                  "fullyQualifiedName": "<trust-zone>/<peer-component-name-2>",
+                  "kind": "process"
+                }
+              ]
+            }
+          ],
+          "partialFingerprints": {
+            "primaryLocationLineHash": "<preserved-from-source-threats-sarif>",
+            "findingId/v1": "T-3",
+            "correlationGroup": "CG-1"
+          },
+          "properties": {
+            "security-severity": "<composite-score-as-numeric-string>",
+            "cvss-base-score": "<cvss-base-score-as-numeric-string>",
+            "cvss-vector": "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L",
+            "exploitability": "<exploitability-score-as-numeric-string>",
+            "scalability": "<scalability-score-as-numeric-string>",
+            "reachability": "<reachability-score-as-numeric-string>",
+            "composite-weights": "0.35/0.30/0.15/0.20",
+            "severity-band": "<Critical|High|Medium|Low>",
+            "risk-owner": "Unassigned",
+            "remediation-sla": "<severity-driven-sla-eg-24h-7d-30d-90d>",
+            "risk-disposition": "<Mitigate|Review>",
+            "review-date": "<scoring-date-plus-sla-duration-YYYY-MM-DD>"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Adds `/risk-score` command that enriches `/threat-model` output with four-dimensional quantitative risk scores (CVSS 3.1, exploitability, scalability, reachability) and a weighted composite score (0.0–10.0)
- Attaches governance fields (risk owner, remediation SLA, disposition, review date) to each scored finding
- Produces dual-format output: `risk-scores.md` (human-readable) and `risk-scores.sarif` (machine-readable SARIF 2.1.0)
- Includes reachability-aware scoring using trust zone analysis from architecture descriptions

## Deliverables

| File | Purpose |
|------|---------|
| `.claude/agents/tachi/risk-scorer.md` | Risk scoring agent with full methodology |
| `.claude/commands/risk-score.md` | Command definition for `/risk-score` |
| `schemas/risk-scoring.yaml` | Scoring schema (dimensions, weights, severity bands) |
| `templates/risk-scores.md` | Markdown output template |
| `templates/risk-scores.sarif` | SARIF 2.1.0 output template |
| `examples/agentic-app/sample-report/risk-scores.*` | Example output |
| `adapters/claude-code/agents/risk-scorer.md` | Distribution adapter |
| `adapters/claude-code/commands/risk-score.md` | Distribution adapter |
| `specs/035-quantitative-risk-scoring/` | Feature specs (spec, plan, tasks) |

## Triad Sign-offs

- **PM**: APPROVED (all 5 user stories covered, 17 FRs traceable)
- **Architect**: APPROVED_WITH_CONCERNS (minor task clarity items)
- **Team-Lead**: APPROVED_WITH_CONCERNS (feasible 5.5-9.5h across 6 waves)

## Test Plan

- [x] T025: Example risk-scores.md generated with executive summary, sorted table, governance fields
- [x] T026: Example risk-scores.sarif generated with SARIF 2.1.0 compliance
- [x] T027: Score differentiation verified (>=80% of same-rated threats get different composites)
- [x] T028: Dual-format parity verified (100% score consistency between md and sarif)
- [x] T029: End-to-end /risk-score command validation passed

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)