### PR TITLE
docs(039): update project docs for Features 035, 036, 039

### DIFF
--- a/.claude/commands/compensating-controls.md
+++ b/.claude/commands/compensating-controls.md
@@ -97,7 +97,8 @@ Single-command entry point for tachi compensating controls analysis — the thir
    ```
    Analyze the following scored threat findings against the target codebase to detect
    existing security controls, classify each threat, recommend remediation for gaps,
-   and calculate residual risk. Execute the complete 6-phase pipeline:
+   and calculate residual risk. Execute your complete 6-phase analysis pipeline
+   (internal to the control-analyzer agent, not the threat-model command pipeline):
    Phase 1 (Parse Input) → Phase 2 (Discover Codebase) → Phase 3 (Detect Controls) →
    Phase 4 (Map & Classify) → Phase 5 (Recommend & Calculate Residual Risk) →
    Phase 6 (Generate Output).

--- a/.claude/commands/risk-score.md
+++ b/.claude/commands/risk-score.md
@@ -100,7 +100,7 @@ Single-command entry point for tachi quantitative risk scoring. Validates prereq
    </architecture-input>
    ```
 
-4. Wait for the risk-scorer agent to complete all 6 pipeline phases.
+4. Wait for the risk-scorer agent to complete all 6 of its internal analysis phases.
 
 ## Step 3: Report Results
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@
 
 ## What is tachi?
 
-tachi is a threat modeling sidecar that you add to any project. It dispatches 14 specialized AI agents against your architecture description and produces a complete threat model in one command. Then `/risk-score` enriches findings with quantitative scores for data-driven prioritization.
+tachi is a threat modeling sidecar that you add to any project. It dispatches 14 specialized AI agents against your architecture description and produces a complete threat model in one command. Then three post-pipeline commands enrich your results: `/risk-score` for quantitative scoring, `/compensating-controls` for codebase control analysis, and `/infographic` for visual risk diagrams.
 
 - **11 threat categories**: 6 STRIDE + 3 LLM-specific + 2 Agentic
 - **5 input formats**: Mermaid, free-text, ASCII, PlantUML, C4
