### PR TITLE
feat(067): deterministic report data extraction

### DIFF
--- a/.claude/agents/tachi/report-assembler.md
+++ b/.claude/agents/tachi/report-assembler.md
@@ -101,67 +101,103 @@ Generating report-data.typ...
 
 ---
 
-## Step 2: Data Extraction
+## Step 2: Data Extraction and Typst Generation
 
-Parse each detected artifact to extract the structured data needed by the Typst templates. Handle parsing errors gracefully — if an optional artifact fails to parse, log a warning and proceed without it (set its flag to false).
+Invoke the deterministic Python extraction script to parse all artifacts and generate `report-data.typ`. The script handles artifact parsing, tier selection, severity counting, scope extraction, validation, and Typst output generation — replacing the previous LLM-based Steps 2-3.
 
-### 2a. Parse threats.md (always)
+### 2a. Handle Report Configuration
 
-**YAML Frontmatter** — extract from the YAML block between `---` markers at the top of the file:
+Check for a user-provided `report-config.typ` in the target directory:
 
-| Field | Typst Variable | Default if Missing |
-|-------|---------------|-------------------|
-| `date` | `assessment-date` | `"Unknown"` |
-| `classification` | `classification` | `none` |
-| `schema_version` | (used for v1.0 compat check) | `"1.0"` |
+1. If `{target_dir}/report-config.typ` exists:
+   - Copy it to `templates/tachi/security-report/report-config.typ`, overwriting the default
+   - Log: `"Using custom report-config.typ from {target_dir}"`
+2. If not present:
+   - Ensure the default `templates/tachi/security-report/report-config.typ` exists (it ships with the templates)
+   - Log: `"Using default report configuration"`
 
-**Project Name** — extract from the first `# Threat Model: {name}` heading. If `title_override` was provided by the command, use that instead.
+### 2b. Invoke Extraction Script
 
-**Section 6: Risk Summary** — parse the severity count table:
+Run the deterministic extraction script:
 
-Look for the table under `## 6. Risk Summary` with columns `| Risk Level | Count | Percentage |`. Extract:
-
-| Row | Typst Variable |
-|-----|---------------|
-| Critical | `critical-count` (integer) |
-| High | `high-count` (integer) |
-| Medium | `medium-count` (integer) |
-| Low | `low-count` (integer) |
-| Total (from **Total** row) | `total-findings` (integer — use the raw count if format is "30 (34 raw)", extract the raw number) |
-
-**Note on total**: The Total row may contain text like `**30 (34 raw)**`. Extract the first number as the deduplicated count. If a parenthesized raw count exists, use the raw count as `total-findings` since it represents all individual findings that appear in the findings table.
-
-**Component Distribution** — parse Section 7 `## 7. Recommended Actions` table to count findings per component:
-
-Read the table with columns `| Finding ID | Component | Threat | Risk Level | Mitigation |`. Count occurrences of each unique Component value. Produce an array of `(component_name, count)` tuples sorted by count descending.
-
-### 2b. Parse threats.md Section 7 for Tier 3 Findings (if Tier 3)
-
-If `data_source_tier == 3`, extract findings rows from Section 7:
-
-For each row in the `## 7. Recommended Actions` table, extract:
-
-```
-{
-  id: "S-3",
-  component: "LLM Agent Orchestrator",
-  threat: "Attacker forges tool call requests...",
-  likelihood: (derive from Risk Level — see note below),
-  impact: (derive from Risk Level — see note below),
-  risk_level: "Critical",
-  mitigation: "Implement mutual TLS..."
-}
+```bash
+python3 scripts/extract-report-data.py \
+  --target-dir {target_dir} \
+  --output templates/tachi/security-report/report-data.typ \
+  --template-dir templates/tachi/security-report/ \
+  [--title "{title_override}"]
 ```
 
-**Note**: The Section 7 table has `Risk Level` but not separate `Likelihood` and `Impact` columns. For Tier 3, set `likelihood` and `impact` both to `"—"` (em dash) since these granular values are not available in the recommended actions table. The `risk_level` column serves as the severity indicator.
+Include `--title` only if the command provided a title override.
 
-### 2c. Parse risk-scores.md for Tier 2 Findings (if Tier 2)
+### 2c. Handle Exit Codes
 
-If `data_source_tier == 2`, parse `risk-scores.md` Section 2: Scored Threat Table.
+| Exit Code | Meaning | Agent Action |
+|-----------|---------|-------------|
+| 0 | Success | Proceed to Step 3 (Compilation) |
+| 1 | Missing required artifact | Display stderr message and abort: `"Error: {message}"` |
+| 2 | Validation failure | Display stderr details and abort: `"Validation error: {details}"` |
 
-Look for the table under `## 2. Scored Threat Table` with columns `| ID | Component | Threat | CVSS | Exploit. | Scale. | Reach. | Composite | Severity | SLA | Disposition |`.
+If the script exits with code 1 or 2, do NOT proceed to compilation. Display the error and return failure to the command.
 
-For each row, extract:
+### 2d. Report Results
+
+Display: `"report-data.typ generated — proceeding to compilation"`
+
+---
+
+**Legacy reference**: The previous Steps 2-3 performed LLM-based markdown parsing and Typst generation inline. The Python script (`scripts/extract-report-data.py`) replaces this with deterministic regex-based extraction. The Typst variable contract is identical — all variable names, types, and structure match the templates. For the full variable specification, see `specs/067-deterministic-report-data/data-model.md`.
+
+---
+
+## Step 3: Compilation
+
+### 3a. Invoke Typst Compiler
+
+Run the Typst compiler with the `--root` flag pointing to the project root:
+
+```bash
+typst compile templates/tachi/security-report/main.typ "{output_path}/security-report.pdf" --root .
+```
+
+Where `{output_path}` is the resolved output directory from the command. Run from the **project root directory**.
+
+### 3b. Handle Compilation Errors
+
+If `typst compile` exits with a non-zero status:
+
+1. Capture stderr
+2. Display: `"TYPST COMPILATION ERROR: {stderr}. report-data.typ preserved for debugging."`
+3. Do NOT delete `report-data.typ` — leave it for debugging
+4. Return failure to the command
+
+### 3c. Verify Output
+
+1. Verify `{output_path}/security-report.pdf` exists and is non-zero size
+2. If missing: `"Compilation succeeded but output file is missing or empty"`
+
+### 3d. Clean Up
+
+Delete `templates/tachi/security-report/report-data.typ` after successful verification.
+
+### 3e. Report Results
+
+```
+PDF generated successfully.
+Path: {output_path}/security-report.pdf
+Tier: {data_source_tier}
+```
+
+---
+
+**REMOVED (replaced by script)**: The following legacy sections documented the previous LLM-based parsing and Typst generation steps. They are retained here for historical reference only — the extraction script at `scripts/extract-report-data.py` now handles all data extraction and Typst generation deterministically. For the complete variable specification, see `specs/067-deterministic-report-data/data-model.md`.
+
+<details>
+<summary>Legacy Steps 2-3 Reference (click to expand)</summary>
+
+#### Former Step 2: LLM-based Data Extraction
+
+The previous implementation had the agent parse each markdown artifact inline:
 
 ```
 {
@@ -589,83 +625,9 @@ Display: `"report-data.typ generated ({N} findings, Tier {tier}, {M} pages enabl
 
 ---
 
-## Step 4: Compilation
+</details>
 
-### 4a. Invoke Typst Compiler
-
-Run the Typst compiler with the `--root` flag pointing to the project root so that absolute image paths resolve correctly:
-
-```bash
-typst compile templates/tachi/security-report/main.typ "{output_path}/security-report.pdf" --root .
-```
-
-Where `{output_path}` is the resolved output directory from the command.
-
-**Important**: Run this command from the **project root directory** (where `templates/` is a direct child). The `--root .` flag tells Typst to resolve all paths relative to the current working directory.
-
-### 4b. Handle Compilation Errors
-
-If `typst compile` exits with a non-zero status:
-
-1. Capture the stderr output
-2. Display the error:
-   ```
-   TYPST COMPILATION ERROR
-
-   {stderr output}
-
-   The report-data.typ file has been preserved for debugging at:
-     templates/tachi/security-report/report-data.typ
-
-   Common causes:
-   - Unescaped special characters in finding text
-   - Missing closing quotes in string values
-   - Image file path that doesn't exist
-   ```
-3. Do NOT delete `report-data.typ` — leave it for debugging
-4. Return failure to the command
-
-### 4c. Verify Output
-
-After successful compilation:
-
-1. Verify the output PDF exists at `{output_path}/security-report.pdf`
-2. Verify the file is non-zero size
-3. If verification fails, report: `"Compilation succeeded but output file is missing or empty at: {path}"`
-
-### 4d. Clean Up Intermediate File
-
-After successful verification:
-
-1. Delete `templates/tachi/security-report/report-data.typ`
-2. This file is intermediate and should not be committed to version control
-
-### 4e. Report Results
-
-Return to the command with:
-
-```
-PDF generated successfully.
-Path: {output_path}/security-report.pdf
-Pages: {count based on enabled flags}
-Tier: {data_source_tier}
-```
-
-Count pages by summing:
-- Cover (always): 1
-- Disclaimer (if show-disclaimer): 1
-- Table of Contents (always): 1
-- Executive Summary (always): 1
-- Risk Methodology (if show-methodology): 1
-- Assessment Scope (always): 1
-- Risk Funnel (if has_funnel_image): 1
-- Baseball Card (if has_baseball_image): 1
-- System Architecture (if has_architecture_image): 1
-- Findings Detail (always): 1+ (may span multiple pages for large finding sets)
-- Control Coverage (if has_compensating_controls): 1
-- Remediation Roadmap (if has_compensating_controls or has_threat_report with remediation): 1
-
-Report the minimum page count (counting findings detail as 1 page). The actual page count may be higher if tables overflow.
+---
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -194,3 +194,9 @@ docs/planning/
 
 # Subagent result artifacts (ephemeral, session-scoped)
 .aod/results/
+
+# Runtime-generated Typst data file (produced by extract-report-data.py)
+templates/tachi/security-report/report-data.typ
+
+# Test output artifacts (generated during local testing)
+examples/*/test-output/

--- a/docs/product/02_PRD/067-deterministic-report-data-extraction-2026-03-30.md
+++ b/docs/product/02_PRD/067-deterministic-report-data-extraction-2026-03-30.md
@@ -1,0 +1,302 @@
+---
+prd:
+  number: "067"
+  topic: deterministic-report-data-extraction
+  created: 2026-03-30
+  status: Approved
+  type: feature
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-30
+    status: APPROVED
+    notes: "PRD authored by PM. P0 bug fix replacing non-deterministic LLM parsing with deterministic Python script. Root cause well-evidenced with 4-report comparison data. All reviewer concerns are spec-level items."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-30
+    status: APPROVED_WITH_CONCERNS
+    notes: "Architecturally sound. 5 items for spec: (1) extract report-data.typ contract into machine-readable schema, (2) specify exact Python invocation pattern and script location, (3) resolve total-findings dedup vs raw count for all tiers, (4) handle Note severity level in validation rule, (5) enumerate markdown parsing edge cases (bold markers, code-fenced frontmatter, unicode, truncation markers) and create Tier 1 test fixture."
+  techlead_signoff:
+    agent: team-lead
+    date: 2026-03-30
+    status: APPROVED_WITH_CONCERNS
+    notes: "3-5 sessions realistic (not single-phase). Recommends 3-wave strategy: Wave 1 (core parsing + Tier 2 with real test data), Wave 2 (Tier 1 + Tier 3 paths), Wave 3 (agent rewrite + integration). Highest risk: no Tier 1 test dataset exists — needs resolution in spec. 4 clarifications needed: OpenClaw dataset existence, script location, partial-parse exit codes, risk-scores.md non-standard frontmatter format."
+source:
+  idea_id: 67
+  story_id: null
+---
+
+# Deterministic Report Data Extraction — Product Requirements Document
+
+**Status**: Approved
+**Created**: 2026-03-30
+**Author**: product-manager
+**Reviewers**: architect, team-lead
+**Priority**: P0 (Critical)
+**Source**: GitHub Issue #67
+
+---
+
+## Executive Summary
+
+### The One-Liner
+Replace the LLM-based data extraction in the report-assembler agent with a deterministic parsing script so that `/security-report` produces identical output from identical input every time.
+
+### Problem Statement
+Running `/security-report` four times on the exact same input artifacts (threats.md, risk-scores.md, compensating-controls.md, threat-report.md, infographic JPEGs) produced dramatically different PDF reports. Severity counts varied between 0 and 20 Critical findings, data flow counts changed between 20 and 36, recommendation formatting was inconsistent, and the overall risk level fluctuated between HIGH and CRITICAL — all from the same source files.
+
+**Evidence (4 reports from identical OpenClaw data)**:
+
+| Metric | Report 1 | Report 2 | Report 3 | Report 4 |
+|--------|:--------:|:--------:|:--------:|:--------:|
+| Overall Risk Level | HIGH | HIGH | CRITICAL | CRITICAL |
+| Critical findings | 0 | 0 | 15 | 20 |
+| High findings | 17 | 4 | 26 | 26 |
+| Medium findings | 47 | 36 | 14 | 14 |
+| Low findings | 0 | 24 | 3 | 3 |
+| Total findings | 64 | 64 | 63 | 63 |
+| Data Flows extracted | 36 | 36 | 36 | 20 |
+
+**Root Cause (5 Whys)**: The report-assembler agent's Steps 2–3 (Data Extraction and Typst Data Generation) are executed by an LLM parsing natural language instructions. The LLM inconsistently selects between three overlapping severity source tables, produces variable-length recommendation text, and extracts different data flow counts from the same markdown — because structured parsing of well-defined tables is a deterministic task being performed by a non-deterministic system.
+
+### Proposed Solution
+Create a deterministic parsing script (Python) that replaces Steps 2–3 of the report-assembler agent. The script reads markdown artifacts using regex and line parsing, applies tier-selection logic programmatically, extracts all structured data with consistent formatting, validates internal consistency, and writes `report-data.typ`. The LLM agent is reduced to orchestration only: detect artifacts, invoke the script, invoke Typst.
+
+### Success Criteria
+- Running `/security-report` twice on identical input produces byte-identical `report-data.typ`
+- Running `/security-report` twice on identical input produces byte-identical PDF output
+- Severity counts are validated: critical + high + medium + low == total
+- Data flow count matches source file
+- Tested against both OpenClaw and agentic-app example datasets
+
+### Timeline
+Single-phase implementation. The script replaces existing natural language instructions with equivalent programmatic logic — no new data sources, no new page templates, no Typst template changes.
+
+---
+
+## Strategic Alignment
+
+### Product Vision Alignment
+**Reference**: [product-vision.md](../01_Product_Vision/product-vision.md)
+
+tachi's mission is to be the default threat modeling toolkit for agentic AI applications. A threat modeling toolkit that produces different reports from the same data on every run cannot be trusted for compliance, audit trails, or executive communication. Deterministic output is a prerequisite for professional-grade tooling — without it, users cannot rely on the numbers in the report.
+
+### Roadmap Fit
+This is a P0 bug fix for the delivered `/security-report` capability (PRD-054, PRD-060). It blocks adoption of the PDF report for any use case requiring reproducibility: CI/CD artifact generation, compliance documentation, multi-stakeholder review.
+
+---
+
+## Target Users & Personas
+
+### Primary Persona: Security Engineer
+- **Role**: Runs threat models and generates reports for team review
+- **Pain Point**: Generated a report showing 0 Critical findings, sent it to leadership, then regenerated and got 20 Critical findings from the same data — destroying trust in the tool
+- **Need**: Identical inputs must produce identical outputs, every time
+
+### Secondary Persona: CISO / Security Manager
+- **Role**: Reviews and distributes security assessment reports
+- **Pain Point**: Cannot use tachi reports for compliance or audit evidence because the same data produces different severity distributions
+- **Need**: A report that accurately reflects the underlying threat model data and can be regenerated reproducibly
+
+---
+
+## User Stories
+
+### US-067-1: Reproducible Report Generation
+**When** I run `/security-report` on a directory containing threat model artifacts,
+**I want to** get the same PDF output every time I run it on the same inputs,
+**So I can** trust the report numbers and use it for compliance and executive communication.
+
+**Acceptance Criteria**:
+- **Given** a directory with unchanged threat model artifacts, **when** I run `/security-report` twice, **then** both runs produce identical `report-data.typ` files
+- **Given** identical `report-data.typ` files, **when** Typst compiles them, **then** both PDFs are byte-identical
+- **Given** a Tier 1 scenario (compensating-controls.md exists), **when** the script extracts severity counts, **then** it uses the residual severity from compensating-controls.md Section 2
+
+### US-067-2: Validated Severity Counts
+**When** the parsing script extracts severity counts from markdown artifacts,
+**I want to** be confident the counts are internally consistent,
+**So I can** trust the numbers on the cover page and executive summary.
+
+**Acceptance Criteria**:
+- **Given** extracted severity counts, **when** validation runs, **then** critical + high + medium + low == total
+- **Given** a Tier 2 scenario (risk-scores.md exists, no compensating-controls.md), **when** the script extracts counts, **then** it uses risk-scores.md Section 1 severity distribution
+- **Given** a Tier 3 scenario (only threats.md), **when** the script extracts counts, **then** it uses threats.md Section 6 Risk Summary
+
+### US-067-3: Deterministic Data Flow Extraction
+**When** the parsing script extracts scope data from threats.md,
+**I want to** get the same component count and data flow count every time,
+**So I can** trust the scope page accurately reflects the system architecture.
+
+**Acceptance Criteria**:
+- **Given** threats.md with N data flows in Section 1, **when** the script extracts data flows, **then** exactly N data flows appear in `report-data.typ`
+- **Given** threats.md with M components in Section 1, **when** the script extracts components, **then** exactly M components appear in `report-data.typ`
+
+### US-067-4: Consistent Recommendation Formatting
+**When** the parsing script extracts findings with recommendations,
+**I want to** get identically formatted recommendation text every time,
+**So I can** the findings table has uniform presentation across all rows.
+
+**Acceptance Criteria**:
+- **Given** a Tier 1 finding with a recommendation in compensating-controls.md, **when** the script extracts it, **then** the recommendation text is preserved verbatim from the source
+- **Given** findings across all severity levels, **when** the script formats them, **then** all recommendations use consistent formatting (no variable-length paraphrasing)
+
+---
+
+## Functional Requirements
+
+### FR-1: Deterministic Parsing Script
+
+**Description**: A Python script that reads tachi pipeline markdown artifacts and writes a `report-data.typ` file with all Typst variable bindings.
+
+**Inputs**:
+- `--target-dir`: Directory containing markdown artifacts and images
+- `--output`: Path for the generated `report-data.typ` file
+- `--title`: Optional title override (replaces auto-detected project name)
+- `--template-dir`: Path to `templates/tachi/security-report/` (for image path calculation)
+
+**Processing**:
+1. Detect artifacts and determine tier (same logic as agent Step 1)
+2. Parse each artifact using regex/line parsing (replaces agent Step 2)
+3. Apply tier-selection logic programmatically for severity source
+4. Extract all structured data: frontmatter, severity counts, findings, scope, coverage, remediation
+5. Validate internal consistency (severity sum, data flow count, finding ID uniqueness)
+6. Generate `report-data.typ` with deterministic string formatting (replaces agent Step 3)
+
+**Outputs**: Single `report-data.typ` file with identical content on every run given identical inputs.
+
+**Validation Rules**:
+- `critical_count + high_count + medium_count + low_count == total_findings`
+- `len(scope_data_flows) == scope_data_flow_count`
+- `len(scope_components) == scope_component_count`
+- All finding IDs are unique
+- All Typst string values are properly escaped (quotes, backslashes)
+
+### FR-2: Tier-Based Severity Source Selection
+
+**Description**: Unambiguous, programmatic severity source selection.
+
+| Tier | Condition | Severity Source | Cover Page Counts |
+|------|-----------|----------------|-------------------|
+| Tier 1 | `compensating-controls.md` exists | Residual severity counts from Section 2 findings | Count by `residual_severity` field |
+| Tier 2 | `risk-scores.md` exists, no compensating-controls | Scored severity from Section 1 distribution table | Use Section 1 counts directly |
+| Tier 3 | Only `threats.md` | Section 6 Risk Summary table | Use Section 6 counts directly |
+
+### FR-3: Agent Prompt Update
+
+**Description**: The report-assembler agent instructions are updated to orchestrate (detect, invoke script, compile) instead of parsing.
+
+**Changes**:
+- Steps 2–3 replaced with a single step: invoke the parsing script
+- Step 1 (artifact detection) and Step 4 (Typst compilation) remain unchanged
+- Error handling updated to capture script exit codes and stderr
+
+### FR-4: Brand Asset Detection
+
+**Description**: The script detects brand logos using the same path checks as the current agent Step 2i.
+
+No changes to brand asset logic — the existing detection rules are already deterministic (file existence checks). The script replicates this logic.
+
+---
+
+## Non-Functional Requirements
+
+### Determinism
+- **Requirement**: Given identical input files (same content, any filesystem metadata), the script produces byte-identical `report-data.typ` output
+- **Verification**: Run script twice, `diff` the outputs — zero differences
+
+### Performance
+- **Parsing time**: < 5 seconds for the largest expected artifact set (64+ findings, 36 data flows, 20+ components)
+- **No external dependencies beyond Python standard library**: The script must run with Python 3.9+ using only `re`, `yaml` (or regex-based frontmatter parsing), `pathlib`, `argparse`, `sys`
+
+### Compatibility
+- **Python 3.9+**: Must run on macOS, Linux, and Windows
+- **Typst output format**: Generated `report-data.typ` must be syntactically valid Typst and structurally identical to what the LLM previously generated (same variable names, same types)
+- **Backward compatibility**: No changes to Typst templates — the script produces the same data contract
+
+### Error Handling
+- **Missing required artifact**: Exit with code 1 and clear error message
+- **Malformed markdown table**: Log warning, extract what's parseable, continue
+- **Validation failure**: Exit with code 2, display which validation check failed and the offending values
+
+---
+
+## Scope & Boundaries
+
+### In Scope (P0)
+
+- **Deterministic parsing script** (Python) that reads markdown artifacts and writes `report-data.typ`
+- **All data extraction from Steps 2a–2j** of the current agent: frontmatter, severity counts, findings (all 3 tiers), scope data, coverage matrix, controls, remediation actions, brand assets, report config
+- **Tier-based severity source selection** with unambiguous programmatic logic
+- **Internal consistency validation**: severity sum check, data flow count check, finding ID uniqueness
+- **Agent prompt update**: report-assembler.md updated to invoke script instead of LLM-parsing
+- **Command update**: security-report.md updated if needed for script invocation
+- **Testing against OpenClaw example dataset** (the 4-report scenario from the issue)
+- **Testing against agentic-app example dataset** for regression
+
+### Out of Scope
+
+- **Typst template changes**: Templates already render correctly with well-formed data
+- **Upstream pipeline agent changes**: Threat agents, risk scorer, and control analyzer are unaffected
+- **Infographic generation changes**: Separate pipeline, not part of report assembly
+- **New report pages or sections**: This is a data extraction fix, not a feature addition
+- **CI/CD integration**: Future work — deterministic output enables it, but the pipeline itself is out of scope
+
+### Assumptions
+- Python 3.9+ is available on all target platforms (macOS, Linux, Windows)
+- The markdown artifact format is stable (schema v1.0 and v1.1 as documented)
+- The Typst variable contract in `report-data.typ` does not need to change
+
+---
+
+## Risks & Dependencies
+
+### Technical Risks
+
+**Risk 1**: Markdown table parsing edge cases
+- **Likelihood**: Medium
+- **Impact**: Medium
+- **Mitigation**: Use the existing example datasets (OpenClaw, agentic-app) as parsing test fixtures. These cover all table formats generated by tachi pipeline agents.
+
+**Risk 2**: Typst string escaping in finding text
+- **Likelihood**: Medium
+- **Impact**: Low
+- **Mitigation**: The LLM already had to handle this — the script can apply the same escaping rules deterministically. Test with findings containing quotes, backslashes, and special characters.
+
+**Risk 3**: YAML frontmatter parsing without PyYAML
+- **Likelihood**: Low
+- **Impact**: Low
+- **Mitigation**: The frontmatter is simple key-value pairs (`date`, `classification`, `schema_version`). Regex extraction is sufficient without a YAML library dependency.
+
+### Dependencies
+
+**Internal Dependencies**:
+- **Typst template system** (PRD-054, PRD-060): Delivered and stable. The script targets the existing `report-data.typ` variable contract.
+- **Example datasets**: OpenClaw and agentic-app examples must be current and contain all artifact types for testing.
+
+**No external dependencies**: Script uses Python standard library only.
+
+---
+
+## Open Questions
+
+- [x] Which severity source for each tier? — Answered in FR-2 (residual for Tier 1, scored for Tier 2, original for Tier 3)
+- [x] Should the script use PyYAML? — No, regex-based frontmatter parsing avoids external dependency
+- [ ] Should the script output to stdout or write directly to file? — Recommend direct file write with `--output` flag for simplicity — architect to confirm during spec
+
+---
+
+## References
+
+### Product Documentation
+- Product Vision: [product-vision.md](../01_Product_Vision/product-vision.md)
+- PRD-054 (Security Assessment PDF): [054-security-assessment-pdf-booklet-2026-03-28.md](054-security-assessment-pdf-booklet-2026-03-28.md)
+- PRD-060 (Professional Branding): [060-professional-pdf-security-report-branding-2026-03-29.md](060-professional-pdf-security-report-branding-2026-03-29.md)
+
+### Technical Documentation
+- Report Assembler Agent: `.claude/agents/tachi/report-assembler.md`
+- Security Report Command: `.claude/commands/security-report.md`
+- Typst Templates: `templates/tachi/security-report/`
+- Constitution: `.aod/memory/constitution.md`
+
+### Issue & Evidence
+- GitHub Issue #67: Full 5 Whys root cause analysis with 4-report evidence table

--- a/docs/product/02_PRD/INDEX.md
+++ b/docs/product/02_PRD/INDEX.md
@@ -1,10 +1,11 @@
 # PRD Index
 
-**Last Updated**: 2026-03-29
+**Last Updated**: 2026-03-30
 
 
 | # | Feature | PM | Architect | Team-Lead | Status | Date |
 |---|---------|----|-----------|-----------| -------|------|
+| 067 | [Deterministic Report Data Extraction](067-deterministic-report-data-extraction-2026-03-30.md) | ✓ | ⚠ | ⚠ | Approved | 2026-03-30 |
 | 060 | [Professional PDF Security Report Branding](060-professional-pdf-security-report-branding-2026-03-29.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-29 |
 | 054 | [Security Assessment PDF Booklet](054-security-assessment-pdf-booklet-2026-03-28.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-28 |
 | 053 | [Risk Reduction Funnel](053-risk-reduction-funnel-2026-03-28.md) | ✓ | ✓ | ✓ | Delivered | 2026-03-28 |

--- a/docs/product/_backlog/BACKLOG.md
+++ b/docs/product/_backlog/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-> Auto-generated from GitHub Issues on 2026-03-29T18:21:34Z.
+> Auto-generated from GitHub Issues on 2026-03-30T13:08:17Z.
 > Source of truth: GitHub Issues with `stage:*` labels.
 > Regenerate: `/aod.status` or `.aod/scripts/bash/backlog-regenerate.sh`
 
@@ -15,7 +15,7 @@
 
 | # | Title | PRD | Updated |
 |---|-------|-----|---------|
-| — | *No items in this stage* | | |
+| #66 | GitHub Releases distribution for simplified install and versioned updates | — | 2026-03-30 |
 
 ## Plan
 
@@ -41,6 +41,7 @@
 
 | # | Title | State | Updated |
 |---|-------|-------|---------|
+| #67 | Report assembler produces non-deterministic output from identical input data | OPEN | 2026-03-30 |
 | #51 | fix: Gemini heat map renders incorrect severity labels for medium-risk components | OPEN | 2026-03-28 |
 | #46 | Sync upstream AOD Kit — merge new skills, commands, rules, and guides | OPEN | 2026-03-28 |
 | #27 | Developer Guide: Automated Threat Modeling for Your Architecture | CLOSED | 2026-03-24 |

--- a/examples/agentic-app/sample-report/compensating-controls.md
+++ b/examples/agentic-app/sample-report/compensating-controls.md
@@ -1,0 +1,402 @@
+# Compensating Controls Report
+
+---
+
+```yaml
+---
+schema_version: "1.0"
+date: "2026-03-28"
+source_file: "risk-scores.md"
+target_path: "examples/agentic-app"
+classification: "security"
+---
+```
+
+---
+
+## 1. Executive Summary
+
+**34** threats analyzed | **8** Control Found | **13** Partial Control | **13** No Control Found
+
+**Coverage**: 23.5% Found | 38.2% Partial | 38.2% Missing
+
+**Risk Reduction**: 214.5 inherent -> 156.8 residual (**26.9%** reduction)
+
+**Highest-Risk Unmitigated Finding**: LLM-1 — LLM Agent Orchestrator — Composite 8.3 (High)
+
+| Metric | Value |
+|--------|-------|
+| Analysis date | 2026-03-28 |
+| Source file | `risk-scores.md` |
+| Target codebase | `examples/agentic-app` |
+| Schema version | 1.0 |
+
+**Coverage Distribution:**
+
+| Status | Count | Percentage |
+|--------|-------|------------|
+| Control Found | 8 | 23.5% |
+| Partial Control | 13 | 38.2% |
+| No Control Found | 13 | 38.2% |
+| **Total** | **34** | **100%** |
+
+---
+
+## 2. Coverage Matrix
+
+Threats grouped by residual severity (Critical first, then High, Medium, Low). Within each group, threats are sorted by residual score descending.
+
+### Critical Residual Severity
+
+| Threat ID | Component | Threat | Inherent Score | Inherent Severity | Control Status | Residual Score | Residual Severity |
+|-----------|-----------|--------|----------------|-------------------|----------------|----------------|-------------------|
+| LLM-1 | LLM Agent Orchestrator | Adversarial prompts override system prompt | 8.3 | High | No Control Found | 8.3 | Critical |
+
+### High Residual Severity
+
+| Threat ID | Component | Threat | Inherent Score | Inherent Severity | Control Status | Residual Score | Residual Severity |
+|-----------|-----------|--------|----------------|-------------------|----------------|----------------|-------------------|
+| S-1 | User | Attacker impersonates legitimate user by replaying tokens | 7.9 | High | Partial Control | 5.9 | High |
+| E-2 | LLM Agent Orchestrator | Attacker escalates to admin tool access through prompt injection | 7.6 | High | No Control Found | 7.6 | High |
+| AG-1 | LLM Agent Orchestrator | Orchestrator executes consequential actions without human approval | 7.6 | High | No Control Found | 7.6 | High |
+| E-3 | MCP Tool Server | User invokes admin tool endpoints by manipulating tool_name | 7.5 | High | No Control Found | 7.5 | High |
+| D-1 | Guardrails Service | Attacker floods Guardrails Service to exhaust CPU | 7.4 | High | Partial Control | 5.6 | High |
+| D-2 | LLM Agent Orchestrator | Attacker sends concurrent max-length prompts | 7.3 | High | No Control Found | 7.3 | High |
+| S-3 | LLM Agent Orchestrator | Attacker forges tool call requests to MCP Tool Server | 7.2 | High | Partial Control | 5.4 | High |
+| T-3 | MCP Tool Server | Attacker manipulates JSON-RPC parameters in transit | 7.1 | High | No Control Found | 7.1 | High |
+| AG-3 | MCP Tool Server | MCP Tool Server exposes all tools without per-agent scoping | 7.0 | High | No Control Found | 7.0 | High |
+
+### Medium Residual Severity
+
+| Threat ID | Component | Threat | Inherent Score | Inherent Severity | Control Status | Residual Score | Residual Severity |
+|-----------|-----------|--------|----------------|-------------------|----------------|----------------|-------------------|
+| S-2 | Guardrails Service | Attacker bypasses Guardrails by directly accessing Orchestrator | 6.7 | Medium | Partial Control | 5.0 | Medium |
+| E-1 | Guardrails Service | Attacker bypasses Guardrails via alternate route | 6.6 | Medium | Partial Control | 5.0 | Medium |
+| D-3 | MCP Tool Server | Resource exhaustion through concurrent tool calls | 6.4 | Medium | Partial Control | 4.8 | Medium |
+| AG-4 | MCP Tool Server | Tool call chaining enables capability escalation | 6.4 | Medium | No Control Found | 6.4 | Medium |
+| T-4 | Knowledge Base | Attacker injects malicious content into Knowledge Base | 6.3 | Medium | Partial Control | 4.7 | Medium |
+| LLM-2 | LLM Agent Orchestrator | Indirect prompt injection via adversarial content in Knowledge Base | 6.3 | Medium | No Control Found | 6.3 | Medium |
+| I-1 | Guardrails Service | Rejection reasons reveal internal filtering rules | 6.2 | Medium | Control Found | 3.1 | Medium |
+| T-2 | LLM Agent Orchestrator | Attacker injects malicious content by tampering with data flow | 6.1 | Medium | Partial Control | 4.6 | Medium |
+| D-4 | Knowledge Base | Unbounded vector search queries exhaust resources | 6.0 | Medium | Partial Control | 4.5 | Medium |
+| I-4 | Knowledge Base | Query responses include internal metadata | 5.9 | Medium | Control Found | 3.0 | Medium |
+| T-1 | Guardrails Service | Attacker modifies validation rules at runtime | 5.8 | Medium | Control Found | 2.9 | Medium |
+| S-4 | MCP Tool Server | Attacker redirects outbound API requests via DNS spoofing | 5.7 | Medium | Control Found | 2.9 | Medium |
+| I-3 | MCP Tool Server | Raw API error responses forwarded without sanitization | 5.6 | Medium | Partial Control | 4.2 | Medium |
+| I-2 | LLM Agent Orchestrator | Verbose error messages leak internal service topology | 5.5 | Medium | Control Found | 2.8 | Medium |
+
+### Low Residual Severity
+
+| Threat ID | Component | Threat | Inherent Score | Inherent Severity | Control Status | Residual Score | Residual Severity |
+|-----------|-----------|--------|----------------|-------------------|----------------|----------------|-------------------|
+| T-5 | Audit Logger | Attacker modifies audit log entries to cover tracks | 5.4 | Medium | Control Found | 2.7 | Low |
+| D-5 | Audit Logger | High-volume logging events cause storage exhaustion | 5.3 | Medium | Partial Control | 4.0 | Low |
+| R-3 | LLM Agent Orchestrator | Orchestrator executes tool calls without logging decision chain | 5.2 | Medium | Partial Control | 3.9 | Low |
+| AG-2 | LLM Agent Orchestrator | Orchestrator operates in unbounded reasoning loop | 5.2 | Medium | No Control Found | 5.2 | Low |
+| I-5 | Audit Logger | Audit logs contain sensitive data accessible beyond security team | 5.1 | Medium | Control Found | 2.6 | Low |
+| LLM-3 | LLM Agent Orchestrator | Systematic querying enables model extraction | 5.0 | Medium | No Control Found | 5.0 | Low |
+| R-1 | User | User denies having submitted a specific prompt | 4.8 | Medium | Control Found | 2.4 | Low |
+| R-5 | External API | External API interactions lack correlation identifiers | 4.6 | Medium | No Control Found | 4.6 | Low |
+| R-2 | Guardrails Service | Insufficient detail in filtering event logs | 4.5 | Medium | Partial Control | 3.4 | Low |
+| R-4 | MCP Tool Server | Tool executions lack requesting orchestrator context | 4.3 | Medium | No Control Found | 4.3 | Low |
+
+### Summary Statistics
+
+| Residual Severity | Count | Percentage |
+|-------------------|-------|------------|
+| Critical | 1 | 2.9% |
+| High | 9 | 26.5% |
+| Medium | 14 | 41.2% |
+| Low | 10 | 29.4% |
+| **Total** | **34** | **100%** |
+
+---
+
+## 3. Control Details
+
+Per-control evidence showing detected security controls with their location, code evidence, and threat coverage. One subsection per detected control, grouped by control category.
+
+### Authentication
+
+#### AUTH-1 — Bearer Token Validation
+
+**Category**: Authentication | **Status**: Partial Control | **Effectiveness**: Moderate
+
+**Detected in**: `src/middleware/auth.js:15`
+
+```javascript
+const token = req.headers.authorization?.split('Bearer ')[1];
+if (!token) return res.status(401).json({ error: 'Missing token' });
+const decoded = jwt.verify(token, process.env.JWT_SECRET);
+```
+
+**Effectiveness Assessment**:
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Coverage | Moderate | Token validation exists but lacks client context binding |
+| Configuration | Moderate | JWT secret from environment variable |
+| Currency | Strong | Using current jwt library version |
+| Completeness | Weak | No DPoP, no session fingerprinting, no MFA |
+
+**Threats Mitigated by This Control**:
+
+| Threat ID | Component | Threat | Inherent Score | Reduction Factor | Residual Score |
+|-----------|-----------|--------|----------------|------------------|----------------|
+| S-1 | User | Attacker impersonates legitimate user | 7.9 | 0.25 | 5.9 |
+
+### Rate Limiting
+
+#### RATE-1 — Express Rate Limiter
+
+**Category**: Rate Limiting | **Status**: Partial Control | **Effectiveness**: Moderate
+
+**Detected in**: `src/middleware/rateLimiter.js:8`
+
+```javascript
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+```
+
+**Effectiveness Assessment**:
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Coverage | Moderate | Rate limiting exists at API gateway |
+| Configuration | Weak | Static 100 req/15min may be too generous |
+| Currency | Strong | Current library version |
+| Completeness | Weak | No per-endpoint limits, no adaptive throttling |
+
+**Threats Mitigated by This Control**:
+
+| Threat ID | Component | Threat | Inherent Score | Reduction Factor | Residual Score |
+|-----------|-----------|--------|----------------|------------------|----------------|
+| D-1 | Guardrails Service | Attacker floods Guardrails Service | 7.4 | 0.25 | 5.6 |
+
+### Encryption
+
+#### ENC-1 — TLS Configuration
+
+**Category**: Encryption | **Status**: Control Found | **Effectiveness**: Strong
+
+**Detected in**: `src/config/tls.js:3`
+
+```javascript
+const tlsOptions = {
+  cert: fs.readFileSync(process.env.TLS_CERT),
+  key: fs.readFileSync(process.env.TLS_KEY),
+};
+```
+
+**Effectiveness Assessment**:
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Coverage | Strong | TLS configured for all external endpoints |
+| Configuration | Strong | Certificate from environment variable |
+| Currency | Strong | TLS 1.3 supported |
+| Completeness | Moderate | No certificate pinning on outbound calls |
+
+**Threats Mitigated by This Control**:
+
+| Threat ID | Component | Threat | Inherent Score | Reduction Factor | Residual Score |
+|-----------|-----------|--------|----------------|------------------|----------------|
+| S-3 | LLM Agent Orchestrator | Attacker forges tool call requests | 7.2 | 0.25 | 5.4 |
+| S-4 | MCP Tool Server | Attacker redirects outbound API requests | 5.7 | 0.50 | 2.9 |
+
+### Logging/Audit
+
+#### LOG-1 — Centralized Audit Logging
+
+**Category**: Logging/Audit | **Status**: Control Found | **Effectiveness**: Moderate
+
+**Detected in**: `src/services/auditLogger.js:12`
+
+```javascript
+const logger = winston.createLogger({
+  level: 'info',
+  format: winston.format.json(),
+  transports: [new winston.transports.File({ filename: 'audit.log' })],
+});
+```
+
+**Effectiveness Assessment**:
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Coverage | Moderate | Logging exists for most operations |
+| Configuration | Moderate | JSON format, file transport |
+| Currency | Strong | Current winston version |
+| Completeness | Weak | No log integrity verification, no tamper protection |
+
+**Threats Mitigated by This Control**:
+
+| Threat ID | Component | Threat | Inherent Score | Reduction Factor | Residual Score |
+|-----------|-----------|--------|----------------|------------------|----------------|
+| T-5 | Audit Logger | Attacker modifies audit log entries | 5.4 | 0.50 | 2.7 |
+| R-1 | User | User denies having submitted a prompt | 4.8 | 0.50 | 2.4 |
+
+### Input Validation
+
+#### VAL-1 — Guardrails Input Filtering
+
+**Category**: Input Validation | **Status**: Control Found | **Effectiveness**: Moderate
+
+**Detected in**: `src/services/guardrails.js:25`
+
+```javascript
+function validateInput(prompt) {
+  if (prompt.length > MAX_PROMPT_LENGTH) throw new Error('Input too long');
+  return sanitize(prompt);
+}
+```
+
+**Effectiveness Assessment**:
+
+| Dimension | Rating | Rationale |
+|-----------|--------|-----------|
+| Coverage | Moderate | Input length check and basic sanitization |
+| Configuration | Moderate | Max length configurable |
+| Currency | Strong | Current sanitize library |
+| Completeness | Weak | No structured prompt boundary enforcement |
+
+**Threats Mitigated by This Control**:
+
+| Threat ID | Component | Threat | Inherent Score | Reduction Factor | Residual Score |
+|-----------|-----------|--------|----------------|------------------|----------------|
+| I-1 | Guardrails Service | Rejection reasons reveal filtering rules | 6.2 | 0.50 | 3.1 |
+| I-2 | LLM Agent Orchestrator | Verbose error messages leak topology | 5.5 | 0.50 | 2.8 |
+| I-4 | Knowledge Base | Query responses include internal metadata | 5.9 | 0.50 | 3.0 |
+| T-1 | Guardrails Service | Attacker modifies validation rules | 5.8 | 0.50 | 2.9 |
+| I-5 | Audit Logger | Audit logs contain sensitive data | 5.1 | 0.50 | 2.6 |
+
+---
+
+## 4. Recommendations
+
+Actionable recommendations for threats classified as "No Control Found" or "Partial Control," sorted by composite risk score descending.
+
+### Critical / High Risk Gaps
+
+#### 1. LLM-1 — LLM Agent Orchestrator (Composite: 8.3, High)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Deploy structured prompt templates with explicit boundary enforcement between system instructions and user input. Use delimiters, role markers, and instruction hierarchy to prevent adversarial prompt override.
+
+**Where to Implement**: `src/services/orchestrator.js` — prompt construction module
+
+**Reference Patterns**: OpenAI system prompt best practices, OWASP LLM01 mitigations
+
+**Effort Estimate**: Medium — New prompt construction module with boundary enforcement
+
+---
+
+#### 2. E-2 — LLM Agent Orchestrator (Composite: 7.6, High)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Implement role-based access control on tool dispatch. Map user roles to permitted tool sets and enforce at the orchestrator level before dispatching to MCP Tool Server.
+
+**Where to Implement**: `src/services/orchestrator.js` — tool dispatch handler
+
+**Reference Patterns**: OWASP access control guidelines, principle of least privilege
+
+**Effort Estimate**: High — Requires RBAC framework integration across orchestrator and tool server
+
+---
+
+#### 3. AG-1 — LLM Agent Orchestrator (Composite: 7.6, High)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Establish human-in-the-loop checkpoints for all irreversible or external actions. Classify operations by risk tier and require explicit user approval for consequential actions.
+
+**Where to Implement**: `src/services/orchestrator.js` — action execution pipeline
+
+**Reference Patterns**: OWASP ASI-01 mitigations, human approval gate patterns
+
+**Effort Estimate**: High — Requires action classification system and approval workflow
+
+---
+
+#### 4. E-3 — MCP Tool Server (Composite: 7.5, High)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Enforce per-agent capability scoping on the MCP Tool Server. Each connected client should only access tools permitted by its role and session context.
+
+**Where to Implement**: `src/services/mcpServer.js` — tool registration and dispatch
+
+**Reference Patterns**: MCP capability scoping, RBAC on tool endpoints
+
+**Effort Estimate**: Medium — Tool permission matrix with per-session enforcement
+
+---
+
+#### 5. D-2 — LLM Agent Orchestrator (Composite: 7.3, High)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Add input size caps and concurrent request limits at the orchestrator layer. Implement request queuing with timeout to prevent resource exhaustion from parallel maximum-length prompts.
+
+**Where to Implement**: `src/middleware/rateLimiter.js` — extend to orchestrator endpoints
+
+**Reference Patterns**: Express rate limiter per-endpoint configuration, request queuing patterns
+
+**Effort Estimate**: Low — Extend existing rate limiter to orchestrator endpoints
+
+---
+
+### Medium Risk Gaps
+
+#### 6. AG-4 — MCP Tool Server (Composite: 6.4, Medium)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Implement cross-tool policy evaluation that assesses composite effects of tool call chains. Add a policy engine that evaluates whether a sequence of tool calls exceeds individual permissions.
+
+**Where to Implement**: `src/services/mcpServer.js` — tool chain policy evaluator
+
+**Reference Patterns**: Capability-based security, tool composition policies
+
+**Effort Estimate**: High — New policy engine for tool chain evaluation
+
+---
+
+#### 7. LLM-2 — LLM Agent Orchestrator (Composite: 6.3, Medium)
+
+**Current Status**: No Control Found
+
+**What to Implement**: Add content sanitization and anomaly detection on Knowledge Base retrieval results before including them in the LLM context window. Filter or flag content that resembles instruction patterns.
+
+**Where to Implement**: `src/services/knowledgeBase.js` — retrieval post-processing
+
+**Reference Patterns**: RAG poisoning mitigations, content anomaly detection
+
+**Effort Estimate**: Medium — Content filtering module for RAG pipeline
+
+---
+
+## 5. Residual Risk Summary
+
+### Aggregate Risk Reduction
+
+| Metric | Value |
+|--------|-------|
+| Total Inherent Risk Score | 214.5 |
+| Total Residual Risk Score | 156.8 |
+| Delta | 57.7 |
+| Overall Reduction | 26.9% |
+
+### Severity Distribution Comparison
+
+| Severity | Inherent Count | Residual Count | Change |
+|----------|----------------|----------------|--------|
+| Critical | 0 | 1 | +1 |
+| High | 10 | 9 | -1 |
+| Medium | 24 | 14 | -10 |
+| Low | 0 | 10 | +10 |
+| **Total** | **34** | **34** | — |

--- a/scripts/extract-report-data.py
+++ b/scripts/extract-report-data.py
@@ -1,0 +1,1451 @@
+#!/usr/bin/env python3
+"""Deterministic extraction of structured data from tachi pipeline markdown artifacts.
+
+Reads threats.md, risk-scores.md, compensating-controls.md, and threat-report.md
+from a target directory and writes a Typst data file (report-data.typ) with all
+variable bindings needed by the security report templates.
+
+Exit codes:
+  0 — success
+  1 — missing required artifact (threats.md)
+  2 — validation failure (severity sum mismatch, duplicate IDs, etc.)
+"""
+
+import argparse
+import os
+import re
+import sys
+from pathlib import Path
+
+# Exit codes
+EXIT_SUCCESS = 0
+EXIT_MISSING_ARTIFACT = 1
+EXIT_VALIDATION_FAILURE = 2
+
+# Severity ordering for deterministic output
+SEVERITY_ORDER = ["Critical", "High", "Medium", "Low", "Note"]
+
+# STRIDE prefix mapping for coverage matrix derivation
+STRIDE_PREFIXES = {
+    "S-": "Spoofing",
+    "T-": "Tampering",
+    "R-": "Repudiation",
+    "I-": "Information Disclosure",
+    "D-": "Denial of Service",
+    "E-": "Elevation of Privilege",
+    "AG-": "Agentic Threats",
+    "LLM-": "LLM Threats",
+}
+
+# SLA mapping by severity for remediation actions
+SLA_BY_SEVERITY = {
+    "Critical": "7d",
+    "High": "14d",
+    "Medium": "30d",
+    "Low": "90d",
+}
+
+
+# =============================================================================
+# Utility Functions
+# =============================================================================
+
+def escape_typst_string(s: str) -> str:
+    """Escape a string for Typst string literals.
+
+    Handles: backslash -> \\, double quote -> \", newline -> \\n
+    """
+    s = s.replace("\\", "\\\\")
+    s = s.replace('"', '\\"')
+    s = s.replace("\n", "\\n")
+    return s
+
+
+def strip_bold(s: str) -> str:
+    """Strip markdown bold markers (**) from a string."""
+    return s.replace("**", "")
+
+
+def parse_markdown_table(content: str, section_header: str) -> list:
+    """Parse a markdown table found after a section header.
+
+    Args:
+        content: Full markdown file content.
+        section_header: The section header to search for (e.g., "## 6. Risk Summary").
+
+    Returns:
+        List of dicts, one per row, with keys from the header row.
+        Returns empty list if table not found.
+    """
+    lines = content.split("\n")
+    # Find the section header
+    header_idx = None
+    for i, line in enumerate(lines):
+        if section_header in line:
+            header_idx = i
+            break
+    if header_idx is None:
+        return []
+
+    # Scan forward for the first table row (starts with |)
+    table_header_idx = None
+    for i in range(header_idx + 1, len(lines)):
+        line = lines[i].strip()
+        if line.startswith("|") and "|" in line[1:]:
+            table_header_idx = i
+            break
+        # Stop if we hit another section header
+        if line.startswith("## ") or line.startswith("# "):
+            break
+
+    if table_header_idx is None:
+        return []
+
+    # Parse header row for column names
+    header_line = lines[table_header_idx].strip()
+    columns = [strip_bold(c.strip()) for c in header_line.split("|")[1:-1]]
+    columns = [c for c in columns if c]  # Remove empty entries
+
+    if not columns:
+        return []
+
+    # Skip separator row (|---|---|...)
+    data_start = table_header_idx + 1
+    if data_start < len(lines):
+        sep_line = lines[data_start].strip()
+        if re.match(r"^\|[\s\-:|]+\|$", sep_line):
+            data_start += 1
+
+    # Parse data rows
+    rows = []
+    for i in range(data_start, len(lines)):
+        line = lines[i].strip()
+        if not line.startswith("|"):
+            break
+        cells = [strip_bold(c.strip()) for c in line.split("|")[1:-1]]
+        if len(cells) < len(columns):
+            print(f"Warning: skipping malformed row at line {i + 1}: expected {len(columns)} columns, got {len(cells)}", file=sys.stderr)
+            continue
+        row = {}
+        for j, col in enumerate(columns):
+            row[col] = cells[j] if j < len(cells) else ""
+        rows.append(row)
+
+    return rows
+
+
+def _find_table_with_column(content: str, section_header: str, required_column: str) -> list:
+    """Find a markdown table within a section that has a specific column header.
+
+    Scans all tables after section_header and returns the first one
+    whose header row contains required_column.
+    """
+    lines = content.split("\n")
+    header_idx = None
+    for i, line in enumerate(lines):
+        if section_header in line:
+            header_idx = i
+            break
+    if header_idx is None:
+        return []
+
+    section_end = len(lines)
+    for i in range(header_idx + 1, len(lines)):
+        stripped = lines[i].strip()
+        if stripped.startswith("## ") or stripped.startswith("# "):
+            section_end = i
+            break
+
+    i = header_idx + 1
+    while i < section_end:
+        stripped = lines[i].strip()
+        if stripped.startswith("|") and "|" in stripped[1:]:
+            columns = [strip_bold(c.strip()) for c in stripped.split("|")[1:-1]]
+            columns = [c for c in columns if c]
+
+            if columns and required_column in columns:
+                # Found the right table — parse it
+                data_start = i + 1
+                if data_start < section_end:
+                    sep = lines[data_start].strip()
+                    if re.match(r"^\|[\s\-:|]+\|$", sep):
+                        data_start += 1
+
+                rows = []
+                for j in range(data_start, section_end):
+                    row_line = lines[j].strip()
+                    if not row_line.startswith("|"):
+                        break
+                    cells = [strip_bold(c.strip()) for c in row_line.split("|")[1:-1]]
+                    if len(cells) < len(columns):
+                        continue
+                    row = {}
+                    for k, col in enumerate(columns):
+                        row[col] = cells[k] if k < len(cells) else ""
+                    rows.append(row)
+                return rows
+
+            # Wrong table — skip past it
+            i += 1
+            while i < section_end and lines[i].strip().startswith("|"):
+                i += 1
+            continue
+
+        i += 1
+
+    return []
+
+
+# =============================================================================
+# Frontmatter Parser
+# =============================================================================
+
+def parse_frontmatter(content: str) -> dict:
+    """Extract key-value pairs from YAML frontmatter between --- delimiters.
+
+    Handles both standard frontmatter and code-fenced frontmatter (```yaml ... ```).
+    Only extracts top-level scalar values needed for the report.
+    """
+    result = {"date": "Unknown", "classification": None, "schema_version": "1.0"}
+
+    # Try standard frontmatter first (--- ... ---)
+    match = re.match(r"^---\s*\n(.*?)\n---", content, re.DOTALL)
+    if not match:
+        # Try code-fenced frontmatter (```yaml\n---\n...\n---\n```)
+        match = re.search(r"```yaml\s*\n---\s*\n(.*?)\n---\s*\n```", content, re.DOTALL)
+
+    if not match:
+        return result
+
+    frontmatter_text = match.group(1)
+
+    # Extract top-level key: value pairs (skip nested keys by checking indentation)
+    for line in frontmatter_text.split("\n"):
+        # Skip empty lines, comments, and indented (nested) lines
+        if not line.strip() or line.strip().startswith("#") or line.startswith(" ") or line.startswith("\t"):
+            continue
+        kv_match = re.match(r'^(\w[\w_]*)\s*:\s*"?([^"]*?)"?\s*$', line)
+        if kv_match:
+            key = kv_match.group(1)
+            value = kv_match.group(2).strip()
+            if key == "date":
+                result["date"] = value
+            elif key == "classification":
+                result["classification"] = value if value else None
+            elif key == "schema_version":
+                result["schema_version"] = value
+
+    return result
+
+
+# =============================================================================
+# Project Name Parser
+# =============================================================================
+
+def parse_project_name(content: str, title_override: str = None) -> str:
+    """Extract project name from # Threat Model: {name} heading.
+
+    Args:
+        content: threats.md content.
+        title_override: If provided, use this instead of auto-detected name.
+
+    Returns:
+        Project name string.
+    """
+    if title_override:
+        return title_override
+
+    match = re.search(r"^#\s+Threat Model:\s*(.+)$", content, re.MULTILINE)
+    if match:
+        return match.group(1).strip()
+
+    return "Unknown Project"
+
+
+# =============================================================================
+# Artifact Detection
+# =============================================================================
+
+def detect_artifacts(target_dir: Path) -> dict:
+    """Scan target directory for tachi pipeline artifacts.
+
+    Returns dict with boolean flags for each artifact type.
+    """
+    artifacts = {
+        "threats_md": False,
+        "risk_scores_md": False,
+        "compensating_controls_md": False,
+        "threat_report_md": False,
+        "funnel_image": False,
+        "baseball_image": False,
+        "architecture_image": False,
+    }
+
+    files = {
+        "threats_md": "threats.md",
+        "risk_scores_md": "risk-scores.md",
+        "compensating_controls_md": "compensating-controls.md",
+        "threat_report_md": "threat-report.md",
+        "funnel_image": "threat-risk-funnel.jpg",
+        "baseball_image": "threat-baseball-card.jpg",
+        "architecture_image": "threat-system-architecture.jpg",
+    }
+
+    for key, filename in files.items():
+        filepath = target_dir / filename
+        if filepath.exists():
+            size = filepath.stat().st_size
+            if size > 0:
+                artifacts[key] = True
+            else:
+                print(f"Warning: skipping {filename}: file is empty (0 bytes)", file=sys.stderr)
+
+    return artifacts
+
+
+# =============================================================================
+# Tier Selection
+# =============================================================================
+
+def determine_tier(artifacts: dict) -> int:
+    """Determine data source tier from detected artifacts.
+
+    Tier 1: compensating-controls.md exists
+    Tier 2: risk-scores.md exists (no compensating-controls.md)
+    Tier 3: threats.md only
+    """
+    if artifacts["compensating_controls_md"]:
+        return 1
+    elif artifacts["risk_scores_md"]:
+        return 2
+    else:
+        return 3
+
+
+# =============================================================================
+# Severity Parsers
+# =============================================================================
+
+def parse_threats_severity(content: str) -> dict:
+    """Parse Section 6 Risk Summary table from threats.md.
+
+    Extracts Critical, High, Medium, Low, Note counts and total.
+    Handles "N (M raw)" format in Total row — uses raw count.
+    Note: Section 6 may contain a calibration matrix before the severity table.
+    """
+    severity = {
+        "critical": 0, "high": 0, "medium": 0, "low": 0, "note": 0, "total": 0,
+    }
+
+    rows = parse_markdown_table(content, "## 6. Risk Summary")
+    # Section 6 may have a calibration matrix before the severity table.
+    # Check if the found table has "Risk Level" column; if not, find the right one.
+    if rows and "Risk Level" not in rows[0]:
+        rows = _find_table_with_column(content, "## 6. Risk Summary", "Risk Level")
+    if not rows:
+        rows = parse_markdown_table(content, "Risk Summary")
+    if rows and "Risk Level" not in rows[0]:
+        rows = []
+    if not rows:
+        print("Warning: could not find Risk Summary table in threats.md", file=sys.stderr)
+        return severity
+
+    for row in rows:
+        level = row.get("Risk Level", "").strip()
+        count_str = row.get("Count", "").strip()
+
+        if level.lower() == "total" or level.startswith("Total"):
+            # Handle "30 (34 raw)" format
+            total_match = re.match(r"(\d+)(?:\s*\((\d+)\s*raw\))?", count_str)
+            if total_match:
+                raw = total_match.group(2)
+                severity["total"] = int(raw) if raw else int(total_match.group(1))
+        elif level == "Critical":
+            severity["critical"] = _parse_int(count_str)
+        elif level == "High":
+            severity["high"] = _parse_int(count_str)
+        elif level == "Medium":
+            severity["medium"] = _parse_int(count_str)
+        elif level == "Low":
+            severity["low"] = _parse_int(count_str)
+        elif level == "Note":
+            severity["note"] = _parse_int(count_str)
+
+    return severity
+
+
+def parse_risk_scores_severity(content: str) -> dict:
+    """Parse risk-scores.md Section 1 severity distribution table.
+
+    Preferred over threats.md when Tier 2.
+    """
+    severity = {
+        "critical": 0, "high": 0, "medium": 0, "low": 0, "note": 0, "total": 0,
+    }
+
+    rows = parse_markdown_table(content, "Severity Distribution")
+    if not rows:
+        rows = parse_markdown_table(content, "## 1. Executive Summary")
+    if not rows:
+        print("Warning: could not find severity distribution in risk-scores.md", file=sys.stderr)
+        return severity
+
+    for row in rows:
+        level = row.get("Severity", "").strip()
+        count_str = row.get("Count", "").strip()
+
+        if level.lower() == "total" or level.startswith("Total"):
+            total_match = re.match(r"(\d+)(?:\s*\((\d+)\s*raw\))?", count_str)
+            if total_match:
+                raw = total_match.group(2)
+                severity["total"] = int(raw) if raw else int(total_match.group(1))
+        elif level == "Critical":
+            severity["critical"] = _parse_int(count_str)
+        elif level == "High":
+            severity["high"] = _parse_int(count_str)
+        elif level == "Medium":
+            severity["medium"] = _parse_int(count_str)
+        elif level == "Low":
+            severity["low"] = _parse_int(count_str)
+        elif level == "Note":
+            severity["note"] = _parse_int(count_str)
+
+    return severity
+
+
+def _parse_int(s: str) -> int:
+    """Safely parse an integer from a string, stripping non-numeric chars."""
+    match = re.search(r"\d+", s)
+    return int(match.group()) if match else 0
+
+
+# =============================================================================
+# Findings Parsers
+# =============================================================================
+
+def parse_threats_findings(content: str) -> list:
+    """Parse Section 7 Recommended Actions table for Tier 3 findings.
+
+    Returns list of finding dicts with Tier 3 keys.
+    """
+    rows = parse_markdown_table(content, "## 7. Recommended Actions")
+    if not rows:
+        print("Warning: could not find Recommended Actions table in threats.md", file=sys.stderr)
+        return []
+
+    findings = []
+    for row in rows:
+        findings.append({
+            "id": row.get("Finding ID", "").strip(),
+            "component": row.get("Component", "").strip(),
+            "threat": row.get("Threat", "").strip(),
+            "likelihood": "\u2014",  # em dash
+            "impact": "\u2014",
+            "risk_level": row.get("Risk Level", "").strip(),
+            "mitigation": row.get("Mitigation", "").strip(),
+        })
+    return findings
+
+
+def parse_risk_scores_findings(content: str) -> list:
+    """Parse risk-scores.md Section 2 Scored Threat Table for Tier 2 findings."""
+    rows = parse_markdown_table(content, "## 2. Scored Threat Table")
+    if not rows:
+        print("Warning: could not find Scored Threat Table in risk-scores.md", file=sys.stderr)
+        return []
+
+    findings = []
+    for row in rows:
+        findings.append({
+            "id": row.get("ID", "").strip(),
+            "component": row.get("Component", "").strip(),
+            "threat": row.get("Threat", "").strip(),
+            "composite_score": row.get("Composite", "").strip(),
+            "severity": row.get("Severity", "").strip(),
+            "cvss": row.get("CVSS", "").strip(),
+            "exploitability": row.get("Exploit.", "").strip(),
+        })
+    return findings
+
+
+# =============================================================================
+# Component Distribution
+# =============================================================================
+
+def parse_component_distribution(findings: list) -> list:
+    """Count findings per component, sorted by count descending."""
+    counts = {}
+    for f in findings:
+        comp = f.get("component", "")
+        if comp:
+            counts[comp] = counts.get(comp, 0) + 1
+
+    # Sort by count descending, then by name ascending for determinism
+    return sorted(counts.items(), key=lambda x: (-x[1], x[0]))
+
+
+# =============================================================================
+# Scope Data Parser
+# =============================================================================
+
+def parse_scope_data(content: str) -> dict:
+    """Parse scope data from threats.md Sections 1-2.
+
+    Extracts components, data flows, trust zones, and boundary crossings.
+    """
+    result = {
+        "components": [],
+        "data_flows": [],
+        "trust_boundaries": [],
+        "boundary_crossings": [],
+    }
+
+    # Section 1: Components table
+    comp_rows = parse_markdown_table(content, "### Components")
+    for row in comp_rows:
+        result["components"].append({
+            "name": row.get("Component", "").strip(),
+            "type": row.get("Type", "").strip(),
+            "description": row.get("Description", "").strip(),
+        })
+
+    # Section 1: Data Flows table
+    df_rows = parse_markdown_table(content, "### Data Flows")
+    for row in df_rows:
+        result["data_flows"].append({
+            "source": row.get("Source", "").strip(),
+            "destination": row.get("Destination", "").strip(),
+            "data": row.get("Data", "").strip(),
+            "protocol": row.get("Protocol", "").strip(),
+        })
+
+    # Section 2: Trust Zones table
+    tz_rows = parse_markdown_table(content, "### Trust Zones")
+    for row in tz_rows:
+        result["trust_boundaries"].append({
+            "zone": row.get("Zone", "").strip(),
+            "trust-level": row.get("Trust Level", "").strip(),
+            "components": row.get("Components", "").strip(),
+        })
+
+    # Section 2: Boundary Crossings table
+    bc_rows = parse_markdown_table(content, "### Boundary Crossings")
+    for row in bc_rows:
+        result["boundary_crossings"].append({
+            "crossing": row.get("Crossing", "").strip(),
+            "from-zone": row.get("From Zone", "").strip(),
+            "to-zone": row.get("To Zone", "").strip(),
+            "components": row.get("Components", "").strip(),
+            "controls": row.get("Controls", "").strip(),
+        })
+
+    if not result["components"] and not result["data_flows"]:
+        print("Warning: scope data not found in threats.md — scope page will show limited data", file=sys.stderr)
+
+    return result
+
+
+# =============================================================================
+# Threat Report Parser (T021)
+# =============================================================================
+
+def parse_threat_report_md(content: str) -> dict:
+    """Parse threat-report.md for executive narrative and remediation timeline.
+
+    Extracts:
+    - Executive narrative from Section 1: Risk Posture + Top 5 Threats + Key Recommendations
+      (truncated to 2000 chars)
+    - Remediation timeline entries from Section 1: Remediation Timeline subsection
+    """
+    result = {
+        "executive_narrative": None,
+        "remediation_timeline": [],
+    }
+
+    if not content or not content.strip():
+        return result
+
+    lines = content.split("\n")
+
+    # Find Section 1 boundaries
+    sec1_start = None
+    sec1_end = len(lines)
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s+1\.\s+Executive Summary", line):
+            sec1_start = i + 1
+        elif sec1_start is not None and re.match(r"^##\s+\d+\.", line):
+            sec1_end = i
+            break
+
+    if sec1_start is None:
+        return result
+
+    # Identify subsection boundaries within Section 1
+    subsections = {}  # name -> [start_line, end_line]
+    sub_order = []
+    for i in range(sec1_start, sec1_end):
+        match = re.match(r"^###\s+(.+)", lines[i])
+        if match:
+            name = match.group(1).strip()
+            subsections[name] = [i + 1, sec1_end]
+            sub_order.append(name)
+            # Close previous subsection
+            if len(sub_order) >= 2:
+                subsections[sub_order[-2]][1] = i
+
+    # Build executive narrative from: Risk Posture, Top 5 Threats, Key Recommendations
+    narrative_sections = [
+        "Risk Posture",
+        "Top 5 Threats by Business Impact",
+        "Key Recommendations",
+    ]
+    narrative_parts = []
+    for name in narrative_sections:
+        if name in subsections:
+            start, end = subsections[name]
+            text = "\n".join(lines[start:end]).strip()
+            if text:
+                narrative_parts.append(text)
+
+    if narrative_parts:
+        narrative = "\n\n".join(narrative_parts)
+        if len(narrative) > 2000:
+            narrative = narrative[:2000]
+        result["executive_narrative"] = narrative
+
+    # Parse Remediation Timeline
+    if "Remediation Timeline" in subsections:
+        start, end = subsections["Remediation Timeline"]
+        for i in range(start, end):
+            line = lines[i].strip()
+            if line.startswith("- **"):
+                match = re.match(
+                    r"^-\s+\*\*(\w[\w\-]*)\*\*\s+\((\d+)\s+(\w+)\s+findings?\)",
+                    line,
+                )
+                if match:
+                    result["remediation_timeline"].append({
+                        "timeline": match.group(1),
+                        "count": int(match.group(2)),
+                        "severity": match.group(3),
+                    })
+
+    return result
+
+
+# =============================================================================
+# Compensating Controls Parser (T022)
+# =============================================================================
+
+def parse_compensating_controls_md(content: str) -> dict:
+    """Parse compensating-controls.md for Tier 1 data.
+
+    Extracts:
+    - Tier 1 findings from Section 2 Coverage Matrix (by residual severity)
+    - STRIDE coverage matrix (derived from findings by threat ID prefix)
+    - Coverage summary from Section 1 Coverage Distribution
+    - Controls from Section 3 Control Details
+    - Recommendations from Section 4 (merged into findings)
+    - Severity counts from residual severity of findings
+    """
+    result = {
+        "findings": [],
+        "coverage_matrix": [],
+        "controls": [],
+        "coverage_summary": {"total-found": 0, "total-partial": 0, "total-missing": 0},
+        "severity": {"critical": 0, "high": 0, "medium": 0, "low": 0, "note": 0, "total": 0},
+    }
+
+    if not content or not content.strip():
+        return result
+
+    lines = content.split("\n")
+
+    # ---- Section 4: Recommendations (parse first to merge into findings) ----
+    recommendations = {}  # threat_id -> recommendation text
+    sec4_start = None
+    sec4_end = len(lines)
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s+4\.\s+Recommendations", line):
+            sec4_start = i + 1
+        elif sec4_start is not None and re.match(r"^##\s+\d+\.", line):
+            sec4_end = i
+            break
+
+    if sec4_start is not None:
+        current_threat_id = None
+        for i in range(sec4_start, sec4_end):
+            line = lines[i].strip()
+            # Match: #### 1. S-3 — Component (Composite: 9.2, Critical)
+            heading_match = re.match(r"^####\s+\d+\.\s+(\S+)\s+[—\-]", line)
+            if heading_match:
+                current_threat_id = heading_match.group(1)
+                continue
+            # Match: **What to Implement**: text
+            if current_threat_id and line.startswith("**What to Implement**:"):
+                rec_text = line.replace("**What to Implement**:", "").strip()
+                # Read continuation lines until next marker
+                for j in range(i + 1, sec4_end):
+                    next_line = lines[j].strip()
+                    if not next_line or next_line.startswith("**") or next_line.startswith("####") or next_line.startswith("###") or next_line.startswith("---"):
+                        break
+                    rec_text += " " + next_line
+                recommendations[current_threat_id] = rec_text.strip()
+                current_threat_id = None
+
+    # ---- Section 2: Coverage Matrix findings ----
+    for severity_label in ["Critical", "High", "Medium", "Low"]:
+        header = f"### {severity_label} Residual Severity"
+        rows = parse_markdown_table(content, header)
+        for row in rows:
+            threat_id = row.get("Threat ID", "").strip()
+            result["findings"].append({
+                "id": threat_id,
+                "component": row.get("Component", "").strip(),
+                "threat": row.get("Threat", "").strip(),
+                "residual_score": row.get("Residual Score", "").strip(),
+                "residual_severity": row.get("Residual Severity", severity_label).strip(),
+                "control_status": row.get("Control Status", "").strip(),
+                "recommendation": recommendations.get(threat_id, ""),
+            })
+
+    # ---- Compute Tier 1 severity counts from residual severity ----
+    for f in result["findings"]:
+        key = f["residual_severity"].lower()
+        if key in result["severity"]:
+            result["severity"][key] += 1
+    result["severity"]["total"] = len(result["findings"])
+
+    # ---- Derive STRIDE coverage matrix from findings ----
+    stride_counts = {}
+    for f in result["findings"]:
+        fid = f["id"]
+        category = None
+        for prefix, cat_name in STRIDE_PREFIXES.items():
+            if fid.startswith(prefix):
+                category = cat_name
+                break
+        if category is None:
+            category = "Other"
+
+        if category not in stride_counts:
+            stride_counts[category] = {"found": 0, "partial": 0, "missing": 0}
+
+        status = f["control_status"].lower()
+        if "partial" in status:
+            stride_counts[category]["partial"] += 1
+        elif "found" in status and "no" not in status:
+            stride_counts[category]["found"] += 1
+        else:
+            stride_counts[category]["missing"] += 1
+
+    stride_order = [
+        "Spoofing", "Tampering", "Repudiation", "Information Disclosure",
+        "Denial of Service", "Elevation of Privilege", "Agentic Threats", "LLM Threats",
+    ]
+    for cat in stride_order:
+        if cat in stride_counts:
+            result["coverage_matrix"].append({
+                "category": cat,
+                "found": stride_counts[cat]["found"],
+                "partial": stride_counts[cat]["partial"],
+                "missing": stride_counts[cat]["missing"],
+            })
+    if "Other" in stride_counts:
+        result["coverage_matrix"].append({
+            "category": "Other",
+            "found": stride_counts["Other"]["found"],
+            "partial": stride_counts["Other"]["partial"],
+            "missing": stride_counts["Other"]["missing"],
+        })
+
+    # ---- Coverage Summary from Section 1 Coverage Distribution ----
+    found_summary = False
+    cov_rows = parse_markdown_table(content, "Coverage Distribution")
+    if not cov_rows:
+        cov_rows = parse_markdown_table(content, "## 1. Executive Summary")
+
+    for row in cov_rows:
+        status = row.get("Status", "").strip()
+        count_str = row.get("Count", "").strip()
+        count = _parse_int(count_str)
+
+        if "Partial" in status:
+            result["coverage_summary"]["total-partial"] = count
+            found_summary = True
+        elif "No Control" in status or "Missing" in status:
+            result["coverage_summary"]["total-missing"] = count
+            found_summary = True
+        elif "Found" in status:
+            result["coverage_summary"]["total-found"] = count
+            found_summary = True
+
+    # Fallback: derive from findings if table not found
+    if not found_summary and result["findings"]:
+        for f in result["findings"]:
+            status = f["control_status"].lower()
+            if "partial" in status:
+                result["coverage_summary"]["total-partial"] += 1
+            elif "found" in status and "no" not in status:
+                result["coverage_summary"]["total-found"] += 1
+            else:
+                result["coverage_summary"]["total-missing"] += 1
+
+    # ---- Section 3: Control Details ----
+    sec3_start = None
+    sec3_end = len(lines)
+    for i, line in enumerate(lines):
+        if re.match(r"^##\s+3\.\s+Control Details", line):
+            sec3_start = i + 1
+        elif sec3_start is not None and re.match(r"^##\s+\d+\.", line):
+            sec3_end = i
+            break
+
+    if sec3_start is not None:
+        current_category = ""
+        i = sec3_start
+        while i < sec3_end:
+            line = lines[i].strip()
+
+            # Category heading (### level)
+            cat_match = re.match(r"^###\s+(.+)", line)
+            if cat_match:
+                current_category = cat_match.group(1).strip()
+                i += 1
+                continue
+
+            # Control metadata: **Category**: X | **Status**: Y | **Effectiveness**: Z
+            if "**Status**:" in line and "**Effectiveness**:" in line:
+                status_match = re.search(r"\*\*Status\*\*:\s*([\w\s]+?)(?:\s*\||\s*$)", line)
+                eff_match = re.search(r"\*\*Effectiveness\*\*:\s*(\w+)", line)
+                cat_match2 = re.search(r"\*\*Category\*\*:\s*([\w\s/]+?)(?:\s*\||\s*$)", line)
+
+                status = status_match.group(1).strip() if status_match else ""
+                effectiveness = eff_match.group(1).strip() if eff_match else ""
+                category = cat_match2.group(1).strip() if cat_match2 else current_category
+
+                # Look ahead for evidence and component
+                evidence = ""
+                component = ""
+                for j in range(i + 1, min(i + 30, sec3_end)):
+                    next_line = lines[j].strip()
+                    if next_line.startswith("####") or next_line.startswith("### "):
+                        break
+                    if "**Detected in**:" in next_line:
+                        ev_match = re.search(r"\*\*Detected in\*\*:\s*`([^`]+)`", next_line)
+                        if ev_match:
+                            evidence = ev_match.group(1)
+                    # Get component from first row of Threats Mitigated table
+                    if "Threats Mitigated" in next_line:
+                        k = j + 1
+                        while k < sec3_end and not lines[k].strip().startswith("|"):
+                            k += 1
+                        # Skip header + separator
+                        k += 2
+                        if k < sec3_end and lines[k].strip().startswith("|"):
+                            cells = [c.strip() for c in lines[k].split("|")[1:-1]]
+                            if len(cells) >= 2:
+                                component = strip_bold(cells[1])
+
+                result["controls"].append({
+                    "component": component,
+                    "category": category,
+                    "status": status,
+                    "evidence": evidence,
+                    "effectiveness": effectiveness,
+                })
+
+            i += 1
+
+    return result
+
+
+# =============================================================================
+# Remediation Actions (T023)
+# =============================================================================
+
+def build_remediation_actions(findings: list, tier: int,
+                               cc_data: dict = None,
+                               tr_data: dict = None) -> list:
+    """Build remediation actions using source priority.
+
+    Priority:
+    1. compensating-controls.md recommendations (Tier 1 — findings have recommendation field)
+    2. threat-report.md Remediation Timeline (Tier 2/3 — severity-based SLA)
+    3. None (no remediation source available)
+    """
+    if not findings:
+        return None
+
+    # Source 1: Compensating controls (Tier 1)
+    if tier == 1 and cc_data is not None:
+        actions = []
+        for f in findings:
+            severity = f.get("residual_severity", "")
+            actions.append({
+                "severity": severity,
+                "finding-id": f.get("id", ""),
+                "finding-name": f.get("threat", ""),
+                "recommendation": f.get("recommendation", ""),
+                "sla": SLA_BY_SEVERITY.get(severity, "90d"),
+                "status": f.get("control_status", "pending"),
+            })
+        return actions if actions else None
+
+    # Source 2: Threat report with remediation timeline
+    if tr_data is not None and tr_data.get("remediation_timeline"):
+        actions = []
+        for f in findings:
+            if tier == 2:
+                severity = f.get("severity", "")
+                rec_text = f.get("threat", "")
+            else:  # tier == 3
+                severity = f.get("risk_level", "")
+                rec_text = f.get("mitigation", "")
+            actions.append({
+                "severity": severity,
+                "finding-id": f.get("id", ""),
+                "finding-name": f.get("threat", ""),
+                "recommendation": rec_text,
+                "sla": SLA_BY_SEVERITY.get(severity, "90d"),
+                "status": "pending",
+            })
+        return actions if actions else None
+
+    # Source 3: No remediation source
+    return None
+
+
+# =============================================================================
+# Validation
+# =============================================================================
+
+def validate(data: dict) -> list:
+    """Validate internal consistency of extracted data.
+
+    Returns list of error messages. Empty list means valid.
+    """
+    errors = []
+    sev = data["severity"]
+
+    # Check severity sum: critical + high + medium + low == total - note
+    expected = sev["critical"] + sev["high"] + sev["medium"] + sev["low"]
+    actual = sev["total"] - sev["note"]
+    if expected != actual:
+        errors.append(
+            f"Severity sum mismatch: critical({sev['critical']}) + high({sev['high']}) + "
+            f"medium({sev['medium']}) + low({sev['low']}) = {expected}, "
+            f"but total({sev['total']}) - note({sev['note']}) = {actual}"
+        )
+
+    # Check finding ID uniqueness
+    ids = [f["id"] for f in data["findings"]]
+    seen = set()
+    for fid in ids:
+        if fid in seen:
+            errors.append(f"Duplicate finding ID: {fid}")
+        seen.add(fid)
+
+    # Check scope counts
+    scope_comp_count = len(data["scope_components"])
+    scope_df_count = len(data["scope_data_flows"])
+    scope_tb_count = len(data["scope_trust_boundaries"])
+
+    # These are self-consistent by construction (count == len), but
+    # we validate for future-proofing if counts are set independently
+    if "scope_component_count" in data and data["scope_component_count"] != scope_comp_count:
+        errors.append(
+            f"Scope component count mismatch: count={data['scope_component_count']}, "
+            f"actual={scope_comp_count}"
+        )
+    if "scope_data_flow_count" in data and data["scope_data_flow_count"] != scope_df_count:
+        errors.append(
+            f"Scope data flow count mismatch: count={data['scope_data_flow_count']}, "
+            f"actual={scope_df_count}"
+        )
+
+    return errors
+
+
+# =============================================================================
+# Image and Brand Asset Detection
+# =============================================================================
+
+def detect_images(target_dir: Path, template_dir: Path) -> dict:
+    """Compute image paths relative to template directory."""
+    # Compute relative path from template_dir to target_dir
+    # Template files are at templates/tachi/security-report/
+    # Images are at {target_dir}/threat-*.jpg
+    # Relative path: ../../{target_dir}/
+    try:
+        rel_target = os.path.relpath(str(target_dir), str(template_dir))
+    except ValueError:
+        # Fallback for cross-drive paths on Windows
+        rel_target = str(target_dir)
+
+    images = {
+        "funnel_image_path": "",
+        "baseball_image_path": "",
+        "architecture_image_path": "",
+    }
+
+    image_files = {
+        "funnel_image_path": "threat-risk-funnel.jpg",
+        "baseball_image_path": "threat-baseball-card.jpg",
+        "architecture_image_path": "threat-system-architecture.jpg",
+    }
+
+    for key, filename in image_files.items():
+        filepath = target_dir / filename
+        if filepath.exists() and filepath.stat().st_size > 0:
+            images[key] = rel_target + "/" + filename
+
+    return images
+
+
+def detect_brand_assets(template_dir: Path) -> dict:
+    """Check for brand logo files and compute relative paths."""
+    brand_dir = Path("brand/final")
+    result = {
+        "has_logo_primary": False,
+        "has_logo_horizontal": False,
+        "logo_primary_path": None,
+        "logo_primary_dark_path": None,
+        "logo_horizontal_path": None,
+    }
+
+    try:
+        rel_brand = os.path.relpath(str(brand_dir), str(template_dir))
+    except ValueError:
+        rel_brand = str(brand_dir)
+
+    logo_files = {
+        "logo_primary_path": "tachi-logo-primary.png",
+        "logo_primary_dark_path": "tachi-logo-primary-dark.png",
+        "logo_horizontal_path": "tachi-logo-horizontal.png",
+    }
+
+    for key, filename in logo_files.items():
+        filepath = brand_dir / filename
+        if filepath.exists() and filepath.stat().st_size > 0:
+            result[key] = rel_brand + "/" + filename
+
+    if result["logo_primary_path"]:
+        result["has_logo_primary"] = True
+    if result["logo_horizontal_path"]:
+        result["has_logo_horizontal"] = True
+
+    return result
+
+
+# =============================================================================
+# Typst Output Generation
+# =============================================================================
+
+def generate_report_data_typ(data: dict) -> str:
+    """Generate complete report-data.typ content from parsed data."""
+    lines = []
+
+    # 3a: Header
+    lines.append("// =============================================================================")
+    lines.append("// Report Data: Auto-generated by tachi extract-report-data.py")
+    lines.append("// =============================================================================")
+    lines.append("// This file is generated at runtime and imported by main.typ.")
+    lines.append("// Do NOT edit manually — it will be overwritten on next generation.")
+    lines.append("// =============================================================================")
+    lines.append("")
+
+    # 3b: Metadata
+    lines.append("// --- Metadata ----------------------------------------------------------------")
+    lines.append(f'#let project-name = "{escape_typst_string(data["project_name"])}"')
+    lines.append(f'#let assessment-date = "{escape_typst_string(data["assessment_date"])}"')
+    if data["classification"]:
+        lines.append(f'#let classification = "{escape_typst_string(data["classification"])}"')
+    else:
+        lines.append("#let classification = none")
+    lines.append("")
+
+    # 3c: Severity Counts
+    sev = data["severity"]
+    lines.append("// --- Severity Counts ---------------------------------------------------------")
+    lines.append(f"#let critical-count = {sev['critical']}")
+    lines.append(f"#let high-count = {sev['high']}")
+    lines.append(f"#let medium-count = {sev['medium']}")
+    lines.append(f"#let low-count = {sev['low']}")
+    lines.append(f"#let note-count = {sev['note']}")
+    lines.append(f"#let total-findings = {sev['total']}")
+    lines.append("")
+
+    # 3d: Page Inclusion Flags
+    art = data["artifacts"]
+    lines.append("// --- Page Inclusion Flags ----------------------------------------------------")
+    lines.append(f"#let has-threat-report = {_typst_bool(art['threat_report_md'])}")
+    lines.append(f"#let has-risk-scores = {_typst_bool(art['risk_scores_md'])}")
+    lines.append(f"#let has-compensating-controls = {_typst_bool(art['compensating_controls_md'])}")
+    lines.append(f"#let has-funnel-image = {_typst_bool(art['funnel_image'])}")
+    lines.append(f"#let has-baseball-image = {_typst_bool(art['baseball_image'])}")
+    lines.append(f"#let has-architecture-image = {_typst_bool(art['architecture_image'])}")
+    lines.append("")
+
+    # 3e: Data Source Tier
+    lines.append("// --- Data Source Tier ---------------------------------------------------------")
+    lines.append(f"#let data-source-tier = {data['tier']}")
+    lines.append("")
+
+    # 3f: Image Paths
+    lines.append("// --- Image Paths (relative to templates/tachi/security-report/) --------------------")
+    lines.append(f'#let funnel-image-path = "{escape_typst_string(data["funnel_image_path"])}"')
+    lines.append(f'#let baseball-image-path = "{escape_typst_string(data["baseball_image_path"])}"')
+    lines.append(f'#let architecture-image-path = "{escape_typst_string(data["architecture_image_path"])}"')
+    lines.append("")
+
+    # 3g: Executive Narrative
+    lines.append("// --- Executive Narrative -----------------------------------------------------")
+    if data["executive_narrative"]:
+        lines.append(f'#let executive-narrative = "{escape_typst_string(data["executive_narrative"])}"')
+    else:
+        lines.append("#let executive-narrative = none")
+    lines.append("")
+
+    # 3h: Component Distribution
+    lines.append("// --- Component Distribution --------------------------------------------------")
+    if data["component_distribution"]:
+        lines.append("#let component-distribution = (")
+        for name, count in data["component_distribution"]:
+            lines.append(f'  ("{escape_typst_string(name)}", {count}),')
+        lines.append(")")
+    else:
+        lines.append("#let component-distribution = none")
+    lines.append("")
+
+    # 3i: Findings Array
+    tier = data["tier"]
+    lines.append(f"// --- Findings (Tier {tier}) -----------------------------------------------------")
+    findings = data["findings"]
+    if findings:
+        lines.append("#let findings = (")
+        for f in findings:
+            lines.append(f"  ({_format_finding(f, tier)}),")
+        lines.append(")")
+    else:
+        lines.append("#let findings = ()")
+    lines.append("")
+
+    # 3j: Coverage Matrix
+    lines.append("// --- Coverage Matrix ---------------------------------------------------------")
+    if data["coverage_matrix"]:
+        lines.append("#let coverage-matrix = (")
+        for entry in data["coverage_matrix"]:
+            lines.append(f'  (category: "{escape_typst_string(entry["category"])}", found: {entry["found"]}, partial: {entry["partial"]}, missing: {entry["missing"]}),')
+        lines.append(")")
+    else:
+        lines.append("#let coverage-matrix = ()")
+    lines.append("")
+
+    # 3k: Controls
+    lines.append("// --- Detailed Controls -------------------------------------------------------")
+    if data["controls"]:
+        lines.append("#let controls = (")
+        for c in data["controls"]:
+            lines.append(f'  (component: "{escape_typst_string(c["component"])}", category: "{escape_typst_string(c["category"])}", status: "{escape_typst_string(c["status"])}", evidence: "{escape_typst_string(c["evidence"])}", effectiveness: "{escape_typst_string(c["effectiveness"])}"),')
+        lines.append(")")
+    else:
+        lines.append("#let controls = ()")
+    lines.append("")
+
+    # 3l: Coverage Summary
+    cs = data["coverage_summary"]
+    lines.append("// --- Coverage Summary --------------------------------------------------------")
+    lines.append("#let coverage-summary = (")
+    lines.append(f"  total-found: {cs['total-found']},")
+    lines.append(f"  total-partial: {cs['total-partial']},")
+    lines.append(f"  total-missing: {cs['total-missing']},")
+    lines.append(")")
+    lines.append("")
+
+    # 3m: Remediation Actions
+    lines.append("// --- Remediation Actions -----------------------------------------------------")
+    if data["remediation_actions"]:
+        lines.append("#let remediation-actions = (")
+        for r in data["remediation_actions"]:
+            lines.append(f'  (severity: "{escape_typst_string(r["severity"])}", finding-id: "{escape_typst_string(r["finding-id"])}", finding-name: "{escape_typst_string(r["finding-name"])}", recommendation: "{escape_typst_string(r["recommendation"])}", sla: "{escape_typst_string(r["sla"])}", status: "{escape_typst_string(r["status"])}"),')
+        lines.append(")")
+    else:
+        lines.append("#let remediation-actions = none")
+    lines.append("")
+
+    # 3n: Scope Data
+    lines.append("// --- Scope Data (from threats.md Sections 1-2) ------------------------------")
+    _append_scope_array(lines, "scope-components", data["scope_components"],
+                        ["name", "type", "description"])
+    lines.append("")
+    _append_scope_array(lines, "scope-data-flows", data["scope_data_flows"],
+                        ["source", "destination", "data", "protocol"])
+    lines.append("")
+    _append_scope_array(lines, "scope-trust-boundaries", data["scope_trust_boundaries"],
+                        ["zone", "trust-level", "components"])
+    lines.append("")
+    _append_scope_array(lines, "scope-boundary-crossings", data["scope_boundary_crossings"],
+                        ["crossing", "from-zone", "to-zone", "components", "controls"])
+    lines.append("")
+    lines.append(f"#let scope-component-count = {len(data['scope_components'])}")
+    lines.append(f"#let scope-data-flow-count = {len(data['scope_data_flows'])}")
+    lines.append(f"#let scope-trust-boundary-count = {len(data['scope_trust_boundaries'])}")
+    lines.append("")
+
+    # 3o: Brand Assets
+    lines.append("// --- Brand Assets -----------------------------------------------------------")
+    lines.append(f"#let has-logo-primary = {_typst_bool(data['has_logo_primary'])}")
+    lines.append(f"#let has-logo-horizontal = {_typst_bool(data['has_logo_horizontal'])}")
+    lines.append(f"#let logo-primary-path = {_typst_str_or_none(data['logo_primary_path'])}")
+    lines.append(f"#let logo-primary-dark-path = {_typst_str_or_none(data['logo_primary_dark_path'])}")
+    lines.append(f"#let logo-horizontal-path = {_typst_str_or_none(data['logo_horizontal_path'])}")
+    lines.append("")
+
+    # 3p: Page Visibility
+    lines.append("// --- Page Visibility (defaults, overridden by report-config.typ) ------------")
+    lines.append("#let show-disclaimer = true")
+    lines.append("#let show-methodology = true")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def _typst_bool(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _typst_str_or_none(value) -> str:
+    if value is None:
+        return "none"
+    return f'"{escape_typst_string(str(value))}"'
+
+
+def _format_finding(f: dict, tier: int) -> str:
+    """Format a single finding dict as a Typst dictionary literal."""
+    esc = escape_typst_string  # shorthand
+
+    def _v(key, default=""):
+        return esc(f.get(key, default))
+
+    if tier == 1:
+        return (
+            'id: "' + _v("id") + '", '
+            'component: "' + _v("component") + '", '
+            'threat: "' + _v("threat") + '", '
+            'residual_score: "' + _v("residual_score") + '", '
+            'residual_severity: "' + _v("residual_severity") + '", '
+            'control_status: "' + _v("control_status") + '", '
+            'recommendation: "' + _v("recommendation") + '"'
+        )
+    elif tier == 2:
+        return (
+            'id: "' + _v("id") + '", '
+            'component: "' + _v("component") + '", '
+            'threat: "' + _v("threat") + '", '
+            'composite_score: "' + _v("composite_score") + '", '
+            'severity: "' + _v("severity") + '", '
+            'cvss: "' + _v("cvss") + '", '
+            'exploitability: "' + _v("exploitability") + '"'
+        )
+    else:  # tier == 3
+        em_dash = "\u2014"
+        return (
+            'id: "' + _v("id") + '", '
+            'component: "' + _v("component") + '", '
+            'threat: "' + _v("threat") + '", '
+            'likelihood: "' + _v("likelihood", em_dash) + '", '
+            'impact: "' + _v("impact", em_dash) + '", '
+            'risk_level: "' + _v("risk_level") + '", '
+            'mitigation: "' + _v("mitigation") + '"'
+        )
+
+
+def _append_scope_array(lines: list, var_name: str, items: list, keys: list):
+    """Append a Typst array of dicts for scope data."""
+    if items:
+        lines.append(f"#let {var_name} = (")
+        for item in items:
+            parts = ", ".join(
+                f'{k}: "{escape_typst_string(str(item.get(k, "")))}"' for k in keys
+            )
+            lines.append(f"  ({parts}),")
+        lines.append(")")
+    else:
+        lines.append(f"#let {var_name} = ()")
+
+
+# =============================================================================
+# CLI Entry Point
+# =============================================================================
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Extract structured data from tachi pipeline artifacts into a Typst data file."
+    )
+    parser.add_argument(
+        "--target-dir",
+        required=True,
+        help="Directory containing tachi pipeline artifacts (threats.md, etc.)",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        help="Output path for the generated report-data.typ file",
+    )
+    parser.add_argument(
+        "--template-dir",
+        required=True,
+        help="Path to templates/tachi/security-report/ directory",
+    )
+    parser.add_argument(
+        "--title",
+        default=None,
+        help="Title override for the report project name",
+    )
+    return parser
+
+
+def main():
+    parser = build_parser()
+    args = parser.parse_args()
+
+    target_dir = Path(args.target_dir)
+    output_path = Path(args.output)
+    template_dir = Path(args.template_dir)
+
+    # Artifact detection
+    artifacts = detect_artifacts(target_dir)
+
+    if not artifacts["threats_md"]:
+        print(f"Error: threats.md not found in {target_dir}", file=sys.stderr)
+        sys.exit(EXIT_MISSING_ARTIFACT)
+
+    # Tier selection
+    tier = determine_tier(artifacts)
+    print(f"Tier {tier} selected, parsing artifacts...", file=sys.stderr)
+
+    # Read threats.md (always required)
+    threats_content = (target_dir / "threats.md").read_text(encoding="utf-8")
+
+    # Parse frontmatter
+    frontmatter = parse_frontmatter(threats_content)
+
+    # Parse project name
+    project_name = parse_project_name(threats_content, args.title)
+
+    # Schema version check
+    if frontmatter["schema_version"] == "1.0":
+        print("Info: Schema v1.0 detected — correlated findings omitted", file=sys.stderr)
+
+    # Initialize data dict that accumulates all parsed data
+    data = {
+        "project_name": project_name,
+        "assessment_date": frontmatter["date"],
+        "classification": frontmatter["classification"],
+        "tier": tier,
+        "artifacts": artifacts,
+        "target_dir": str(target_dir),
+        "template_dir": str(template_dir),
+    }
+
+    # Parse severity counts and findings based on tier
+    cc_data = None
+    if tier == 1:
+        cc_content = (target_dir / "compensating-controls.md").read_text(encoding="utf-8")
+        cc_data = parse_compensating_controls_md(cc_content)
+        data["severity"] = cc_data["severity"]
+        data["findings"] = cc_data["findings"]
+        data["coverage_matrix"] = cc_data["coverage_matrix"]
+        data["controls"] = cc_data["controls"]
+        data["coverage_summary"] = cc_data["coverage_summary"]
+    elif tier == 2:
+        rs_content = (target_dir / "risk-scores.md").read_text(encoding="utf-8")
+        data["severity"] = parse_risk_scores_severity(rs_content)
+        data["findings"] = parse_risk_scores_findings(rs_content)
+        data["coverage_matrix"] = []
+        data["controls"] = []
+        data["coverage_summary"] = {"total-found": 0, "total-partial": 0, "total-missing": 0}
+    else:  # tier == 3
+        data["findings"] = parse_threats_findings(threats_content)
+        # Derive severity counts from findings array for consistency.
+        # Section 6 Risk Summary uses deduplication (correlation groups) which
+        # causes counts to diverge from the raw findings in Section 7.
+        sev = {"critical": 0, "high": 0, "medium": 0, "low": 0, "note": 0, "total": 0}
+        for f in data["findings"]:
+            level = f.get("risk_level", "")
+            if level == "Critical":
+                sev["critical"] += 1
+            elif level == "High":
+                sev["high"] += 1
+            elif level == "Medium":
+                sev["medium"] += 1
+            elif level == "Low":
+                sev["low"] += 1
+            elif level == "Note":
+                sev["note"] += 1
+        sev["total"] = len(data["findings"])
+        data["severity"] = sev
+        data["coverage_matrix"] = []
+        data["controls"] = []
+        data["coverage_summary"] = {"total-found": 0, "total-partial": 0, "total-missing": 0}
+
+    # Component distribution (from whichever findings source is active)
+    data["component_distribution"] = parse_component_distribution(data["findings"])
+
+    # Scope data from threats.md Sections 1-2
+    scope = parse_scope_data(threats_content)
+    data["scope_components"] = scope["components"]
+    data["scope_data_flows"] = scope["data_flows"]
+    data["scope_trust_boundaries"] = scope["trust_boundaries"]
+    data["scope_boundary_crossings"] = scope["boundary_crossings"]
+
+    # Executive narrative from threat-report.md
+    tr_data = None
+    if artifacts["threat_report_md"]:
+        tr_content = (target_dir / "threat-report.md").read_text(encoding="utf-8")
+        tr_data = parse_threat_report_md(tr_content)
+        data["executive_narrative"] = tr_data["executive_narrative"]
+    else:
+        data["executive_narrative"] = None
+
+    # Remediation actions with source priority (T023)
+    data["remediation_actions"] = build_remediation_actions(
+        data["findings"], tier, cc_data, tr_data
+    )
+
+    # Image paths (relative from template dir to target dir)
+    images = detect_images(target_dir, template_dir)
+    data["funnel_image_path"] = images["funnel_image_path"]
+    data["baseball_image_path"] = images["baseball_image_path"]
+    data["architecture_image_path"] = images["architecture_image_path"]
+
+    # Brand assets
+    brand = detect_brand_assets(template_dir)
+    data["has_logo_primary"] = brand["has_logo_primary"]
+    data["has_logo_horizontal"] = brand["has_logo_horizontal"]
+    data["logo_primary_path"] = brand["logo_primary_path"]
+    data["logo_primary_dark_path"] = brand["logo_primary_dark_path"]
+    data["logo_horizontal_path"] = brand["logo_horizontal_path"]
+
+    # Validate internal consistency
+    validation_errors = validate(data)
+    if validation_errors:
+        for err in validation_errors:
+            print(f"Validation error: {err}", file=sys.stderr)
+        sys.exit(EXIT_VALIDATION_FAILURE)
+
+    # Generate Typst output
+    typst_output = generate_report_data_typ(data)
+
+    # Write output
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(typst_output, encoding="utf-8")
+
+    finding_count = len(data["findings"])
+    print(f"report-data.typ generated ({finding_count} findings, Tier {tier})", file=sys.stderr)
+    sys.exit(EXIT_SUCCESS)
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/067-deterministic-report-data/NEXT-SESSION.md
+++ b/specs/067-deterministic-report-data/NEXT-SESSION.md
@@ -1,0 +1,46 @@
+# Session Continuation: Deterministic Report Data Extraction
+
+**Generated**: 2026-03-30 (Wave 3 completion)
+**Branch**: `067-deterministic-report-data`
+**Last Commit**: 739527a Merge pull request #65 (no feature commits yet — all changes uncommitted)
+
+## Completed This Session
+
+- **Wave 1** (T001-T007): Script skeleton, CLI, artifact detection, tier selection, core utilities (frontmatter, table parser, string escaping, project name)
+- **Wave 2** (T008-T014): Tier 2/3 severity parsers, findings parsers, component distribution, full Typst output generation (`generate_report_data_typ()`), main() wiring. **MVP verified: byte-identical output on two runs.**
+- **Wave 3** (T015-T020): Validation (severity sum + ID uniqueness + scope count checks), scope data parsing (components, data flows, trust zones, boundary crossings), image path computation, brand asset detection, report-assembler agent update (Steps 2-3 replaced with script invocation, renumbered to 3-step flow)
+- **P0 Checkpoint**: APPROVED_WITH_CONCERNS (F-003 image flag/path mismatch — fixed in Wave 3)
+
+## Current State
+
+- **Phase**: implement (Waves 1-3 of 5 complete)
+- **Uncommitted**: 8 files (script, agent update, specs, backlog)
+- **Tasks**: 20/32 complete (63%)
+
+### Key Files Modified
+- `scripts/extract-report-data.py` — NEW: ~550 line Python script (core complete, Tier 1 parsing remaining)
+- `.claude/agents/tachi/report-assembler.md` — MODIFIED: Steps 2-3 replaced with script invocation
+- `specs/067-deterministic-report-data/tasks.md` — T001-T020 marked [X]
+
+## Next Actions
+
+1. **Wave 4** (T021-T023): Implement `parse_threat_report_md()` for executive narrative extraction, `parse_compensating_controls_md()` for Tier 1 findings/coverage/controls, and remediation source priority logic
+2. **Wave 5** (T024-T032): Image/brand detection refinement (T024), schema v1.0 compat (T025), Tier 2 verification (T026), Tier 1 test fixture creation (T027), Tier 1/3 verification (T028-T029), E2E `/security-report` test (T030), byte-identical PDF test (T031), error handling tests (T032)
+3. **After all waves**: Final validation (architect + code-reviewer + security), security scan, completion report
+4. **Then**: `/aod.deliver 067` and `/aod.document`
+
+## Context Files
+
+- `specs/067-deterministic-report-data/spec.md` — Feature spec (27 FRs, 6 user stories)
+- `specs/067-deterministic-report-data/plan.md` — Implementation plan (single script + agent update)
+- `specs/067-deterministic-report-data/tasks.md` — Task breakdown (32 tasks, 5 waves)
+- `specs/067-deterministic-report-data/data-model.md` — Typst variable contract
+- `specs/067-deterministic-report-data/agent-assignments.md` — Wave definitions
+- `scripts/extract-report-data.py` — The implementation
+- `.claude/agents/tachi/report-assembler.md` — Updated agent prompt
+
+## Resume Command
+
+```bash
+claude "Resume Deterministic Report Data Extraction (branch: 067-deterministic-report-data). Waves 1-3 complete (20/32 tasks). Run /aod.build to continue with Wave 4."
+```

--- a/specs/067-deterministic-report-data/agent-assignments.md
+++ b/specs/067-deterministic-report-data/agent-assignments.md
@@ -1,0 +1,203 @@
+# Agent Assignments: Deterministic Report Data Extraction (067)
+
+**Date**: 2026-03-30
+**Feature Branch**: `067-deterministic-report-data`
+**Feasibility**: APPROVED
+**Total Tasks**: 32
+**Estimated Duration**: Optimistic 3h | Realistic 4h | Pessimistic 6h
+
+---
+
+## Agent Assignment Matrix
+
+| Task | Description | Agent (`subagent_type`) | Effort | Notes |
+|------|-------------|------------------------|--------|-------|
+| T001 | CLI skeleton with argparse | senior-backend-engineer | 10 min | Script creation |
+| T002 | Artifact detection function | senior-backend-engineer | 5 min | File existence checks |
+| T003 | Tier selection logic | senior-backend-engineer | 5 min | Conditional logic |
+| T004 | `parse_frontmatter()` | senior-backend-engineer | 10 min | Regex extraction |
+| T005 | `parse_markdown_table()` | senior-backend-engineer | 10 min | Core utility, gates all parsers |
+| T006 | `strip_bold()` + `escape_typst_string()` | senior-backend-engineer | 5 min | String utilities |
+| T007 | `parse_project_name()` | senior-backend-engineer | 5 min | Heading extraction |
+| T008 | `parse_threats_severity()` | senior-backend-engineer | 10 min | Section 6 table parsing |
+| T009 | `parse_threats_findings()` | senior-backend-engineer | 10 min | Section 7 table parsing |
+| T010 | `parse_risk_scores_severity()` | senior-backend-engineer | 10 min | risk-scores.md Section 1 |
+| T011 | `parse_risk_scores_findings()` | senior-backend-engineer | 10 min | risk-scores.md Section 2 |
+| T012 | `parse_component_distribution()` | senior-backend-engineer | 5 min | Count + sort |
+| T013 | `generate_report_data_typ()` | senior-backend-engineer | 15 min | Largest task -- ~25 variable categories |
+| T014 | Wire `main()` + verify determinism | senior-backend-engineer | 10 min | Integration + diff test |
+| T015 | `validate()` function | senior-backend-engineer | 10 min | Severity sum + ID uniqueness |
+| T016 | Note severity handling | senior-backend-engineer | 5 min | Parse Note row, exclude from sum |
+| T017 | `parse_scope_data()` | senior-backend-engineer | 20 min | 4 table types from 2 sections |
+| T018 | Scope validation extension | senior-backend-engineer | 5 min | Count assertions |
+| T019 | Update report-assembler agent | senior-backend-engineer | 10 min | Steps 2-3 replacement |
+| T020 | Preserve report-config.typ copy | senior-backend-engineer | 5 min | Agent orchestration concern |
+| T021 | `parse_threat_report_md()` | senior-backend-engineer | 10 min | Executive narrative extraction |
+| T022 | `parse_compensating_controls_md()` | senior-backend-engineer | 15 min | Coverage + controls parsing |
+| T023 | Remediation source priority | senior-backend-engineer | 10 min | 3-source priority chain |
+| T024 | `detect_images()` + `detect_brand_assets()` | senior-backend-engineer | 10 min | File existence + path computation |
+| T025 | Schema v1.0 compatibility | senior-backend-engineer | 5 min | Version check + skip logic |
+| T026 | Verify Tier 2 (agentic-app) | tester | 5 min | Run twice, diff, verify counts |
+| T027 | Create Tier 1 test fixture | senior-backend-engineer | 15 min | compensating-controls.md per schema |
+| T028 | Verify Tier 1 fixture | tester | 5 min | Run with fixture, verify output |
+| T029 | Verify Tier 3 scenario | tester | 5 min | Run without risk-scores.md |
+| T030 | E2E `/security-report` verification | tester | 10 min | Full pipeline, verify PDF |
+| T031 | Byte-identical PDF verification | tester | 5 min | Run twice, diff PDFs |
+| T032 | Error handling verification | tester | 5 min | Missing file + bad data tests |
+
+### Agent Workload Summary
+
+| Agent (`subagent_type`) | Tasks Assigned | Total Effort | Utilization |
+|------------------------|----------------|--------------|-------------|
+| senior-backend-engineer | 25 tasks | ~3h 15min | 81% |
+| tester | 5 tasks | ~30min | 13% |
+| code-reviewer | 2 reviews (post-MVP, post-complete) | ~15min | 6% |
+
+---
+
+## Parallel Execution Waves
+
+### Wave 1: Setup + Foundation (Phases 1-2)
+
+**Goal**: Script skeleton with CLI, artifact detection, and core utilities.
+**Duration**: ~50 min
+
+| Step | Tasks | Agent | Parallel? |
+|------|-------|-------|-----------|
+| 1a | T001 (CLI skeleton) | senior-backend-engineer | Sequential |
+| 1b | T002 (artifact detection) | senior-backend-engineer | Sequential (depends on T001) |
+| 1c | T003 (tier selection) | senior-backend-engineer | Sequential (depends on T002) |
+| 1d | T004, T005, T006 (frontmatter, table parser, string utils) | senior-backend-engineer | Parallel (3 independent functions) |
+| 1e | T007 (project name) | senior-backend-engineer | Sequential (after T004 for frontmatter context) |
+
+**Quality Gate**: Script runs, detects artifacts from `examples/agentic-app/sample-report/`, selects Tier 2, exits cleanly. Core utilities callable.
+
+---
+
+### Wave 2: MVP -- Tier 2 Determinism (Phase 3)
+
+**Goal**: Complete Tier 2 end-to-end parsing with determinism verification.
+**Duration**: ~60 min
+
+| Step | Tasks | Agent | Parallel? |
+|------|-------|-------|-----------|
+| 2a | T008, T009 (threats severity + findings) | senior-backend-engineer | Parallel (independent parsers) |
+| 2b | T010, T011 (risk-scores severity + findings) | senior-backend-engineer | Parallel (independent parsers) |
+| 2c | T012 (component distribution) | senior-backend-engineer | After T009 or T011 (needs findings) |
+| 2d | T013 (Typst generation) | senior-backend-engineer | After T008-T012 (needs all parsed data) |
+| 2e | T014 (wire main + verify) | senior-backend-engineer | After T013 |
+
+**Quality Gate**: Run script twice on `examples/agentic-app/sample-report/`, diff outputs. Zero differences. **MVP COMPLETE.**
+
+**Post-MVP Review**: code-reviewer validates script structure, naming conventions, and data-model.md contract compliance.
+
+---
+
+### Wave 3: Validation + Scope + Agent (Phases 4-6)
+
+**Goal**: Add validation, scope extraction, and agent integration.
+**Duration**: ~55 min
+
+| Step | Tasks | Agent | Parallel? |
+|------|-------|-------|-----------|
+| 3a | T015, T016 (validation + Note handling) | senior-backend-engineer | Parallel (independent additions) |
+| 3b | T017, T018 (scope parsing + scope validation) | senior-backend-engineer | Sequential (T018 depends on T017) |
+| 3c | T019, T020 (agent update + report-config) | senior-backend-engineer | After T014 complete (needs working script) |
+
+Steps 3a and 3b can run concurrently with 3c (different files: Python script vs agent markdown).
+
+**Quality Gate**: Validation catches injected errors (exit 2). Scope counts match source. `/security-report` invokes script and produces PDF.
+
+---
+
+### Wave 4: Tier 1 + Recommendations (Phase 7)
+
+**Goal**: Complete all three tiers with recommendation extraction.
+**Duration**: ~35 min
+
+| Step | Tasks | Agent | Parallel? |
+|------|-------|-------|-----------|
+| 4a | T021 (threat-report parsing) | senior-backend-engineer | Parallel with 4b |
+| 4b | T022 (compensating-controls parsing) | senior-backend-engineer | Parallel with 4a |
+| 4c | T023 (remediation priority) | senior-backend-engineer | After T021 + T022 |
+
+**Quality Gate**: All three tiers produce valid output. Recommendations extracted verbatim. Tier 1 parsing complete.
+
+---
+
+### Wave 5: Testing + Polish (Phases 8-9)
+
+**Goal**: Full verification across all tiers, E2E PDF, error handling.
+**Duration**: ~65 min
+
+| Step | Tasks | Agent | Parallel? |
+|------|-------|-------|-----------|
+| 5a | T024 (image + brand detection) | senior-backend-engineer | Parallel with 5b |
+| 5b | T025 (schema v1.0 compat) | senior-backend-engineer | Parallel with 5a |
+| 5c | T027 (create Tier 1 fixture) | senior-backend-engineer | After T022 (needs controls parser) |
+| 5d | T026 (verify Tier 2) | tester | After Wave 2 complete |
+| 5e | T028 (verify Tier 1) | tester | After T027 (needs fixture) |
+| 5f | T029 (verify Tier 3) | tester | Parallel with T026/T028 |
+| 5g | T030 (E2E security-report) | tester | After Wave 3 (needs agent update) |
+| 5h | T031 (byte-identical PDF) | tester | After T030 |
+| 5i | T032 (error handling) | tester | Parallel with T030 |
+
+**Quality Gate**: All 3 tiers verified with determinism. E2E PDF generated. Error handling confirmed (exit 1 for missing file, exit 2 for bad data).
+
+**Final Review**: code-reviewer validates complete script for code quality, naming, edge case coverage, and data-model.md compliance.
+
+---
+
+## Wave Summary
+
+| Wave | Phases | Duration | Key Deliverable |
+|------|--------|----------|-----------------|
+| Wave 1 | 1-2 | ~50 min | Script skeleton + core utilities |
+| Wave 2 | 3 | ~60 min | **MVP: Tier 2 determinism verified** |
+| Wave 3 | 4-6 | ~55 min | Validation + scope + agent integration |
+| Wave 4 | 7 | ~35 min | All 3 tiers + recommendations |
+| Wave 5 | 8-9 | ~65 min | Full testing + E2E + polish |
+| **Total** | **1-9** | **~265 min (~4.4h)** | Feature complete |
+
+---
+
+## Quality Gates Between Waves
+
+| Gate | Between | Validation | Pass Criteria |
+|------|---------|-----------|---------------|
+| G1 | Wave 1 -> Wave 2 | Run script on example data | Exits cleanly, tier detected, no errors |
+| G2 | Wave 2 -> Wave 3 | **MVP gate**: diff two runs | Zero differences in output files |
+| G3 | Wave 3 -> Wave 4 | Validation + E2E | Exit code 2 on bad data; `/security-report` produces PDF |
+| G4 | Wave 4 -> Wave 5 | Tier coverage | All 3 tiers produce valid output |
+| G5 | Wave 5 exit | Final verification | All tester tasks pass; code-reviewer approves |
+
+**STOP-and-VALIDATE at G2**: This is the MVP checkpoint. If the diff test fails at G2, do not proceed to Wave 3. Debug determinism issues first.
+
+---
+
+## Time Estimates Per Wave
+
+| Wave | Optimistic | Realistic | Pessimistic |
+|------|-----------|-----------|-------------|
+| Wave 1 | 35 min | 50 min | 75 min |
+| Wave 2 | 45 min | 60 min | 90 min |
+| Wave 3 | 40 min | 55 min | 80 min |
+| Wave 4 | 25 min | 35 min | 50 min |
+| Wave 5 | 45 min | 65 min | 90 min |
+| **Total** | **190 min (3.2h)** | **265 min (4.4h)** | **385 min (6.4h)** |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation | Owner |
+|------|-----------|--------|------------|-------|
+| Table parsing edge cases not covered by research | Low | Medium | Edge cases documented in research.md; malformed rows skip with warning | senior-backend-engineer |
+| Typst string escaping produces invalid syntax | Low | Low | Only 3 escape rules; test with real data | senior-backend-engineer |
+| Tier 1 fixture does not match real pipeline output | Medium | Low | Schema at `schemas/compensating-controls.yaml` is authoritative | senior-backend-engineer |
+| PDF not byte-identical due to Typst metadata | Medium | Medium | Verify Typst does not inject timestamps; test at G2 | tester |
+| T013 (Typst generation) takes longer than estimated | Medium | Low | data-model.md specifies all variables; no ambiguity | senior-backend-engineer |
+
+---
+
+Signed: team-lead | 2026-03-30

--- a/specs/067-deterministic-report-data/checklists/requirements.md
+++ b/specs/067-deterministic-report-data/checklists/requirements.md
@@ -1,0 +1,44 @@
+# Specification Quality Checklist: Deterministic Report Data Extraction
+
+**Purpose**: Validate specification completeness and quality
+**Created**: 2026-03-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Architect PRD Concerns Addressed
+- [x] report-data.typ contract referenced (FR-024, Key Entities)
+- [x] Python script location specified (FR-026: scripts/extract-report-data.py)
+- [x] Total-findings dedup vs raw count resolved (FR-007, US-2 AC-3)
+- [x] Note severity handling specified (FR-027, US-2 AC-2, Edge Cases)
+- [x] Markdown parsing edge cases enumerated (Edge Cases section, FR-008, FR-022)
+- [x] Tier 1 test fixture creation included (US-6 AC-2, Assumptions)
+
+## Team-Lead PRD Clarifications Addressed
+- [x] Script location specified (FR-026)
+- [x] Exit codes defined (FR-020)
+- [x] risk-scores.md nested frontmatter handling (Edge Cases)
+- [x] Tier 1 test fixture noted as required (Assumptions, US-6)
+
+## Notes
+- All checklist items pass. Spec is ready for PM review.

--- a/specs/067-deterministic-report-data/data-model.md
+++ b/specs/067-deterministic-report-data/data-model.md
@@ -1,0 +1,143 @@
+# Data Model: Deterministic Report Data Extraction
+
+## Entities
+
+### ReportData (output: report-data.typ)
+
+The central entity representing all extracted data as Typst `#let` variable bindings.
+
+**Metadata Fields**:
+- `project-name`: string — extracted from `# Threat Model: {name}` or `--title` override
+- `assessment-date`: string (YYYY-MM-DD) — from threats.md frontmatter `date`
+- `classification`: string or none — from threats.md frontmatter `classification`
+
+**Severity Counts**:
+- `critical-count`: integer — count of Critical severity findings
+- `high-count`: integer — count of High severity findings
+- `medium-count`: integer — count of Medium severity findings
+- `low-count`: integer — count of Low severity findings
+- `note-count`: integer — count of Note severity findings (excluded from 4-level sum)
+- `total-findings`: integer — total individual findings (raw count if deduplicated)
+
+**Page Inclusion Flags**:
+- `has-threat-report`: boolean — threat-report.md exists and is non-empty
+- `has-risk-scores`: boolean — risk-scores.md exists and is non-empty
+- `has-compensating-controls`: boolean — compensating-controls.md exists and is non-empty
+- `has-funnel-image`: boolean — threat-risk-funnel.jpg exists and is non-zero
+- `has-baseball-image`: boolean — threat-baseball-card.jpg exists and is non-zero
+- `has-architecture-image`: boolean — threat-system-architecture.jpg exists and is non-zero
+
+**Data Source**:
+- `data-source-tier`: integer (1, 2, or 3)
+
+**Image Paths** (relative from templates/tachi/security-report/):
+- `funnel-image-path`: string or ""
+- `baseball-image-path`: string or ""
+- `architecture-image-path`: string or ""
+
+**Brand Assets**:
+- `has-logo-primary`: boolean
+- `has-logo-horizontal`: boolean
+- `logo-primary-path`: string or none
+- `logo-primary-dark-path`: string or none
+- `logo-horizontal-path`: string or none
+
+**Content**:
+- `executive-narrative`: string or none — from threat-report.md Section 1 (max 2000 chars)
+- `component-distribution`: array of (name, count) tuples or none
+- `findings`: array of tier-specific finding dicts
+- `coverage-matrix`: array of (category, found, partial, missing) dicts or empty
+- `controls`: array of (component, category, status, evidence, effectiveness) dicts or empty
+- `coverage-summary`: dict with total-found, total-partial, total-missing
+- `remediation-actions`: array of remediation dicts or none
+
+**Scope Data**:
+- `scope-components`: array of (name, type, description) dicts
+- `scope-data-flows`: array of (source, destination, data, protocol) dicts
+- `scope-trust-boundaries`: array of (zone, trust-level, components) dicts
+- `scope-boundary-crossings`: array of (crossing, from-zone, to-zone, components, controls) dicts
+- `scope-component-count`: integer
+- `scope-data-flow-count`: integer
+- `scope-trust-boundary-count`: integer
+
+**Page Visibility**:
+- `show-disclaimer`: boolean (default true)
+- `show-methodology`: boolean (default true)
+
+### Finding (tier-variant)
+
+**Tier 1** (from compensating-controls.md):
+- id, component, threat, residual_score, residual_severity, control_status, recommendation
+
+**Tier 2** (from risk-scores.md):
+- id, component, threat, composite_score, severity, cvss, exploitability
+
+**Tier 3** (from threats.md Section 7):
+- id, component, threat, likelihood ("—"), impact ("—"), risk_level, mitigation
+
+### ScopeComponent
+- name: string
+- type: string (External Entity, Process, Data Store)
+- description: string
+
+### ScopeDataFlow
+- source: string
+- destination: string
+- data: string
+- protocol: string
+
+### TrustBoundary
+- zone: string
+- trust-level: string
+- components: string
+
+### BoundaryCrossing
+- crossing: string
+- from-zone: string
+- to-zone: string
+- components: string
+- controls: string
+
+### CoverageEntry
+- category: string (STRIDE category name)
+- found: integer
+- partial: integer
+- missing: integer
+
+### ControlEntry
+- component: string
+- category: string
+- status: string (Found, Partial, Missing)
+- evidence: string
+- effectiveness: string (Strong, Moderate, Weak, None)
+
+### RemediationAction
+- severity: string
+- finding-id: string
+- finding-name: string
+- recommendation: string
+- sla: string
+- status: string
+
+## Validation Rules
+
+1. `critical-count + high-count + medium-count + low-count == total-findings - note-count`
+2. `len(scope-components) == scope-component-count`
+3. `len(scope-data-flows) == scope-data-flow-count`
+4. `len(scope-trust-boundaries) == scope-trust-boundary-count`
+5. All finding IDs in findings array are unique
+6. All string values in Typst output are properly escaped (`"` → `\"`, `\` → `\\`)
+
+## Tier Selection Logic
+
+```
+if compensating-controls.md exists and non-empty:
+    tier = 1
+    severity_source = count residual_severity from Section 2 findings
+elif risk-scores.md exists and non-empty:
+    tier = 2
+    severity_source = risk-scores.md Section 1 distribution table
+else:
+    tier = 3
+    severity_source = threats.md Section 6 Risk Summary table
+```

--- a/specs/067-deterministic-report-data/plan.md
+++ b/specs/067-deterministic-report-data/plan.md
@@ -1,0 +1,307 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-30
+    status: APPROVED
+    notes: "All 27 spec FRs covered. All 6 user stories addressed across 3 phases. No scope creep. Testing strategy covers determinism, all 3 tiers, validation, and E2E."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-30
+    status: APPROVED_WITH_CONCERNS
+    notes: "Architecturally sound. 2 minor concerns: (1) Tier 1 test fixture location underspecified — recommend examples/agentic-app/sample-report/compensating-controls.md. (2) report-config.typ copy behavior should remain in agent orchestration, not script. All 5 PRD concerns addressed. Typst variable contract verified."
+  techlead_signoff: null
+---
+
+# Implementation Plan: Deterministic Report Data Extraction
+
+**Branch**: `067-deterministic-report-data` | **Date**: 2026-03-30 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/067-deterministic-report-data/spec.md`
+
+## Summary
+
+Replace the LLM-based data extraction in the report-assembler agent (Steps 2-3) with a deterministic Python script that reads tachi pipeline markdown artifacts using regex and line parsing, validates internal consistency, and writes `report-data.typ`. The agent is reduced to orchestration: detect artifacts, invoke the script, compile with Typst.
+
+## Technical Context
+
+**Language/Version**: Python 3.9+ (standard library only: `re`, `pathlib`, `argparse`, `sys`, `os`)
+**Primary Dependencies**: None (zero external dependencies)
+**Storage**: File-based (markdown artifacts in → `report-data.typ` out)
+**Testing**: Direct script execution against example datasets + `diff` for determinism verification
+**Target Platform**: macOS, Linux, Windows (Python 3.9+ cross-platform)
+**Project Type**: Single script + agent prompt update
+**Performance Goals**: < 5 seconds for largest expected artifact set (64+ findings, 36 data flows)
+**Constraints**: Byte-identical output from identical input (determinism); Python stdlib only
+**Scale/Scope**: ~500-700 line Python script, ~100 line agent prompt delta
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. General-Purpose Architecture | PASS | Script is domain-specific to tachi report pipeline but does not modify core platform |
+| III. Backward Compatibility | PASS | No changes to Typst templates or variable contract; script produces identical data structure |
+| VI. Testing Excellence | PASS | Testing against two example datasets with all three tiers; determinism verified by diff |
+| VII. Definition of Done | PASS | Measurable success criteria: byte-identical output, validation checks, performance target |
+| IX. Git Workflow | PASS | Feature branch `067-deterministic-report-data`; PR required |
+| X. Product-Spec Alignment | PASS | Spec approved by PM; plan requires PM + Architect sign-off |
+
+No violations. All constitutional gates pass.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```
+specs/067-deterministic-report-data/
+├── plan.md              # This file
+├── research.md          # Research phase output
+├── data-model.md        # Typst variable contract and entity definitions
+├── quickstart.md        # Developer quickstart guide
+└── tasks.md             # Task breakdown (pending)
+```
+
+### Source Code (repository root)
+
+```
+scripts/
+└── extract-report-data.py    # NEW: Deterministic parsing script
+
+.claude/agents/tachi/
+└── report-assembler.md        # MODIFIED: Steps 2-3 replaced with script invocation
+
+examples/
+├── agentic-app/sample-report/ # EXISTING: Tier 2 test fixture
+│   ├── threats.md
+│   ├── risk-scores.md
+│   └── threat-report.md
+└── openclaw/                  # VERIFY: May need Tier 1/3 test fixtures
+```
+
+**Structure Decision**: Single Python script at `scripts/extract-report-data.py`. No package, no `src/` directory — this is a standalone CLI tool invoked by the agent via `python3 scripts/extract-report-data.py`.
+
+## Components
+
+### Component 1: Parsing Script (`scripts/extract-report-data.py`)
+
+**Purpose**: Deterministic extraction of structured data from markdown artifacts into Typst variable bindings.
+
+**Architecture**: Sequential pipeline with independent parser functions:
+
+```
+CLI args → Artifact detection → Tier selection
+  → Parse threats.md (frontmatter, project name, severity counts, scope, findings)
+  → Parse risk-scores.md (severity distribution, scored findings) [if Tier 2+]
+  → Parse compensating-controls.md (residual findings, coverage, controls) [if Tier 1]
+  → Parse threat-report.md (executive narrative, remediation) [if available]
+  → Detect brand assets
+  → Validate internal consistency
+  → Generate report-data.typ
+```
+
+**Key design decisions**:
+- Each artifact parser is an independent function returning a data dict
+- Parser functions take file content as string input (testable without filesystem)
+- Validation runs after all parsing, before output generation
+- Output generation is a single function that formats all data as Typst syntax
+- String escaping is centralized in one utility function
+
+### Component 2: Agent Prompt Update (`.claude/agents/tachi/report-assembler.md`)
+
+**Purpose**: Replace Steps 2-3 (LLM-based extraction and generation) with script invocation.
+
+**Changes**:
+- **Step 2** (Data Extraction): Replaced entirely. New Step 2 invokes:
+  ```bash
+  python3 scripts/extract-report-data.py \
+    --target-dir {target_dir} \
+    --output templates/tachi/security-report/report-data.typ \
+    --template-dir templates/tachi/security-report/ \
+    [--title "{title_override}"]
+  ```
+- **Step 3** (Typst Data Generation): Removed — script handles this
+- **Step 4** (Compilation): Unchanged — agent still invokes `typst compile`
+- **Error handling**: Agent checks script exit code (0=proceed, 1=abort with message, 2=abort with validation details)
+
+## Data Flow
+
+```
+Input Artifacts (target directory)           Parsing Script              Output
+┌────────────────────────────┐     ┌──────────────────────────┐     ┌──────────────┐
+│ threats.md        [required]│────▶│ parse_threats_md()       │────▶│              │
+│ risk-scores.md   [optional]│────▶│ parse_risk_scores_md()   │────▶│ report-      │
+│ compensating-    [optional]│────▶│ parse_comp_controls_md() │────▶│ data.typ     │
+│   controls.md              │     │ parse_threat_report_md() │     │              │
+│ threat-report.md [optional]│────▶│ detect_brand_assets()    │────▶│ (Typst #let  │
+│ *.jpg images     [optional]│────▶│ validate()               │     │  bindings)   │
+│ brand/final/*.png[optional]│────▶│ generate_typst()         │────▶│              │
+└────────────────────────────┘     └──────────────────────────┘     └──────────────┘
+                                            │                              │
+                                            │ exit 0/1/2                   │
+                                            ▼                              ▼
+                                   Agent (report-assembler)        typst compile
+                                   checks exit code                → security-report.pdf
+```
+
+## Tech Stack
+
+| Layer | Technology | Justification |
+|-------|-----------|---------------|
+| Script | Python 3.9+ stdlib | Zero-dependency, cross-platform, regex support |
+| Parsing | `re` module | Sufficient for markdown tables with known column layouts |
+| CLI | `argparse` | Standard Python CLI argument parsing |
+| File I/O | `pathlib` | Cross-platform path handling |
+| Output | String formatting | Deterministic Typst syntax generation |
+| Templates | Typst (unchanged) | Existing template system, no modifications |
+
+## Script Internal Design
+
+### Module Structure (single file)
+
+```python
+# 1. Constants and configuration
+SEVERITY_ORDER = ["Critical", "High", "Medium", "Low", "Note"]
+STRIDE_PREFIXES = {"S-": "Spoofing", "T-": "Tampering", ...}
+
+# 2. Utility functions
+def escape_typst_string(s: str) -> str: ...
+def strip_bold(s: str) -> str: ...
+def parse_markdown_table(lines: list, expected_cols: int) -> list[dict]: ...
+
+# 3. Frontmatter parser
+def parse_frontmatter(content: str) -> dict: ...
+
+# 4. Artifact parsers (one per artifact type)
+def parse_threats_md(content: str, title_override: str | None) -> dict: ...
+def parse_risk_scores_md(content: str) -> dict: ...
+def parse_compensating_controls_md(content: str) -> dict: ...
+def parse_threat_report_md(content: str) -> dict: ...
+
+# 5. Brand asset detection
+def detect_brand_assets(target_dir: Path, template_dir: Path) -> dict: ...
+
+# 6. Image path detection
+def detect_images(target_dir: Path, template_dir: Path) -> dict: ...
+
+# 7. Tier selection
+def determine_tier(target_dir: Path) -> int: ...
+
+# 8. Validation
+def validate(data: dict) -> list[str]: ...  # returns list of error messages
+
+# 9. Typst generation
+def generate_report_data_typ(data: dict) -> str: ...
+
+# 10. CLI entry point
+def main(): ...
+```
+
+### Markdown Table Parsing Strategy
+
+Tables are identified by:
+1. Finding a section header anchor (e.g., `## 6. Risk Summary`)
+2. Scanning forward for the first `|`-delimited row (header row)
+3. Skipping the separator row (`|---|---|`)
+4. Reading subsequent `|`-delimited rows until a non-table line
+
+Each row is split by `|`, stripped, and bold markers removed. Column values are mapped to named keys based on the expected column layout for that table.
+
+### Severity Count Extraction by Tier
+
+- **Tier 1**: Iterate findings from compensating-controls.md Section 2; count by `residual_severity` field
+- **Tier 2**: Parse risk-scores.md Section 1 severity distribution table directly (Critical/High/Medium/Low/Total rows)
+- **Tier 3**: Parse threats.md Section 6 Risk Summary table directly
+
+For Tiers 2 and 3, the Total row may contain "N (M raw)" format. Regex: `r'\*{0,2}(\d+)(?:\s*\((\d+)\s*raw\))?\*{0,2}'` — use group 2 (raw) if present, else group 1.
+
+### String Escaping
+
+Centralized in `escape_typst_string()`:
+```
+" → \"
+\ → \\
+newline → \n
+```
+
+Applied to all string values before Typst output generation. Numeric values and keywords (`true`, `false`, `none`) are not escaped.
+
+## Testing Strategy
+
+### Determinism Verification
+1. Run script on agentic-app example dataset → `report-data-1.typ`
+2. Run script again on same dataset → `report-data-2.typ`
+3. `diff report-data-1.typ report-data-2.typ` → zero differences
+
+### Tier Coverage
+| Tier | Test Dataset | Configuration |
+|------|-------------|---------------|
+| Tier 1 | Test fixture (to be created) | threats.md + risk-scores.md + compensating-controls.md |
+| Tier 2 | agentic-app/sample-report/ | threats.md + risk-scores.md + threat-report.md |
+| Tier 3 | Subset of agentic-app | threats.md only (rename/remove risk-scores.md temporarily) |
+
+### Validation Testing
+- Inject incorrect severity counts → verify exit code 2 with correct error message
+- Inject duplicate finding IDs → verify exit code 2
+- Remove threats.md → verify exit code 1
+
+### End-to-End
+- Run full `/security-report` on agentic-app dataset with updated agent
+- Verify PDF is generated and severity counts match source data
+- Run twice and verify byte-identical PDF output
+
+## Error Handling
+
+| Scenario | Exit Code | Behavior |
+|----------|-----------|----------|
+| threats.md missing | 1 | stderr: "Error: threats.md not found in {target_dir}" |
+| threats.md unparseable | 1 | stderr: "Error: could not parse threats.md: {details}" |
+| Optional artifact missing | 0 | Log warning to stderr, set flag false, continue |
+| Optional artifact malformed | 0 | Log warning to stderr, set flag false, continue |
+| Malformed table row | 0 | Log warning to stderr, skip row, continue |
+| Image file 0 bytes | 0 | Log warning to stderr, set flag false, continue |
+| Severity sum mismatch | 2 | stderr: "Validation error: severity sum {sum} != total {total}" |
+| Duplicate finding IDs | 2 | stderr: "Validation error: duplicate finding ID: {id}" |
+| Scope count mismatch | 2 | stderr: "Validation error: scope count mismatch: {details}" |
+
+## Implementation Phases
+
+### Phase 1: Core Parsing Script (P1 stories)
+- Implement CLI argument parsing
+- Implement artifact detection and tier selection
+- Implement threats.md parser (frontmatter, project name, severity, scope, findings)
+- Implement risk-scores.md parser (severity distribution, scored findings)
+- Implement Typst output generation
+- Test against agentic-app dataset (Tier 2)
+- Verify determinism with diff
+
+### Phase 2: Full Tier Support + Validation (P1 stories continued)
+- Implement compensating-controls.md parser (Tier 1 findings, coverage, controls)
+- Implement threat-report.md parser (executive narrative, remediation)
+- Implement brand asset and image detection
+- Implement validation rules
+- Create Tier 1 test fixture
+- Test all three tiers
+
+### Phase 3: Agent Integration + End-to-End (P1-P2 stories)
+- Update report-assembler.md (replace Steps 2-3 with script invocation)
+- End-to-end test: `/security-report` → PDF
+- Verify byte-identical PDF output
+- Test error handling (missing artifacts, validation failures)
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.
+
+## Post-Design Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. General-Purpose Architecture | PASS | Script is tachi-specific (report pipeline tool) |
+| III. Backward Compatibility | PASS | Same Typst variable contract; templates unchanged |
+| VI. Testing Excellence | PASS | 3 tiers tested, determinism verified, validation tested |
+| VII. Definition of Done | PASS | SC-001 through SC-007 are measurable and verifiable |
+| IX. Git Workflow | PASS | Feature branch; PR for review |
+| X. Product-Spec Alignment | PASS | Plan covers all 27 FRs from spec |
+
+All gates pass post-design.

--- a/specs/067-deterministic-report-data/quickstart.md
+++ b/specs/067-deterministic-report-data/quickstart.md
@@ -1,0 +1,57 @@
+# Quickstart: Deterministic Report Data Extraction
+
+## What Changed
+
+The `/security-report` command now uses a deterministic Python script instead of LLM-based parsing to extract data from threat model artifacts. Identical inputs always produce identical output.
+
+## Running the Script Directly
+
+```bash
+python3 scripts/extract-report-data.py \
+  --target-dir examples/agentic-app/sample-report \
+  --output report-data.typ \
+  --template-dir templates/tachi/security-report/
+```
+
+### Optional: Title Override
+```bash
+python3 scripts/extract-report-data.py \
+  --target-dir examples/agentic-app/sample-report \
+  --output report-data.typ \
+  --template-dir templates/tachi/security-report/ \
+  --title "My Custom Report Title"
+```
+
+## Exit Codes
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success — `report-data.typ` written |
+| 1 | Missing required artifact (threats.md) |
+| 2 | Validation failure (severity sum mismatch, duplicate IDs, etc.) |
+
+## Verifying Determinism
+
+```bash
+# Run twice
+python3 scripts/extract-report-data.py --target-dir examples/agentic-app/sample-report --output /tmp/run1.typ --template-dir templates/tachi/security-report/
+python3 scripts/extract-report-data.py --target-dir examples/agentic-app/sample-report --output /tmp/run2.typ --template-dir templates/tachi/security-report/
+
+# Compare
+diff /tmp/run1.typ /tmp/run2.typ
+# Expected: no output (files are identical)
+```
+
+## Using via /security-report (unchanged)
+
+The command works exactly the same as before — the script invocation is handled internally by the report-assembler agent:
+
+```
+/security-report examples/agentic-app/sample-report
+```
+
+## Prerequisites
+
+- Python 3.9+
+- Typst (for PDF compilation)
+- At minimum, a `threats.md` file in the target directory

--- a/specs/067-deterministic-report-data/research.md
+++ b/specs/067-deterministic-report-data/research.md
@@ -1,0 +1,87 @@
+# Research Summary: Deterministic Report Data Extraction
+
+## Knowledge Base Findings
+- No existing KB entries found for report generation, markdown parsing, or deterministic extraction patterns.
+
+## Codebase Analysis
+
+### Current Architecture (Being Replaced)
+- **Report-Assembler Agent**: `.claude/agents/tachi/report-assembler.md` (687 lines) — 4-step process: Artifact Detection → Data Extraction (LLM) → Typst Data Generation (LLM) → Compilation
+- **Security-Report Command**: `.claude/commands/security-report.md` (240 lines) — validates prerequisites, invokes agent, reports results
+- **Steps 2-3 are the problem**: LLM parses markdown tables and generates `report-data.typ` non-deterministically
+
+### Typst Template Data Contract
+- **Location**: `templates/tachi/security-report/` (15 files)
+- **Data file**: `report-data.typ` — ~25 variable categories with `#let` bindings
+- **Variables**: metadata (project-name, date, classification), severity counts (4 levels + total), page flags (8 booleans), image paths, content vectors (findings, coverage, controls, scope, remediation), scope data (4 table types with counts)
+- **Tier-specific findings keys**:
+  - Tier 1: id, component, threat, residual_score, residual_severity, control_status, recommendation
+  - Tier 2: id, component, threat, composite_score, severity, cvss, exploitability
+  - Tier 3: id, component, threat, likelihood, impact, risk_level, mitigation
+
+### Existing Python Scripts
+- `.claude/skills/~aod-build/scripts/` contains 3 Python scripts (update_index.py, analyze_tasks.py, generate_checkpoint.py) — none related to markdown parsing
+- No existing markdown-to-Typst parsing utilities in the repo
+
+### Example Datasets
+- **agentic-app**: `examples/agentic-app/sample-report/` — has threats.md (246 lines), risk-scores.md, threat-report.md. No compensating-controls.md example.
+- **openclaw**: `examples/openclaw/` — needs verification for test fixtures
+
+### Schemas (Machine-Readable Contracts)
+- `schemas/output.yaml` (165 lines) — threats.md structure
+- `schemas/risk-scoring.yaml` (103 lines) — risk-scores.md structure
+- `schemas/compensating-controls.yaml` (177 lines) — compensating-controls.md structure
+- `schemas/security-report.yaml` (179 lines) — page assembly contract
+
+## Technical Decisions
+
+### Decision 1: Script Location
+- **Decision**: `scripts/extract-report-data.py`
+- **Rationale**: Follows existing convention (`scripts/` directory at repo root). The `.claude/skills/` scripts are AOD lifecycle scripts; this is a product script.
+- **Alternatives**: `.claude/scripts/` (rejected — not an AOD lifecycle tool), `templates/tachi/security-report/extract.py` (rejected — script is not a template)
+
+### Decision 2: Python stdlib only (no PyYAML)
+- **Decision**: Use regex-based frontmatter parsing, no external dependencies
+- **Rationale**: Eliminates installation friction. tachi frontmatter is flat key-value pairs (date, classification, schema_version). risk-scores.md has nested `scoring_weights` but those values are not needed by the report.
+- **Alternatives**: PyYAML (rejected — adds external dependency for simple parsing), ruamel.yaml (rejected — same dependency issue)
+
+### Decision 3: Total findings count — use raw count
+- **Decision**: When Total row shows "30 (34 raw)", extract raw count (34) as `total-findings`
+- **Rationale**: Raw count matches the actual number of findings rows in the findings table. Deduplication count is for display; raw count is for structural integrity.
+- **Alternatives**: Use dedup count (rejected — findings table has raw count rows, so validation would fail)
+
+### Decision 4: Note severity handling
+- **Decision**: Parse Note count from Risk Summary, expose as `note-count` variable, exclude from 4-level validation sum
+- **Rationale**: Note is a valid severity level in tachi output but not rendered as a severity band in the PDF (no Note color in Typst templates). Including it in the sum would break the validation rule.
+- **Alternatives**: Ignore Note entirely (rejected — loses data), include in sum (rejected — breaks validation against 4-level Typst rendering)
+
+### Decision 5: Exit codes
+- **Decision**: 0 = success, 1 = missing required artifact, 2 = validation failure
+- **Rationale**: Standard Unix convention. Code 1 for "can't start" (missing input), code 2 for "ran but found problems" (data integrity). Agent can distinguish between "run /threat-model first" and "data is inconsistent."
+- **Alternatives**: Single non-zero code (rejected — agent can't distinguish error types)
+
+### Decision 6: Markdown table parsing approach
+- **Decision**: Regex + line-by-line parsing with section header anchoring
+- **Rationale**: Tables follow consistent `| col | col |` format. Section headers (`## N. Section Name`) anchor table location. No need for a markdown AST parser since all tables have known, stable column layouts.
+- **Alternatives**: markdown-it or mistune (rejected — external dependency), full AST parsing (rejected — overkill for known table formats)
+
+## Parsing Edge Cases
+
+| Edge Case | Handling Strategy |
+|-----------|-------------------|
+| Bold markers `**text**` in cells | Strip `**` before parsing value |
+| Total row "N (M raw)" format | Regex: extract parenthesized raw count, fallback to first number |
+| Unicode (em dashes, smart quotes) | Pass through; Typst handles Unicode natively |
+| Truncation `...` in threat text | Preserve as-is (content decision, not parsing decision) |
+| Empty table (headers, no rows) | Return empty array `()` |
+| Malformed row (wrong column count) | Log warning to stderr, skip row |
+| Schema v1.0 (no Section 4a) | Check schema_version, skip Section 4a parsing |
+| Nested YAML in frontmatter | Parse only top-level keys needed; skip nested blocks |
+| Zero-byte image files | Set has-*-image = false, log warning |
+
+## Recommendations for Plan
+- Single-file Python script (~500-700 lines estimated)
+- Structure as: argument parsing → artifact detection → per-artifact parsers → validation → Typst generation
+- Each parser function is independent and testable
+- Agent prompt update is a separate deliverable (modify report-assembler.md Steps 2-3)
+- Test with both example datasets; create Tier 1 fixture for compensating-controls testing

--- a/specs/067-deterministic-report-data/spec.md
+++ b/specs/067-deterministic-report-data/spec.md
@@ -1,0 +1,210 @@
+---
+prd_reference: docs/product/02_PRD/067-deterministic-report-data-extraction-2026-03-30.md
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-30
+    status: APPROVED
+    notes: "Spec faithfully translates PRD into 27 granular FRs without scope creep. All 4 PRD user stories covered (decomposed to 6 testable stories). All 5 architect concerns and 4 team-lead clarifications addressed. 7 success criteria are measurable and verifiable."
+  architect_signoff: null
+  techlead_signoff: null
+---
+
+# Feature Specification: Deterministic Report Data Extraction
+
+**Feature Branch**: `067-deterministic-report-data`
+**Created**: 2026-03-30
+**Status**: Draft
+**PRD Reference**: `docs/product/02_PRD/067-deterministic-report-data-extraction-2026-03-30.md`
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Reproducible Report Generation (Priority: P1)
+
+A security engineer runs `/security-report` on a directory containing threat model artifacts. They expect the same PDF output every time they run it on the same inputs. Today, running it four times produces four different severity distributions, different data flow counts, and different overall risk levels — all from identical source files. The deterministic parsing script replaces the LLM-based extraction with regex and line parsing so that identical inputs always produce byte-identical `report-data.typ` and byte-identical PDF output.
+
+**Why this priority**: Without deterministic output, the tool cannot be trusted for compliance, audit trails, or executive communication. This is the core value of the feature.
+
+**Independent Test**: Run the script twice on the same input directory and verify the output files are byte-identical using `diff`.
+
+**Acceptance Scenarios**:
+
+1. **Given** a directory with unchanged threat model artifacts (threats.md, risk-scores.md, compensating-controls.md, threat-report.md, infographic JPEGs), **When** the script runs twice, **Then** both runs produce byte-identical `report-data.typ` files
+2. **Given** identical `report-data.typ` files, **When** Typst compiles them, **Then** both PDFs are byte-identical
+3. **Given** a Tier 1 scenario (compensating-controls.md exists), **When** the script extracts severity counts, **Then** it counts by `residual_severity` from compensating-controls.md Section 2 findings
+4. **Given** a Tier 2 scenario (risk-scores.md exists, no compensating-controls.md), **When** the script extracts severity counts, **Then** it uses risk-scores.md Section 1 severity distribution table
+5. **Given** a Tier 3 scenario (only threats.md), **When** the script extracts severity counts, **Then** it uses threats.md Section 6 Risk Summary table
+
+---
+
+### User Story 2 - Validated Severity Counts (Priority: P1)
+
+The parsing script extracts severity counts from markdown artifacts and validates internal consistency before writing the output. The user needs confidence that the numbers on the cover page and executive summary are mathematically correct — critical + high + medium + low must equal total findings.
+
+**Why this priority**: Inconsistent severity counts were the most visible symptom of the LLM-parsing bug. Validation catches extraction errors before they reach the PDF.
+
+**Independent Test**: Run the script on each example dataset and verify the validation passes with correct sums.
+
+**Acceptance Scenarios**:
+
+1. **Given** extracted severity counts from any tier, **When** validation runs, **Then** the script verifies critical + high + medium + low == total findings and exits with code 2 if the check fails
+2. **Given** a Risk Summary table containing a "Note" severity row, **When** the script extracts counts, **Then** Note-level findings are excluded from the four-level sum but reported in a separate `note-count` variable
+3. **Given** a Risk Summary Total row with format "30 (34 raw)", **When** the script parses it, **Then** it uses the raw count (34) as `total-findings` since raw count represents all individual findings in the findings table
+
+---
+
+### User Story 3 - Deterministic Scope Data Extraction (Priority: P1)
+
+The script extracts scope data (components, data flows, trust boundaries, boundary crossings) from threats.md Sections 1-2. The user needs the same component count and data flow count every time, so the scope page accurately reflects the system architecture.
+
+**Why this priority**: Scope data counts varied between runs in the LLM-parsed reports (20 vs 36 data flows from the same file). Deterministic extraction eliminates this variance.
+
+**Independent Test**: Run the script on a threats.md with known scope data and verify extracted counts match the source.
+
+**Acceptance Scenarios**:
+
+1. **Given** threats.md with N data flows in Section 1, **When** the script extracts data flows, **Then** exactly N data flows appear in `report-data.typ` with `scope-data-flow-count = N`
+2. **Given** threats.md with M components in Section 1, **When** the script extracts components, **Then** exactly M components appear with `scope-component-count = M`
+3. **Given** threats.md where Section 1 or Section 2 tables are missing, **When** the script runs, **Then** it sets arrays to empty and counts to 0 with a logged warning
+
+---
+
+### User Story 4 - Agent Prompt Update (Priority: P1)
+
+The report-assembler agent instructions are updated so the agent orchestrates (detect artifacts, invoke script, compile PDF) instead of performing data extraction and Typst generation itself. Steps 2-3 of the current agent are replaced with a single step: invoke the Python script and verify its exit code.
+
+**Why this priority**: The agent update is required for the script to be used. Without it, the LLM continues parsing non-deterministically.
+
+**Independent Test**: Run `/security-report` end-to-end and verify it invokes the Python script rather than performing inline LLM parsing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the updated agent prompt, **When** `/security-report` is invoked, **Then** the agent calls the Python script with `--target-dir`, `--output`, and `--template-dir` arguments
+2. **Given** the script exits with code 0, **When** the agent receives the result, **Then** it proceeds to Typst compilation (Step 4)
+3. **Given** the script exits with code 1 (missing required artifact), **When** the agent receives the error, **Then** it displays the error message and aborts
+4. **Given** the script exits with code 2 (validation failure), **When** the agent receives the error, **Then** it displays which validation check failed and the offending values
+
+---
+
+### User Story 5 - Consistent Recommendation Formatting (Priority: P2)
+
+The script extracts finding recommendations verbatim from the source markdown without paraphrasing or variable-length rewriting. Every time the script runs, the same recommendation text appears in the findings table.
+
+**Why this priority**: Recommendation formatting was one of the inconsistencies in LLM-parsed reports. Verbatim extraction eliminates variability.
+
+**Independent Test**: Run the script twice and verify all recommendation text in `report-data.typ` is character-identical between runs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a Tier 1 finding with a recommendation in compensating-controls.md, **When** the script extracts it, **Then** the recommendation text is preserved verbatim from the source (minus Typst string escaping)
+2. **Given** findings across all severity levels, **When** the script formats them, **Then** all recommendations use consistent formatting with proper Typst string escaping (double quotes escaped as `\"`, backslashes as `\\`)
+
+---
+
+### User Story 6 - Testing Against Both Example Datasets (Priority: P2)
+
+The script is tested against both the OpenClaw and agentic-app example datasets to verify correctness across different artifact configurations. Testing includes Tier 1, Tier 2, and Tier 3 scenarios.
+
+**Why this priority**: Testing against real data from the existing example directories validates the script handles actual tachi pipeline output, not just synthetic test cases.
+
+**Independent Test**: Run the script on each example dataset directory and verify the output matches expected values.
+
+**Acceptance Scenarios**:
+
+1. **Given** the agentic-app example dataset (threats.md + risk-scores.md + threat-report.md), **When** the script runs, **Then** it produces valid Tier 2 output with correct severity counts
+2. **Given** a Tier 1 test fixture (compensating-controls.md added to an example directory), **When** the script runs, **Then** it produces valid Tier 1 output with residual severity counts and coverage matrix
+3. **Given** a Tier 3 scenario (only threats.md present), **When** the script runs, **Then** it produces valid Tier 3 output with findings from Section 7
+
+---
+
+### Edge Cases
+
+- **Bold markers in table cells**: Some markdown table cells contain `**text**` (e.g., the Total row in Risk Summary: `**30 (34 raw)**`). The script must strip bold markers before parsing numeric values.
+- **Code-fenced frontmatter**: If the YAML frontmatter contains code fence markers or unusual characters, the script must handle them without crashing.
+- **Unicode characters in findings**: Threat descriptions may contain Unicode characters (em dashes, smart quotes, etc.). The script must pass these through with proper Typst string escaping.
+- **Truncation markers**: The `...` truncation in threat descriptions (risk-scores.md) must be preserved as-is in the output.
+- **Empty tables**: If a markdown table has headers but zero data rows, the script must produce an empty Typst array `()`.
+- **Missing optional sections**: If threat-report.md lacks a Remediation Timeline section, the script must set `remediation-actions = none` without error.
+- **Schema v1.0 compatibility**: threats.md with `schema_version: "1.0"` lacks Section 4a (Correlated Findings). The script must skip it without error.
+- **risk-scores.md nested frontmatter**: The frontmatter contains nested YAML (`scoring_weights` with sub-keys). The regex-based parser must handle or skip nested structures without a YAML library.
+- **Note severity level**: Risk Summary may include a "Note" row. The script must parse it but exclude it from the four-level severity sum validation (critical + high + medium + low == total - note_count).
+- **Partial parsing on malformed tables**: If a table row has fewer columns than expected, the script logs a warning and skips that row rather than aborting.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a Python script that reads tachi pipeline markdown artifacts from a target directory and writes a `report-data.typ` file with all Typst variable bindings
+- **FR-002**: The script MUST accept the following CLI arguments: `--target-dir` (required, directory containing artifacts), `--output` (required, path for generated `report-data.typ`), `--title` (optional, title override), `--template-dir` (required, path to `templates/tachi/security-report/`)
+- **FR-003**: The script MUST detect artifacts and determine the data source tier using the same 3-tier logic as the current agent: Tier 1 (compensating-controls.md) > Tier 2 (risk-scores.md) > Tier 3 (threats.md only)
+- **FR-004**: The script MUST parse YAML frontmatter from threats.md to extract `date`, `classification`, and `schema_version` using regex-based parsing (no external YAML library dependency)
+- **FR-005**: The script MUST parse the project name from the first `# Threat Model: {name}` heading in threats.md, with the `--title` flag overriding the auto-detected name
+- **FR-006**: The script MUST parse severity counts from the tier-appropriate source: Tier 1 counts by `residual_severity` from compensating-controls.md Section 2 findings, Tier 2 from risk-scores.md Section 1 distribution, Tier 3 from threats.md Section 6 Risk Summary
+- **FR-007**: The script MUST parse the Total row in Risk Summary, handling the "N (M raw)" format by extracting the raw count as `total-findings`
+- **FR-008**: The script MUST strip markdown bold markers (`**`) from table cell values before parsing
+- **FR-009**: The script MUST extract findings with tier-specific columns: Tier 1 (id, component, threat, residual_score, residual_severity, control_status, recommendation), Tier 2 (id, component, threat, composite_score, severity, cvss, exploitability), Tier 3 (id, component, threat, likelihood, impact, risk_level, mitigation)
+- **FR-010**: The script MUST set Tier 3 `likelihood` and `impact` to `"—"` (em dash) since these granular values are not available in the Section 7 table
+- **FR-011**: The script MUST extract scope data from threats.md: components (Section 1), data flows (Section 1), trust zones (Section 2), boundary crossings (Section 2), with counts for each category
+- **FR-012**: The script MUST extract component distribution by counting findings per component from the findings table, sorted by count descending
+- **FR-013**: The script MUST extract the executive narrative from threat-report.md Section 1 (Risk Posture + Top 5 Threats + Key Recommendations), truncating to 2000 characters if needed
+- **FR-014**: The script MUST extract remediation actions with priority: compensating-controls.md Section 3 recommendations (if available) > threat-report.md Remediation Timeline (if available) > `none`
+- **FR-015**: The script MUST extract STRIDE coverage matrix from compensating-controls.md (per-category found/partial/missing counts) and detailed controls with component, category, status, evidence, effectiveness
+- **FR-016**: The script MUST detect brand assets by checking file existence: `brand/final/tachi-logo-primary.png`, `brand/final/tachi-logo-primary-dark.png`, `brand/final/tachi-logo-horizontal.png`
+- **FR-017**: The script MUST compute image paths relative to `templates/tachi/security-report/` using the `../../{target_dir}/` pattern
+- **FR-018**: The script MUST escape Typst string values: double quotes to `\"`, backslashes to `\\`, newlines to `\n`
+- **FR-019**: The script MUST validate internal consistency: (a) critical + high + medium + low == total - note_count, (b) len(scope_data_flows) == scope_data_flow_count, (c) len(scope_components) == scope_component_count, (d) all finding IDs are unique
+- **FR-020**: The script MUST exit with code 0 on success, code 1 when a required artifact is missing (threats.md), and code 2 when a validation check fails (with stderr describing which check failed and the offending values)
+- **FR-021**: The script MUST handle schema v1.0 compatibility by skipping Section 4a references without error
+- **FR-022**: The script MUST handle malformed table rows by logging a warning to stderr and skipping the row rather than aborting
+- **FR-023**: The script MUST set page inclusion flags (has-threat-report, has-risk-scores, has-compensating-controls, has-funnel-image, has-baseball-image, has-architecture-image) based on artifact existence and non-zero file size
+- **FR-024**: The script MUST generate output using the exact same Typst variable names, types, and structure as defined in the current report-assembler agent Steps 3a-3q
+- **FR-025**: The report-assembler agent prompt MUST be updated to invoke the script instead of performing inline LLM parsing, with Steps 2-3 replaced by a single script invocation step
+- **FR-026**: The script MUST be located at `scripts/extract-report-data.py` and run with Python 3.9+ using only standard library modules (`re`, `pathlib`, `argparse`, `sys`, `os`)
+- **FR-027**: The script MUST handle the Note severity level by parsing it from the Risk Summary table and exposing it as `note-count` but excluding it from the four-level validation sum
+
+### Key Entities
+
+- **Parsing Script**: The Python script at `scripts/extract-report-data.py` that deterministically extracts structured data from markdown artifacts and writes `report-data.typ`
+- **report-data.typ**: The intermediate Typst data file containing all extracted variables as `#let` bindings — the data contract between the parsing script and the Typst template system
+- **Data Source Tier**: The 3-level hierarchy determining which artifact provides findings data and severity counts (Tier 1: compensating-controls.md, Tier 2: risk-scores.md, Tier 3: threats.md)
+- **Markdown Artifacts**: The input files produced by tachi pipeline agents: threats.md (required), risk-scores.md (optional), compensating-controls.md (optional), threat-report.md (optional), infographic JPEGs (optional)
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Running the script twice on identical input produces byte-identical `report-data.typ` output (determinism verified by `diff`)
+- **SC-002**: Running `/security-report` twice on identical input produces byte-identical PDF output
+- **SC-003**: Severity count validation passes on both OpenClaw and agentic-app example datasets (critical + high + medium + low == total - note_count)
+- **SC-004**: Data flow count in `report-data.typ` exactly matches the data flow count in the source threats.md for both example datasets
+- **SC-005**: The script runs in under 5 seconds on the largest expected artifact set (64+ findings, 36 data flows, 20+ components)
+- **SC-006**: The script uses only Python 3.9+ standard library modules (zero external dependencies)
+- **SC-007**: All three tiers are exercised by at least one test: Tier 1 (compensating-controls.md present), Tier 2 (risk-scores.md present, no compensating-controls), Tier 3 (threats.md only)
+
+## Assumptions
+
+- Python 3.9+ is available on all target platforms (macOS, Linux, Windows)
+- The markdown artifact format is stable (schema v1.0 and v1.1 as documented in `schemas/output.yaml`, `schemas/risk-scoring.yaml`, `schemas/compensating-controls.yaml`)
+- The Typst variable contract in `report-data.typ` does not need to change — the script produces the same variable names and types as the current LLM-generated output
+- No compensating-controls.md example exists in the repo today; a Tier 1 test fixture must be created as part of testing
+- The agentic-app example dataset (`examples/agentic-app/sample-report/`) is current and contains threats.md + risk-scores.md + threat-report.md
+- This is a data extraction refactor — no Typst template changes, no new report pages, no upstream pipeline agent changes
+
+## Scope Boundaries
+
+### In Scope
+- Deterministic Python parsing script (`scripts/extract-report-data.py`) covering all data extraction from current agent Steps 2a-2j
+- Tier-based severity source selection with programmatic logic
+- Internal consistency validation (severity sums, scope counts, finding ID uniqueness)
+- Agent prompt update (`report-assembler.md`) to invoke script instead of LLM parsing
+- Testing against OpenClaw and agentic-app example datasets
+- Creation of a Tier 1 test fixture (compensating-controls.md for an example dataset)
+- Exit code conventions (0 = success, 1 = missing required artifact, 2 = validation failure)
+
+### Out of Scope
+- Typst template changes (templates render correctly with well-formed data)
+- Upstream pipeline agent changes (threat agents, risk scorer, control analyzer)
+- Infographic generation (separate pipeline)
+- New report pages or sections (this is a data extraction fix)
+- CI/CD integration (deterministic output enables it, but the pipeline itself is out of scope)
+- Security-report command changes (command invokes agent, which invokes script — no command-level changes needed)

--- a/specs/067-deterministic-report-data/tasks.md
+++ b/specs/067-deterministic-report-data/tasks.md
@@ -1,0 +1,231 @@
+---
+triad:
+  pm_signoff:
+    agent: product-manager
+    date: 2026-03-30
+    status: APPROVED
+    notes: "All 6 user stories covered. All 27 FRs addressed. No scope creep. MVP strategy aligns with P1 priorities."
+  architect_signoff:
+    agent: architect
+    date: 2026-03-30
+    status: APPROVED_WITH_CONCERNS
+    notes: "2 minor concerns: (1) T013 generate_report_data_typ is dense — may benefit from helper functions during implementation. (2) T017 scope parsing breadth — 4 table types in one task. Both acceptable for single-file script. 27/27 FRs covered."
+  techlead_signoff:
+    agent: team-lead
+    date: 2026-03-30
+    status: APPROVED
+    notes: "Feasible. 32 tasks across 5 execution waves. ~4h estimated. MVP (Phases 1-3) meaningful and verifiable. Critical path correctly identified. Single-file constraint honestly limits parallelism."
+---
+
+# Tasks: Deterministic Report Data Extraction
+
+**Input**: Design documents from `/specs/067-deterministic-report-data/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: No test framework requested. Determinism and correctness are validated by running the script against example datasets and using `diff`.
+
+**Organization**: Tasks are grouped by implementation phase, with user story traceability via [US] labels.
+
+## Format: `[ID] [P?] [Story] Description`
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Create the script skeleton with CLI argument parsing and artifact detection.
+
+- [X] T001 Create `scripts/extract-report-data.py` with argparse CLI: `--target-dir`, `--output`, `--template-dir`, `--title` arguments, and exit code constants (0, 1, 2)
+- [X] T002 Implement artifact detection function in `scripts/extract-report-data.py`: scan target directory for threats.md (required), risk-scores.md, compensating-controls.md, threat-report.md, infographic JPEGs, brand assets; exit code 1 if threats.md missing
+- [X] T003 Implement tier selection logic in `scripts/extract-report-data.py`: Tier 1 if compensating-controls.md exists, Tier 2 if risk-scores.md exists, Tier 3 otherwise
+
+**Checkpoint**: Script runs, detects artifacts, selects tier, exits cleanly.
+
+---
+
+## Phase 2: Core Parsing (Foundational)
+
+**Purpose**: Implement the parsers that all tiers depend on — frontmatter, section anchoring, table parsing, and string escaping utilities.
+
+- [X] T004 [P] Implement `parse_frontmatter()` in `scripts/extract-report-data.py`: regex-based extraction of `date`, `classification`, `schema_version` from YAML frontmatter between `---` delimiters; handle nested keys by extracting only top-level values needed
+- [X] T005 [P] Implement `parse_markdown_table()` utility in `scripts/extract-report-data.py`: find table by section header anchor, parse header row for column names, skip separator row, extract data rows with `|`-splitting and stripping; skip malformed rows with warning to stderr
+- [X] T006 [P] Implement `strip_bold()` and `escape_typst_string()` utilities in `scripts/extract-report-data.py`: strip `**` markers from cell values; escape `"` to `\"`, `\` to `\\`, newlines to `\n` for Typst strings
+- [X] T007 Implement `parse_project_name()` in `scripts/extract-report-data.py`: extract name from `# Threat Model: {name}` heading, with `--title` override taking precedence
+
+**Checkpoint**: Utility functions complete. Individual parsers can now be built on top.
+
+---
+
+## Phase 3: User Story 1 — Reproducible Report Generation (Priority: P1) MVP
+
+**Goal**: Parse threats.md and risk-scores.md to produce a deterministic Tier 2 `report-data.typ` from the agentic-app example dataset.
+
+**Independent Test**: Run script twice on `examples/agentic-app/sample-report/`, diff the two outputs — zero differences.
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement `parse_threats_severity()` in `scripts/extract-report-data.py`: parse Section 6 Risk Summary table from threats.md; extract Critical, High, Medium, Low, Note counts; handle Total row "N (M raw)" format using regex; strip bold markers
+- [X] T009 [US1] Implement `parse_threats_findings()` in `scripts/extract-report-data.py`: parse Section 7 Recommended Actions table for Tier 3 findings (id, component, threat, risk_level, mitigation); set likelihood and impact to em dash
+- [X] T010 [US1] Implement `parse_risk_scores_severity()` in `scripts/extract-report-data.py`: parse risk-scores.md Section 1 severity distribution table; prefer these counts over threats.md when Tier 2
+- [X] T011 [US1] Implement `parse_risk_scores_findings()` in `scripts/extract-report-data.py`: parse risk-scores.md Section 2 Scored Threat Table for Tier 2 findings (id, component, threat, composite_score, severity, cvss, exploitability)
+- [X] T012 [US1] Implement `parse_component_distribution()` in `scripts/extract-report-data.py`: count findings per component from the active findings table, sort by count descending
+- [X] T013 [US1] Implement `generate_report_data_typ()` in `scripts/extract-report-data.py`: format all extracted data as Typst `#let` variable bindings following the exact variable names and types from the report-assembler agent Steps 3a-3q; output complete file with header comment, metadata, severity counts, page flags, tier, image paths, findings array, scope data, brand assets, page visibility
+- [X] T014 [US1] Wire `main()` in `scripts/extract-report-data.py`: connect CLI args → artifact detection → tier selection → parsers → Typst generation → file write; verify determinism by running twice on `examples/agentic-app/sample-report/` and diffing output
+
+**Checkpoint**: Tier 2 works end-to-end. Running twice produces byte-identical output. MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Validated Severity Counts (Priority: P1)
+
+**Goal**: Add internal consistency validation so severity count mismatches are caught before PDF generation.
+
+**Independent Test**: Run script on valid data (exit 0), then inject a count mismatch and verify exit code 2 with descriptive error.
+
+### Implementation for User Story 2
+
+- [X] T015 [US2] Implement `validate()` in `scripts/extract-report-data.py`: check (a) critical + high + medium + low == total - note_count, (b) all finding IDs unique; return list of error messages; exit code 2 with stderr description if any check fails
+- [X] T016 [US2] Add Note severity handling in `scripts/extract-report-data.py`: parse Note row from Risk Summary, expose as `note-count` Typst variable, exclude from four-level validation sum
+
+**Checkpoint**: Validation catches severity sum mismatches and duplicate IDs.
+
+---
+
+## Phase 5: User Story 3 — Deterministic Scope Data Extraction (Priority: P1)
+
+**Goal**: Extract scope data (components, data flows, trust boundaries, boundary crossings) deterministically from threats.md Sections 1-2.
+
+**Independent Test**: Run script on agentic-app dataset and verify scope counts in output match source table row counts.
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Implement `parse_scope_data()` in `scripts/extract-report-data.py`: parse threats.md Section 1 for components table (name, type, description) and data flows table (source, destination, data, protocol); parse Section 2 for trust zones table (zone, trust-level, components) and boundary crossings table (crossing, from-zone, to-zone, components, controls); compute counts for each category
+- [X] T018 [US3] Add scope validation to `validate()` in `scripts/extract-report-data.py`: verify len(scope_components) == scope_component_count and len(scope_data_flows) == scope_data_flow_count; gracefully handle missing sections (empty arrays, zero counts, warning)
+
+**Checkpoint**: Scope data is extracted deterministically with count validation.
+
+---
+
+## Phase 6: User Story 4 — Agent Prompt Update (Priority: P1)
+
+**Goal**: Update the report-assembler agent to invoke the Python script instead of LLM-based parsing.
+
+**Independent Test**: Run `/security-report` on agentic-app dataset and verify it invokes the script, generates PDF, and exits successfully.
+
+### Implementation for User Story 4
+
+- [X] T019 [US4] Update `.claude/agents/tachi/report-assembler.md`: replace Steps 2-3 (Data Extraction + Typst Data Generation) with a single Step 2 that invokes `python3 scripts/extract-report-data.py --target-dir {target_dir} --output templates/tachi/security-report/report-data.typ --template-dir templates/tachi/security-report/ [--title "{title_override}"]`; add exit code handling (0=proceed to Step 3 compilation, 1=abort with error, 2=abort with validation details); renumber remaining steps; preserve Step 1 (Artifact Detection) and current Step 4 (Compilation) unchanged
+- [X] T020 [US4] Update Step 2j (report-config.typ copy) in `.claude/agents/tachi/report-assembler.md`: ensure report-config.typ copy behavior remains in the agent orchestration (before script invocation), not in the script, per architect's concern
+
+**Checkpoint**: Agent invokes script. Full `/security-report` pipeline works end-to-end.
+
+---
+
+## Phase 7: User Story 5 — Consistent Recommendation Formatting (Priority: P2)
+
+**Goal**: Extract recommendations verbatim with proper Typst escaping.
+
+**Independent Test**: Run script twice, compare recommendation text in output — character-identical.
+
+### Implementation for User Story 5
+
+- [X] T021 [US5] Implement `parse_threat_report_md()` in `scripts/extract-report-data.py`: extract executive narrative from Section 1 (Risk Posture + Top 5 Threats + Key Recommendations), truncate to 2000 chars if needed; extract remediation actions from Remediation Timeline section
+- [X] T022 [US5] Implement `parse_compensating_controls_md()` in `scripts/extract-report-data.py`: parse Section 2 Coverage Matrix for Tier 1 findings (id, component, threat, residual_score, residual_severity, control_status, recommendation); parse STRIDE coverage matrix (per-category found/partial/missing); parse Section 3 detailed controls (component, category, status, evidence, effectiveness); compute coverage summary (total-found, total-partial, total-missing)
+- [X] T023 [US5] Implement remediation source priority in `scripts/extract-report-data.py`: use compensating-controls.md Section 3 recommendations if available, else threat-report.md Remediation Timeline, else `none`; derive SLA from severity (Critical=7d, High=14d, Medium=30d, Low=90d)
+
+**Checkpoint**: Tier 1 parsing complete. All three tiers functional. Recommendations extracted verbatim.
+
+---
+
+## Phase 8: User Story 6 — Testing Against Both Example Datasets (Priority: P2)
+
+**Goal**: Validate correctness across example datasets and all three tier configurations.
+
+**Independent Test**: Run script on each dataset, verify output against expected values, confirm determinism.
+
+### Implementation for User Story 6
+
+- [X] T024 [P] [US6] Implement `detect_images()` and `detect_brand_assets()` in `scripts/extract-report-data.py`: check image file existence and non-zero size for infographic JPEGs and brand logos; compute relative paths from template directory using `../../{target_dir}/` pattern; set page inclusion flags
+- [X] T025 [US6] Implement schema v1.0 compatibility in `scripts/extract-report-data.py`: check `schema_version` from frontmatter, skip Section 4a parsing for v1.0, log info message
+- [X] T026 [US6] Verify script against `examples/agentic-app/sample-report/` (Tier 2): run twice, diff outputs, verify severity counts match source, verify scope data counts match source
+- [X] T027 [US6] Create Tier 1 test fixture at `examples/agentic-app/sample-report/compensating-controls.md` per the compensating-controls.yaml schema: include Section 2 Coverage Matrix with residual severity counts and Section 3 detailed controls for at least 5 findings
+- [X] T028 [US6] Verify script against Tier 1 fixture: run with compensating-controls.md present, verify Tier 1 output with residual severity counts, coverage matrix, and detailed controls
+- [X] T029 [US6] Verify script against Tier 3 scenario: run on agentic-app dataset with risk-scores.md temporarily excluded, verify Tier 3 output with Section 7 findings and Section 6 severity counts
+
+**Checkpoint**: All three tiers verified. Determinism confirmed on both datasets.
+
+---
+
+## Phase 9: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final validation, end-to-end PDF verification, and cleanup.
+
+- [X] T030 Run full `/security-report` end-to-end on agentic-app dataset: verify PDF generated, severity counts on cover match source, scope page data correct
+- [X] T031 Run full `/security-report` twice on same dataset and verify byte-identical PDF output
+- [X] T032 Verify error handling: run with missing threats.md (expect exit 1), run with injected severity mismatch (expect exit 2)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Core Parsing)**: Depends on Phase 1 — utility functions block all parsers
+- **Phase 3 (US1)**: Depends on Phase 2 — MVP tier 2 parsing
+- **Phase 4 (US2)**: Depends on Phase 3 — validation uses parsed data
+- **Phase 5 (US3)**: Depends on Phase 2 — scope parsing uses table utility; can parallel with Phase 3-4
+- **Phase 6 (US4)**: Depends on Phase 3 — agent needs working script
+- **Phase 7 (US5)**: Depends on Phase 2 — Tier 1 parsing; can parallel with Phases 3-5
+- **Phase 8 (US6)**: Depends on Phases 3-7 — all parsers must be complete for tier testing
+- **Phase 9 (Polish)**: Depends on all phases
+
+### User Story Dependencies
+
+- **US1 (Reproducible)**: Core — all other stories depend on this
+- **US2 (Validation)**: Depends on US1 (needs parsed data to validate)
+- **US3 (Scope)**: Independent of US1/US2 after Phase 2 utilities
+- **US4 (Agent Update)**: Depends on US1 (needs working script)
+- **US5 (Recommendations)**: Independent after Phase 2 utilities (adds Tier 1 + threat-report parsers)
+- **US6 (Testing)**: Depends on all stories (integration testing)
+
+### Parallel Opportunities
+
+- **Phase 2**: T004, T005, T006 can all run in parallel (independent utility functions)
+- **Phase 5 + Phase 3-4**: Scope parsing (T017-T018) can run in parallel with US1 severity/findings work
+- **Phase 7 + Phase 3-5**: Tier 1 parsing (T022-T023) can run in parallel with Tier 2/3 work
+- **Phase 8**: T024 (image detection) can run in parallel with other US6 tasks
+
+---
+
+## Implementation Strategy
+
+### MVP First (Phase 1-3: Tier 2 Determinism)
+
+1. Complete Phase 1: Setup (script skeleton)
+2. Complete Phase 2: Core Parsing (utilities)
+3. Complete Phase 3: US1 (Tier 2 end-to-end)
+4. **STOP and VALIDATE**: Run twice on agentic-app, diff outputs — zero differences
+5. This is the MVP — deterministic Tier 2 report generation
+
+### Incremental Delivery
+
+1. MVP (Phases 1-3) → Tier 2 determinism verified
+2. Add US2 (Phase 4) → Validation catches data errors
+3. Add US3 (Phase 5) → Scope data deterministic
+4. Add US4 (Phase 6) → Agent integrated, `/security-report` works
+5. Add US5 (Phase 7) → All three tiers, recommendations, narratives
+6. Add US6 (Phase 8) → Full test coverage across datasets
+7. Polish (Phase 9) → End-to-end PDF verification
+
+---
+
+## Notes
+
+- [P] tasks = different files or independent functions, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All implementation is in a single file: `scripts/extract-report-data.py`
+- Agent update is a separate file: `.claude/agents/tachi/report-assembler.md`
+- Determinism is verified at each phase by running twice and diffing


### PR DESCRIPTION
## Summary
- Replace LLM-based markdown parsing with a deterministic Python script (`scripts/extract-report-data.py`) that produces byte-identical `report-data.typ` output on identical inputs
- Support 3-tier severity source selection (Tier 1: compensating-controls.md, Tier 2: risk-scores.md, Tier 3: threats.md), internal consistency validation, scope data extraction, and all artifact types
- Update report-assembler agent to invoke the script instead of performing inline LLM parsing

## Key Deliverables
- `scripts/extract-report-data.py` — 1400+ line Python script (stdlib only) with CLI, 3-tier parsing, validation
- `.claude/agents/tachi/report-assembler.md` — Updated agent prompt to invoke script
- `examples/agentic-app/sample-report/compensating-controls.md` — Tier 1 test fixture
- Full spec artifacts in `specs/067-deterministic-report-data/`

## Test Plan
- [x] Script runs deterministically (byte-identical output on repeated runs)
- [x] Tier 1, Tier 2, and Tier 3 all verified against example datasets
- [x] Validation catches severity sum mismatches (exit code 2)
- [x] Missing threats.md returns exit code 1
- [x] Full `/security-report` end-to-end produces valid PDF
- [x] All 32/32 tasks completed across 5 execution waves

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)