-- **10 output artifacts**: structured findings, SARIF, narrative report, attack trees, infographics, quantitative risk scores
+- **12+ output artifacts**: structured findings, SARIF, narrative report, attack trees, quantitative risk scores, compensating controls analysis, visual infographics
 - **Works with any stack**: tachi analyzes architecture, not code
 
 tachi is built with the [Agentic Oriented Development Kit (AOD Kit)](https://github.com/davidmatousek/agentic-oriented-development-kit), a governance framework for AI agent-assisted development.
@@ -43,11 +43,13 @@ cp -r ~/Projects/tachi/adapters/claude-code/agents/ .claude/agents/tachi/
 mkdir -p .claude/commands
 cp ~/Projects/tachi/adapters/claude-code/commands/threat-model.md .claude/commands/
 cp ~/Projects/tachi/adapters/claude-code/commands/risk-score.md .claude/commands/
+cp ~/Projects/tachi/.claude/commands/compensating-controls.md .claude/commands/
+cp ~/Projects/tachi/adapters/claude-code/commands/infographic.md .claude/commands/
 ```
 
 ### 3. Restart Claude Code
 
-After copying the files, **restart Claude Code** (close and reopen the VS Code window, or start a new CLI session) so it picks up the new agents and `/threat-model` command.
+After copying the files, **restart Claude Code** (close and reopen the VS Code window, or start a new CLI session) so it picks up the new agents and commands.
 
 If you want infographic images (`.jpg`), set the `GEMINI_API_KEY` environment variable with a key from [Google AI Studio](https://aistudio.google.com/apikey). This is optional — all text-based outputs work without it.
 
@@ -73,26 +75,30 @@ That's it. One command. tachi validates the setup, reads your architecture, disp
 
 ### 6. Review your results
 
-| File | What It Contains |
-|------|-----------------|
-| `threats.md` | Primary threat model -- findings, coverage matrix, risk summary, mitigations |
-| `threats.sarif` | SARIF 2.1.0 for GitHub Code Scanning and CI/CD integration |
-| `threat-report.md` | Narrative report with executive summary and remediation roadmap |
-| `attack-trees/` | One Mermaid attack tree per Critical/High finding |
-| `threat-baseball-card-spec.md` | Baseball Card risk dashboard specification |
-| `threat-baseball-card.jpg` | Baseball Card infographic (requires `GEMINI_API_KEY`) |
-| `threat-system-architecture-spec.md` | Annotated architecture diagram specification |
-| `threat-system-architecture.jpg` | Architecture infographic with finding legend (requires `GEMINI_API_KEY`) |
-| `risk-scores.md` | Quantitative risk scores with CVSS, exploitability, scalability, reachability, governance fields |
-| `risk-scores.sarif` | SARIF 2.1.0 with composite scores as `security-severity` per finding |
+| File | Source | What It Contains |
+|------|--------|-----------------|
+| `threats.md` | `/threat-model` | Primary threat model -- findings, coverage matrix, risk summary, mitigations |
+| `threats.sarif` | `/threat-model` | SARIF 2.1.0 for GitHub Code Scanning and CI/CD integration |
+| `threat-report.md` | `/threat-model` | Narrative report with executive summary and remediation roadmap |
+| `attack-trees/` | `/threat-model` | One Mermaid attack tree per Critical/High finding |
+| `risk-scores.md` | `/risk-score` | Quantitative risk scores with CVSS, exploitability, scalability, reachability |
+| `risk-scores.sarif` | `/risk-score` | SARIF 2.1.0 with composite scores as `security-severity` per finding |
+| `compensating-controls.md` | `/compensating-controls` | Detected codebase controls, residual risk, missing control recommendations |
+| `compensating-controls.sarif` | `/compensating-controls` | SARIF 2.1.0 with residual risk as `security-severity` per finding |
+| `threat-baseball-card-spec.md` | `/infographic` | Baseball Card risk dashboard specification |
+| `threat-baseball-card.jpg` | `/infographic` | Baseball Card infographic (requires `GEMINI_API_KEY`) |
+| `threat-system-architecture-spec.md` | `/infographic` | Annotated architecture diagram specification |
+| `threat-system-architecture.jpg` | `/infographic` | Architecture infographic with finding legend (requires `GEMINI_API_KEY`) |
 
-Start with `threats.md` Section 7 -- Recommended Actions. Then run `/risk-score` to get quantitative prioritization. Work through Critical findings first, then High.
+Start with `threats.md` Section 7 -- Recommended Actions. Then run `/risk-score` for quantitative prioritization, `/compensating-controls` to detect existing defenses, and `/infographic` for visual risk diagrams. Work through Critical findings first, then High.
 
 ---
 
 ## Command Options
 
 ### /threat-model
+
+Runs the 5-phase threat modeling pipeline: scope, determine threats, determine countermeasures, assess, and report. Produces `threats.md`, `threats.sarif`, `threat-report.md`, and `attack-trees/`.
 
 ```bash
 # Default -- uses docs/security/architecture.md
@@ -106,9 +112,6 @@ Start with `threats.md` Section 7 -- Recommended Actions. Then run `/risk-score`
 
 # Version-tagged output for a release
 /threat-model docs/security/architecture.md --version v1.0.0
-
-# Only generate one infographic template
-/threat-model docs/security/architecture.md --infographic-template baseball-card
 ```
 
 ### /risk-score
@@ -124,6 +127,45 @@ Enriches threat model output with four-dimensional quantitative risk scores (CVS
 
 # Custom output directory
 /risk-score docs/security/2026-03-27/ --output-dir reports/risk/
+```
+
+### /compensating-controls
+
+Scans a target codebase against scored threats to detect existing security controls, calculate residual risk, and recommend missing controls. Requires `/risk-score` output as input. Produces `compensating-controls.md` and `compensating-controls.sarif`.
+
+```bash
+# Scan current project against risk scores in the default location
+/compensating-controls
+
+# Scan against risk scores in a specific directory
+/compensating-controls docs/security/2026-03-27/
+
+# Scan a different codebase
+/compensating-controls docs/security/2026-03-27/ --target ~/Projects/my-app/
+
+# Custom output directory
+/compensating-controls docs/security/2026-03-27/ --output-dir reports/controls/
+```
+
+### /infographic
+
+Generates visual threat infographic specifications and presentation-ready images. Auto-detects the richest data source in the output directory (prefers `risk-scores.md` over `threats.md`). Produces spec markdown and `.jpg` images (images require `GEMINI_API_KEY`).
+
+```bash
+# Generate all infographic templates from the default location
+/infographic
+
+# Generate from a specific directory
+/infographic docs/security/2026-03-27/
+
+# Generate only the baseball card template
+/infographic docs/security/2026-03-27/ --template baseball-card
+
+# Generate only the system architecture template
+/infographic docs/security/2026-03-27/ --template system-architecture
+
+# Custom output directory
+/infographic docs/security/2026-03-27/ --output-dir reports/visuals/
 ```
 
 ---
@@ -193,7 +235,7 @@ The agentic-app example includes a [complete sample report](examples/agentic-app
 | Resource | Location | Purpose |
 |----------|----------|---------|
 | Interface Contract | [`docs/INTERFACE-CONTRACT.md`](docs/INTERFACE-CONTRACT.md) | Input formats, invocation protocol, output structure |
-| Output Templates | [`templates/`](templates/) | Canonical output structures ([threats.md](templates/threats.md), [risk-scores.md](templates/risk-scores.md), [risk-scores.sarif](templates/risk-scores.sarif)) |
+| Output Templates | [`templates/`](templates/) | Canonical output structures ([threats.md](templates/threats.md), [risk-scores.md](templates/risk-scores.md), [risk-scores.sarif](templates/risk-scores.sarif), [compensating-controls.md](templates/compensating-controls.md), [compensating-controls.sarif](templates/compensating-controls.sarif)) |
 | Schemas | [`schemas/`](schemas/) | Machine-readable contracts ([finding.yaml](schemas/finding.yaml), [input.yaml](schemas/input.yaml), [output.yaml](schemas/output.yaml), [risk-scoring.yaml](schemas/risk-scoring.yaml)) |
 | Threat Agents | [`agents/stride/`](agents/stride/) + [`agents/ai/`](agents/ai/) | Agent prompt definitions |
 | Developer Guide | [`docs/guides/DEVELOPER_GUIDE_TACHI.md`](docs/guides/DEVELOPER_GUIDE_TACHI.md) | Full walkthrough with worked examples |

--- a/docs/devops/README.md
+++ b/docs/devops/README.md
@@ -1,6 +1,6 @@
 # DevOps Documentation - tachi
 
-**Last Updated**: 2026-03-23
+**Last Updated**: 2026-03-28
 **Owner**: DevOps Agent
 **Status**: Active
 
@@ -44,13 +44,15 @@ CI/CD setup instructions for common platforms
 
 ## Platform Adapters (Feature 021)
 
-Feature 021 introduced platform adapters that package tachi's 14 threat agents for use across AI coding platforms and CI pipelines. These live in the `adapters/` directory at the repository root.
+Feature 021 introduced platform adapters that package tachi's 14 threat agents for use across AI coding platforms and CI pipelines. These live in the `adapters/` directory at the repository root. Features 035, 036, and 039 extended the Claude Code adapter with command files for tachi's four product commands: `/threat-model`, `/risk-score`, `/compensating-controls`, and `/infographic`.
 
 ### Adapter Directory Structure
 
 ```
 adapters/
   claude-code/     # .md agents with name/description frontmatter
+    agents/        #   14 threat agents + risk-scorer
+    commands/      #   /threat-model, /risk-score, /infographic
   copilot/         # .agent.md + .instructions.md files
   cursor/          # .mdc rule files
   generic/         # Numbered .md prompt files (any LLM)

--- a/docs/guides/CONSUMER_GUIDE_TACHI.md
+++ b/docs/guides/CONSUMER_GUIDE_TACHI.md
@@ -207,7 +207,7 @@ For each remaining feature (F-002 through F-010), copy the feature block from th
 1. **STRIDE Analysis**: 6 specialized agents analyzing architecture through Spoofing, Tampering, Repudiation, Information Disclosure, Denial of Service, and Elevation of Privilege lenses
 2. **AI Threat Analysis**: 2 agents covering OWASP Top 10 for Agentic Applications + OWASP MCP Top 10 (2025) and OWASP Top 10 for LLM Applications
 3. **Parallel Orchestration**: Orchestrator parses input, dispatches to 8 agents in parallel, collects findings, deduplicates, correlates, and rates risks
-4. **Multi-Format Output**: threats.md (structured), threats.sarif (CI/CD), threat-report.md (narrative + attack trees), threat-infographic.jpg (visual)
+4. **Multi-Format Output**: threats.md (structured), threats.sarif (CI/CD), threat-report.md (narrative + attack trees), risk-scores.md/sarif (quantitative scoring via `/risk-score`), compensating-controls.md/sarif (control analysis via `/compensating-controls`), infographics (visual, via `/infographic`)
 5. **Platform Portability**: Adapters for Claude Code, Cursor, Copilot, GitHub Actions, and generic prompt format
 
 ---

--- a/docs/guides/prompts/GUIDE_PROMPT.md
+++ b/docs/guides/prompts/GUIDE_PROMPT.md
@@ -120,9 +120,9 @@ Tachi uses 14 markdown-based agents, coordinated by a central orchestrator:
 
 ---
 
-## Orchestrator Flow (6 Phases)
+## Orchestrator Flow (5 Phases)
 
-The orchestrator implements the OWASP four-step threat modeling methodology, extended with two reporting phases:
+The orchestrator implements the OWASP four-step threat modeling methodology, extended with one reporting phase:
 
 1. **Phase 1 — Scope**: Parse architecture input, auto-detect format, extract components, classify each as a DFD element type (External Entity, Process, Data Store, Data Flow), identify trust boundaries and boundary crossings.
 
@@ -226,20 +226,23 @@ git clone https://github.com/davidmatousek/tachi.git ~/Projects/tachi
 # Copy agents + templates into your project's Claude Code agents directory
 cp -r ~/Projects/tachi/adapters/claude-code/agents/ .claude/agents/tachi/
 
-# Copy the /threat-model command for single-command invocation
+# Copy commands (threat-model + post-pipeline commands)
 mkdir -p .claude/commands
 cp ~/Projects/tachi/adapters/claude-code/commands/threat-model.md .claude/commands/
+cp ~/Projects/tachi/adapters/claude-code/commands/risk-score.md .claude/commands/
+cp ~/Projects/tachi/.claude/commands/compensating-controls.md .claude/commands/
+cp ~/Projects/tachi/adapters/claude-code/commands/infographic.md .claude/commands/
 
 # Verify installation
 ls .claude/agents/tachi/              # Should show 14 .md files + templates/ directory
 ls .claude/agents/tachi/templates/    # Should show infographic-corporate-white.md
-ls .claude/commands/                   # Should show threat-model.md
+ls .claude/commands/                   # Should show threat-model.md, risk-score.md, compensating-controls.md, infographic.md
 ```
 
 This installs three things:
 1. **14 agent files** in `.claude/agents/tachi/` — Claude Code auto-discovers these as dispatchable agents
 2. **Infographic templates** in `.claude/agents/tachi/templates/` — design templates for Gemini image generation (default: `corporate-white`)
-3. **`/threat-model` command** in `.claude/commands/` — single slash command to run analysis
+3. **4 command files** in `.claude/commands/` — `/threat-model`, `/risk-score`, `/compensating-controls`, `/infographic`
 
 **Additional setup for infographic image generation:**
 
@@ -268,6 +271,9 @@ No npm install or other dependencies required beyond Claude Code and the Gemini 
 cd ~/Projects/tachi && git pull
 cp -r adapters/claude-code/agents/ ~/Projects/my-app/.claude/agents/tachi/
 cp adapters/claude-code/commands/threat-model.md ~/Projects/my-app/.claude/commands/
+cp adapters/claude-code/commands/risk-score.md ~/Projects/my-app/.claude/commands/
+cp .claude/commands/compensating-controls.md ~/Projects/my-app/.claude/commands/
+cp adapters/claude-code/commands/infographic.md ~/Projects/my-app/.claude/commands/
 ```
 
 **Custom infographic templates are preserved** — the `cp -r` overwrites the default template but won't delete custom templates you've added to `.claude/agents/tachi/templates/`.
@@ -494,8 +500,8 @@ Get a developer from zero to their first threat model in 5 steps. No theory — 
 
 **Structure:**
 1. **Prerequisites**: Claude Code installed, a Gemini API key stored as `GEMINI_API_KEY` environment variable (for infographic generation), a project with architecture docs (or create a simple one)
-2. **Install Tachi**: Clone tachi, copy agents + command (`cp` commands from installation section)
-3. **Verify**: `ls .claude/agents/tachi/` shows 14 files, `ls .claude/commands/` shows `threat-model.md`
+2. **Install Tachi**: Clone tachi, copy agents + commands (`cp` commands from installation section)
+3. **Verify**: `ls .claude/agents/tachi/` shows 14 files, `ls .claude/commands/` shows 4 command files (threat-model.md, risk-score.md, compensating-controls.md, infographic.md)
 4. **Create Your Architecture File**: Create `docs/security/architecture.md` with a simple 3-component architecture as the minimal example (e.g., a React frontend, a Node.js API, and a PostgreSQL database — show the Mermaid diagram)
 5. **Run Your First Analysis**: `/threat-model` — that's it, one command
 6. **Read Your Results**: Where to find `threats.md`, what the key sections mean, what to do first (look at Critical/High findings in Section 7)


### PR DESCRIPTION
## Summary

- **README.md**: Added `/compensating-controls` and `/infographic` command sections, updated Quick Start to copy all 4 commands, removed stale `--infographic-template` flag, updated results table with new output files
- **GUIDE_PROMPT.md**: Fixed "6 Phases" → "5 Phases", updated install/update instructions for 4 command files
- **CONSUMER_GUIDE_TACHI.md**: Updated output listing to reflect standalone `/infographic` command
- **devops/README.md**: Added all 4 tachi commands to adapter section
- **risk-score.md / compensating-controls.md**: Clarified "6-phase" references as agent-internal (not pipeline)

## Test plan

- [ ] Verify README Quick Start instructions work end-to-end
- [ ] Confirm no remaining "6 phase" pipeline references in user-facing docs
- [ ] Verify all 4 commands listed in install instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)