### PR TITLE
docs(128): post-delivery quality review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Executive Threat Architecture Infographic** (Feature 128) — New `/tachi.infographic --template executive-architecture` (alias: `exec`) generates a layered architecture diagram with Critical/High finding callouts, designed for CISO-level readers. In the compiled PDF security report the new page lands immediately after the Executive Summary (pages 2–3 area) so executives see the visual threat narrative within their first-glance window. Included in the `all` shorthand expansion alongside the existing five templates. Backward compatible — example PDFs without a generated `threat-executive-architecture.jpg` render byte-identical to the pre-F-128 baseline. Ships with tachi's first project-level pytest harness (`pyproject.toml`, `requirements-dev.txt`, `tests/`) and five committed `.baseline` PDFs guarding backward compatibility against silent regressions.
 - **Architecture Lifecycle Command** (Feature 120) — `/tachi.architecture` now tracks versions with YAML frontmatter (version, date, description, SHA-256 checksum), archives previous versions to `.archive/v{N}/`, and supports guided updates through change categories. `/tachi.threat-model` automatically snapshots the architecture file into each timestamped output folder for full traceability. Backward compatible with existing architecture files.
 
 ### Changed

--- a/docs/INSTITUTIONAL_KNOWLEDGE.md
+++ b/docs/INSTITUTIONAL_KNOWLEDGE.md
@@ -5,7 +5,7 @@
 **Created**: {{PROJECT_START_DATE}}
 **Last Updated**: 2026-04-10
 
-**Entry Count**: 26 / 20 (KB System Upgrade triggers at 20 — schedule review)
+**Entry Count**: 27 / 20 (KB System Upgrade triggers at 20 — schedule review)
 **Last Review**: 2026-03-30
 **Status**: ✅ Manual mode (file-based)
 
@@ -545,6 +545,29 @@ Captured during structured delivery retrospective. Smooth sailing — everything
 **Tags**: #retrospective #process #git #parallel-sessions #workflow #delivery
 
 **Quality Score**: 7/10
+
+---
+
+### KB-027: Post-Delivery Simplify Pass Commonly Finds Narrative-Comment Sprawl in Generated Tests
+
+**Date**: 2026-04-10
+**Category**: Process / Tooling
+**Source**: Feature 128 /aod.document simplify review
+**Severity**: Informational
+
+**Problem**: Feature 128 shipped 2,139 lines of new Python (two extraction-script additions plus six test modules bootstrapping the pytest harness). The post-delivery `/aod.document` simplify review deleted 660 lines and rewrote 216 — a 31% reduction in changed-line count — with almost all of that coming from the test modules. The cleanup was dominated by three repeating anti-patterns: (1) module-level docstrings narrating the task-gating story ("Note on the test-first gate (T007)"), (2) per-function step-enumeration comments (`# Step 1:`, `# Step 2:`), and (3) inline references to task IDs (T023, T024, T029, T033) and review-artifact paths that will not make sense after the feature branch is merged.
+
+**Root Cause**: Test generation during feature build captures the implementer's working-memory narrative — which tasks are gating which tests, which steps run in which order, which review findings shaped which assertion — and emits it as comments and docstrings. This information is useful *during* implementation (while the author is still holding the whole plan in their head) but becomes stale the moment the feature merges. The comments then linger as archaeological debris in the test modules, reducing signal density and creating misleading context for future maintainers.
+
+**Solution**: Keep the `/aod.document` simplify step in the lifecycle as a mandatory cleanup gate, not an optional polish. The `/simplify` skill's three-agent review (reuse, quality, efficiency) reliably catches these patterns when pointed at the changed files. For F-128 the pass also caught a dead parameter, two duplicated closures, a hand-rolled severity dict that duplicated an imported constant, and 5× redundant subprocess runs in a parametrized test that collapsed cleanly into a module-scoped fixture.
+
+**Result**: Production code became smaller, tighter, and free of task-reference artifacts. The pytest harness gained a `slow` marker registration enabling `pytest -m "not slow"` to run in ~5 seconds instead of ~20 (4× faster local iteration). Full suite still passes (39/39) and the smoke test against the agentic-app sample produces byte-identical output to the pre-refactor run.
+
+**When to Apply**: Every feature that ships new test modules or non-trivial Python helpers. Expect a post-delivery simplify pass to remove 20–30% of changed-line count through comment and duplication cleanup alone. Allocate time for the `/aod.document` stage rather than treating it as optional.
+
+**Tags**: #retrospective #process #simplify #test-quality #comments #tooling #aod-document
+
+**Quality Score**: 8/10
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,6 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]
 addopts = "-ra --strict-markers"
+markers = [
+    "slow: tests that invoke typst compile or other slow external subprocesses",
+]

--- a/scripts/extract-infographic-data.py
+++ b/scripts/extract-infographic-data.py
@@ -20,6 +20,7 @@ import json
 import math
 import re
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
@@ -62,8 +63,19 @@ SEVERITY_COLORS = {
     "Note": "#6B7280",
 }
 
-# Alias for backward compatibility within this script
 _SEVERITY_ORDINAL = SEVERITY_ORDINAL
+
+_QUALIFYING_SEVERITIES = frozenset({"Critical", "High"})
+_SEVERITY_FIELD_PREFERENCE = ("severity", "residual_severity", "risk_level")
+_TIER_SOURCE_LABEL = {1: "compensating-controls", 2: "risk-scores", 3: "threats"}
+
+
+def _canonical_severity(finding):
+    for key in _SEVERITY_FIELD_PREFERENCE:
+        val = finding.get(key)
+        if val:
+            return str(val).strip().title()
+    return ""
 
 
 # =============================================================================
@@ -655,23 +667,8 @@ def _compute_trust_zones(scope_data):
     return zones
 
 
-# =============================================================================
-# F-128: Executive Architecture Helpers
-# =============================================================================
-
 def _normalize_component_name(name):
-    """Normalize a component name for case-insensitive, punctuation-insensitive matching.
-
-    Strips whitespace, lowercases, and removes hyphens, underscores, and spaces so that
-    "API Gateway", "api-gateway", "api_gateway", and "apigateway" all collapse to
-    "apigateway". Used as the matching key for layer-finding association.
-
-    Args:
-        name: Component name string (may be None).
-
-    Returns:
-        Normalized string. Empty string if input is None or empty.
-    """
+    """Collapse component names so "API Gateway", "api-gateway", "api_gateway" all match."""
     if not name:
         return ""
     return (
@@ -684,24 +681,11 @@ def _normalize_component_name(name):
 
 
 def _compute_dfd_type_layers(scope_data):
-    """Group Section 1 components by DFD type for the executive-architecture fallback.
-
-    Used when no trust zones are defined in Section 2. Each unique component `type`
-    becomes an ArchitecturalLayer, with components listed alphabetically within the
-    layer. Layers are sorted alphabetically by type name.
-
-    Args:
-        scope_data: Dict from parse_scope_data().
-
-    Returns:
-        List of layer dicts (name, position, components, component_count, source_kind)
-        or None if scope_data has no components at all.
-    """
+    """Fallback layer derivation: group Section 1 components by DFD type when no trust zones exist."""
     components = scope_data.get("components", [])
     if not components:
         return None
 
-    # Group component names by type
     by_type = {}
     for comp in components:
         ctype = (comp.get("type") or "").strip()
@@ -713,7 +697,6 @@ def _compute_dfd_type_layers(scope_data):
     if not by_type:
         return None
 
-    # Build layer dicts sorted alphabetically by type name
     layers = []
     for position, ctype in enumerate(sorted(by_type.keys())):
         comp_names = sorted(by_type[ctype])
@@ -730,31 +713,32 @@ def _compute_dfd_type_layers(scope_data):
     return layers if layers else None
 
 
+def _extract_composite_score(finding):
+    for key in ("composite_score", "residual_score"):
+        raw = finding.get(key)
+        if raw is None or raw == "":
+            continue
+        try:
+            return float(raw)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _extract_description(finding):
+    for key in ("description", "threat", "mitigation"):
+        val = finding.get(key)
+        if val:
+            return str(val).strip()
+    return ""
+
+
 def _select_critical_high_callouts(findings, layers):
-    """Filter Critical/High findings and select one callout per layer.
+    """Select one Critical/High callout per layer.
 
-    For each layer:
-      1. Filter findings whose normalized component is in the layer's normalized
-         component set, AND whose severity is Critical or High.
-      2. Sort by:
-         a. severity descending (Critical before High)
-         b. composite_score descending (None treated as 0.0)
-         c. finding_id ascending (lexicographic tie-break)
-      3. Select the first element as the layer's callout.
-
-    Orphaned findings (those whose component matches no layer) are dropped.
-
-    Args:
-        findings: List of finding dicts from parse_*_findings(). Expected keys:
-            `id`, `component`, `threat` (or `description`), `severity` or `risk_level`,
-            optional `composite_score`, `residual_score`.
-        layers: List of layer dicts (name, components, ...).
-
-    Returns:
-        List of callout dicts matching the ThreatCallout schema in data-model.md.
-        One callout maximum per layer; layers with no qualifying findings yield no callout.
+    Sort order per layer: severity desc, composite score desc, finding id asc.
+    Findings whose component matches no layer are dropped.
     """
-    # Build a lookup: normalized component name -> (layer_name, layer_index)
     comp_to_layer = {}
     for idx, layer in enumerate(layers):
         for comp in layer.get("components", []):
@@ -762,53 +746,18 @@ def _select_critical_high_callouts(findings, layers):
             if key and key not in comp_to_layer:
                 comp_to_layer[key] = (layer["name"], idx)
 
-    # Severity ordering for sort: Critical=2, High=1 (others excluded by filter)
-    _SEV_RANK = {"critical": 2, "high": 1}
-
-    def _extract_severity(finding):
-        """Return canonical severity label ('Critical', 'High') or empty string."""
-        # Tier 2/1 use `severity` / `residual_severity`; Tier 3 uses `risk_level`.
-        for key in ("severity", "residual_severity", "risk_level"):
-            val = finding.get(key)
-            if val:
-                return str(val).strip().title()
-        return ""
-
-    def _extract_composite_score(finding):
-        """Return composite score as float or None."""
-        for key in ("composite_score", "residual_score"):
-            raw = finding.get(key)
-            if raw is None or raw == "":
-                continue
-            try:
-                return float(raw)
-            except (TypeError, ValueError):
-                continue
-        return None
-
-    def _extract_description(finding):
-        """Return the narrative description for the callout."""
-        for key in ("description", "threat", "mitigation"):
-            val = finding.get(key)
-            if val:
-                return str(val).strip()
-        return ""
-
-    # Group qualifying findings by layer
     per_layer = {layer["name"]: [] for layer in layers}
     for finding in findings:
-        severity = _extract_severity(finding)
-        if severity not in ("Critical", "High"):
+        severity = _canonical_severity(finding)
+        if severity not in _QUALIFYING_SEVERITIES:
             continue
         component = finding.get("component") or ""
         key = _normalize_component_name(component)
         if not key or key not in comp_to_layer:
-            # Orphaned finding — drop per architect L-1 observation
             continue
         layer_name, _idx = comp_to_layer[key]
         per_layer[layer_name].append(finding)
 
-    # Select the top finding per layer using the tie-break rule
     callouts = []
     for layer in layers:
         layer_findings = per_layer.get(layer["name"], [])
@@ -816,58 +765,42 @@ def _select_critical_high_callouts(findings, layers):
             continue
 
         def _sort_key(f):
-            severity = _extract_severity(f)
+            severity = _canonical_severity(f)
             composite = _extract_composite_score(f)
             return (
-                -_SEV_RANK.get(severity.lower(), 0),          # severity desc
-                -(composite if composite is not None else 0.0),  # score desc
-                f.get("id", ""),                               # id asc
+                -_SEVERITY_ORDINAL.get(severity, 0),
+                -(composite if composite is not None else 0.0),
+                f.get("id", ""),
             )
 
         layer_findings.sort(key=_sort_key)
         top = layer_findings[0]
-        composite = _extract_composite_score(top)
         callouts.append({
             "layer_name": layer["name"],
             "finding_id": top.get("id", ""),
-            "severity": _extract_severity(top),
+            "severity": _canonical_severity(top),
             "raw_description": _extract_description(top),
-            "composite_score": composite,
+            "composite_score": _extract_composite_score(top),
             "affected_component": (top.get("component") or None),
         })
 
     return callouts
 
 
-def _build_executive_architecture_payload(threats_content, tier, findings, scope_data, source_file):
-    """Assemble the ExecutiveArchitecturePayload dict for the executive-architecture template.
+def _build_executive_architecture_payload(tier, findings, scope_data, source_file):
+    """Assemble the ExecutiveArchitecturePayload.
 
-    Handles layer derivation (trust zones → DFD type fallback), Critical/High filtering,
-    per-layer callout selection, metadata assembly, and the skip_image flag.
-
-    Args:
-        threats_content: Full text of threats.md (unused; reserved for future use).
-        tier: Tier source label (one of "compensating-controls", "risk-scores", "threats").
-        findings: List of finding dicts from extract_severity().
-        scope_data: Dict from parse_scope_data().
-        source_file: Path-like to the source threats.md file.
-
-    Returns:
-        ExecutiveArchitecturePayload dict, OR a dict {"error": "no_scope_data"} when
-        neither trust zones nor DFD-type-grouped components can be derived from
-        scope_data. The caller translates the error dict into exit code 2.
+    Derives layers from trust zones (preferred) or falls back to grouping components by
+    DFD type. Returns ``{"error": "no_scope_data"}`` when neither source yields layers;
+    the caller translates that into exit code 2.
     """
-    from datetime import datetime, timezone
-
-    # --- Step 1: Derive architectural layers ---
     trust_zones = _compute_trust_zones(scope_data)
     fallback_used = False
     layers = []
 
     if trust_zones:
-        # Trust zones returned sorted by trust level ASCENDING (trusted first).
-        # The executive-architecture view wants UNTRUSTED at top (position 0 = most
-        # exposed), so we reverse the order.
+        # Trust zones arrive sorted trusted-first; the executive view places the most
+        # exposed layer at position 0, so reverse into untrusted-first order.
         ordered = list(reversed(trust_zones))
         for position, zone in enumerate(ordered):
             comp_names = list(zone.get("components") or [])
@@ -886,35 +819,24 @@ def _build_executive_architecture_payload(threats_content, tier, findings, scope
             fallback_used = True
             layers = dfd_layers
 
-    # Drop any layers that ended up with zero components
     layers = [layer for layer in layers if layer.get("component_count", 0) > 0]
 
     if not layers:
         return {"error": "no_scope_data"}
 
-    # --- Step 2: Filter findings to Critical/High ---
-    def _severity_of(f):
-        for key in ("severity", "residual_severity", "risk_level"):
-            val = f.get(key)
-            if val:
-                return str(val).strip().title()
-        return ""
-
     critical_count = 0
     high_count = 0
     for f in findings:
-        sev = _severity_of(f)
+        sev = _canonical_severity(f)
         if sev == "Critical":
             critical_count += 1
         elif sev == "High":
             high_count += 1
     total_qualifying = critical_count + high_count
 
-    # --- Step 3: Per-layer callout selection ---
     callouts = _select_critical_high_callouts(findings, layers)
     total_after_layer_dedup = len(callouts)
 
-    # --- Step 4: Metadata assembly ---
     skip_image = (total_qualifying == 0)
     generation_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
     metadata = {
@@ -1529,15 +1451,9 @@ def main():
     # Extract severity, findings, and cc_data
     severity, findings, cc_data = extract_severity(tier, threats_content, rs_content, cc_content)
 
-    # F-128 T011: executive-architecture branch (early exit — unique payload shape)
     if args.template == "executive-architecture":
-        # Map integer tier to string tier_source label per data-model.md PayloadMetadata
-        _TIER_SOURCE_LABEL = {1: "compensating-controls", 2: "risk-scores", 3: "threats"}
-        tier_source = _TIER_SOURCE_LABEL.get(tier, "threats")
-
         payload = _build_executive_architecture_payload(
-            threats_content=threats_content,
-            tier=tier_source,
+            tier=_TIER_SOURCE_LABEL.get(tier, "threats"),
             findings=findings,
             scope_data=scope,
             source_file=(target_dir / "threats.md"),
@@ -1564,7 +1480,6 @@ def main():
             file=sys.stderr,
         )
         sys.exit(EXIT_SUCCESS)
-    # End F-128 T011 early exit
 
     # Compute severity percentages
     severity_distribution = compute_severity_percentages(severity)

--- a/scripts/extract-infographic-data.py
+++ b/scripts/extract-infographic-data.py
@@ -714,6 +714,7 @@ def _compute_dfd_type_layers(scope_data):
 
 
 def _extract_composite_score(finding):
+    """Prefer composite_score, fall back to residual_score; return float or None."""
     for key in ("composite_score", "residual_score"):
         raw = finding.get(key)
         if raw is None or raw == "":
@@ -726,6 +727,7 @@ def _extract_composite_score(finding):
 
 
 def _extract_description(finding):
+    """Prefer description, fall back to threat, fall back to mitigation."""
     for key in ("description", "threat", "mitigation"):
         val = finding.get(key)
         if val:

--- a/tests/scripts/test_backward_compatibility.py
+++ b/tests/scripts/test_backward_compatibility.py
@@ -1,45 +1,20 @@
-"""F-128 backward compatibility test — byte-identical PDF guarantee.
+"""Backward compatibility test — byte-identical PDF guarantee.
 
-This module implements task T024 for feature 128-prd-128-executive (Wave 4,
-US-2). It proves that the 5 unmodified example PDFs render byte-identical
-before and after the F-128 changes, protecting against silent regressions in
-the PDF security-report pipeline for examples that F-128 does not touch.
+Proves that running the current pipeline against each unmodified example produces
+a PDF byte-identical to the committed ``.baseline``. Byte-identity catches any
+silent regression to the PDF security-report pipeline for examples that recent
+changes do not intentionally touch.
 
-Why byte-identity?
-------------------
-Byte-identity is the strongest possible guarantee that the F-128 code changes
-do not affect outputs for unmodified examples. It catches any regression the
-moment it would change a single pixel of rendered content. See
-``specs/128-prd-128-executive/decisions.md`` Decision 1 for the storage
-rationale (committed ``.baseline`` files) and Decision 3 for the determinism
-rationale (``SOURCE_DATE_EPOCH``).
+Typst embeds wall-clock timestamps into the PDF Info dictionary, XMP metadata
+stream, and ``xmpMM:InstanceID``, so two consecutive invocations normally
+produce non-identical PDFs. The reproducible-builds.org ``SOURCE_DATE_EPOCH``
+convention is honored natively by Typst and pins all timestamp-derived fields.
+This test MUST set the same value used when the baselines were generated,
+otherwise the byte comparison fails inside the metadata region.
 
-Why SOURCE_DATE_EPOCH?
-----------------------
-Typst's default PDF output embeds wall-clock timestamps into the PDF Info
-dictionary (``/ModDate``, ``/CreationDate``), the XMP metadata stream, and a
-timestamp-derived ``xmpMM:InstanceID``. That means two consecutive Typst
-invocations produce non-byte-identical PDFs even when every other byte is the
-same. The reproducible-builds.org convention ``SOURCE_DATE_EPOCH`` is honored
-natively by Typst and pins all timestamp-derived fields to a fixed value. The
-baselines in ``examples/{name}/security-report.pdf.baseline`` were generated
-with ``SOURCE_DATE_EPOCH=1700000000`` (see ``.aod/results/wave-2-baselines.md``
-Resolution section), so this test MUST set the same value or the byte-cmp
-will always fail inside the Typst metadata region.
-
-Scope: 5 baseline examples only
--------------------------------
-This test covers exactly the 5 examples F-128 does NOT modify:
-
-* ``web-app``
-* ``microservices``
-* ``ascii-web-api``
-* ``mermaid-agentic-app``
-* ``free-text-microservice``
-
-The ``agentic-app`` example is intentionally excluded — it is the F-128
-regeneration target (T033) and is not expected to match any pre-F-128
-baseline.
+The ``agentic-app`` example is excluded because it is the regeneration target
+for the executive-architecture template and is not expected to match the
+pre-existing baseline.
 """
 
 import os
@@ -50,20 +25,16 @@ from pathlib import Path
 import pytest
 
 
-# Repository root resolved from this file's location:
-# tests/scripts/test_backward_compatibility.py -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "extract-report-data.py"
 TEMPLATE_DIR = REPO_ROOT / "templates" / "tachi" / "security-report"
 TEMPLATE_MAIN = TEMPLATE_DIR / "main.typ"
 REPORT_DATA_TYP = TEMPLATE_DIR / "report-data.typ"
 
-# Fixed epoch from decisions.md Decision 3. Do NOT change this value without
-# regenerating all 5 .baseline files in the same commit — any other value will
-# make Typst emit different metadata timestamps and the cmp will fail.
+# Do NOT change this without regenerating all .baseline files in the same commit —
+# any other value will make Typst emit different metadata timestamps and cmp will fail.
 SOURCE_DATE_EPOCH = "1700000000"
 
-# The 5 examples that must remain byte-identical across F-128.
 BASELINE_EXAMPLES = [
     "web-app",
     "microservices",
@@ -74,12 +45,6 @@ BASELINE_EXAMPLES = [
 
 
 def _hex_context(data: bytes, offset: int, window: int = 16) -> str:
-    """Return a human-readable hex dump of ``data`` around ``offset``.
-
-    Used in the failure message to show exactly where two PDFs diverge. The
-    window is ``±window`` bytes around the divergence, clamped to the buffer
-    bounds.
-    """
     start = max(0, offset - window)
     end = min(len(data), offset + window + 1)
     chunk = data[start:end]
@@ -88,14 +53,6 @@ def _hex_context(data: bytes, offset: int, window: int = 16) -> str:
 
 
 def _find_first_divergence(a: bytes, b: bytes) -> int:
-    """Return the byte offset of the first mismatch between ``a`` and ``b``.
-
-    If the buffers are the same length and byte-identical, this is not called
-    because the equality assertion passes first. If the buffers differ in
-    length, the offset returned is the first differing position up to the
-    shorter length, or the shorter length itself if one is a strict prefix of
-    the other.
-    """
     min_len = min(len(a), len(b))
     for i in range(min_len):
         if a[i] != b[i]:
@@ -103,48 +60,23 @@ def _find_first_divergence(a: bytes, b: bytes) -> int:
     return min_len
 
 
+@pytest.mark.slow
 @pytest.mark.parametrize("example_name", BASELINE_EXAMPLES)
 def test_unmodified_examples_byte_identical_pdfs(
     example_name: str, tmp_path: Path
 ) -> None:
-    """Assert that running the F-128 pipeline produces a byte-identical PDF.
-
-    For each example in ``BASELINE_EXAMPLES``:
-
-    1. Locate the committed baseline at
-       ``examples/{name}/security-report.pdf.baseline``.
-    2. Run ``scripts/extract-report-data.py`` against
-       ``examples/{name}/`` to regenerate ``report-data.typ``.
-    3. Run ``typst compile`` on ``main.typ`` with
-       ``SOURCE_DATE_EPOCH=1700000000`` set, writing the PDF to
-       ``tmp_path/security-report.pdf``.
-    4. Read both files as bytes and assert byte-identity.
-    5. On failure, surface the first diverging byte offset with ±16 bytes of
-       hex context for diagnosis.
-
-    The intermediate ``report-data.typ`` is cleaned up in a ``finally`` block
-    so a failed assertion does not leave stale state for the next test case.
-    """
+    """Regenerate report-data.typ, run typst compile, and assert bytes match the baseline."""
     target_dir = REPO_ROOT / "examples" / example_name
     baseline_pdf = target_dir / "security-report.pdf.baseline"
     generated_pdf = tmp_path / "security-report.pdf"
 
-    # Pre-condition: baseline must exist. If it's missing, T003d didn't copy
-    # the file into place — fail loud and direct the reader at the right task.
     assert baseline_pdf.exists(), (
-        f"Baseline PDF missing for example '{example_name}': {baseline_pdf}. "
-        "Expected file to be present from Wave 2 task T003d. See "
-        ".aod/results/wave-2-baselines.md for generation procedure."
+        f"Baseline PDF missing for example '{example_name}': {baseline_pdf}"
     )
 
-    # Environment for both subprocess invocations: inherit current env and
-    # pin SOURCE_DATE_EPOCH so Typst produces deterministic timestamps.
     pipeline_env = {**os.environ, "SOURCE_DATE_EPOCH": SOURCE_DATE_EPOCH}
 
     try:
-        # Step 1: Extract report data from the example's threats.md (and
-        # friends) into templates/tachi/security-report/report-data.typ. The
-        # script overwrites in place; cleanup happens in the finally block.
         extract_cmd = [
             sys.executable,
             str(SCRIPT_PATH),
@@ -163,9 +95,6 @@ def test_unmodified_examples_byte_identical_pdfs(
             capture_output=True,
         )
 
-        # Step 2: Compile main.typ to PDF. --root . ties Typst's import
-        # resolution to the repo root, matching how the baselines were
-        # produced (see wave-2-baselines.md section T003b).
         compile_cmd = [
             "typst",
             "compile",
@@ -182,19 +111,12 @@ def test_unmodified_examples_byte_identical_pdfs(
             capture_output=True,
         )
 
-        # Read both PDFs as raw bytes for the comparison.
         baseline_bytes = baseline_pdf.read_bytes()
         generated_bytes = generated_pdf.read_bytes()
 
-        # Fast-path: equal bytes means the test passes.
         if baseline_bytes == generated_bytes:
             return
 
-        # Failure path: surface the first divergence with hex context so a
-        # human reviewer can tell at a glance whether the mismatch is in
-        # content (unexpected F-128 regression) or metadata (unexpected
-        # determinism issue — should not happen because SOURCE_DATE_EPOCH is
-        # set, but worth distinguishing in the error).
         divergence = _find_first_divergence(baseline_bytes, generated_bytes)
         baseline_ctx = _hex_context(baseline_bytes, divergence)
         generated_ctx = _hex_context(generated_bytes, divergence)
@@ -209,17 +131,13 @@ def test_unmodified_examples_byte_identical_pdfs(
             f"  Baseline context:  {baseline_ctx}\n"
             f"  Generated context: {generated_ctx}\n"
             f"  SOURCE_DATE_EPOCH={SOURCE_DATE_EPOCH} (determinism pin).\n"
-            "  If offset is inside the PDF Info dictionary or XMP stream, "
+            "  If the offset is inside the PDF Info dictionary or XMP stream, "
             "the env var is not being honored (determinism regression). "
-            "Otherwise this is a real F-128 backward-compat break — "
-            "investigate the script/template change that would alter "
-            "unmodified examples."
+            "Otherwise investigate any script or template change that would "
+            "alter unmodified examples."
         )
 
     except subprocess.CalledProcessError as exc:
-        # Surface the subprocess stderr so pipeline errors don't masquerade as
-        # a silent comparison failure. This also helps debug PATH or Typst
-        # version drift in CI environments.
         stderr = (exc.stderr or b"").decode("utf-8", errors="replace")
         stdout = (exc.stdout or b"").decode("utf-8", errors="replace")
         raise AssertionError(
@@ -231,14 +149,10 @@ def test_unmodified_examples_byte_identical_pdfs(
         ) from exc
 
     finally:
-        # Always remove the generated report-data.typ so the next test case
-        # (or any other test that runs after) starts from a clean template
-        # directory. The template dir does not commit report-data.typ, so
-        # leaving it behind would also pollute the working tree.
+        # Remove the generated report-data.typ so the template dir stays clean
+        # for any subsequent test. The template dir does not commit this file.
         if REPORT_DATA_TYP.exists():
             try:
                 REPORT_DATA_TYP.unlink()
             except OSError:
-                # Best-effort cleanup; do not mask the primary assertion
-                # failure if unlink races with something.
                 pass

--- a/tests/scripts/test_command_dispatch.py
+++ b/tests/scripts/test_command_dispatch.py
@@ -1,29 +1,15 @@
-"""F-128 command dispatch tests (T026) — US-3 file-content assertions.
+"""Command dispatch tests for the ``tachi.infographic`` command file.
 
-This module implements task T026 for feature 128-prd-128-executive (Wave 5,
-US-3). It verifies that ``.claude/commands/tachi.infographic.md`` registers
-the new ``executive-architecture`` template in two places the user can reach:
+Verifies that ``.claude/commands/tachi.infographic.md`` registers the new
+``executive-architecture`` template in the two user-reachable places: the
+``all`` shorthand expansion, and the short ``exec`` alias (matching the
+existing alias convention: ``corporate-white`` → ``baseball-card``,
+``maestro`` → maestro pair).
 
-1. The ``all`` shorthand expansion — running ``/tachi.infographic`` with no
-   ``--template`` flag (or ``--template all``) must generate the executive
-   architecture infographic alongside the other templates.
-2. The ``exec`` alias — a short alias mapping to ``executive-architecture``
-   so users can type ``/tachi.infographic --template exec`` instead of the
-   full template name. This matches the existing alias convention
-   (``corporate-white`` → ``baseball-card``, ``maestro`` → maestro pair).
-
-These are **file-content assertions**, not script invocations. They open the
-command markdown file and assert string presence. They will initially FAIL
-until T027 lands the corresponding command file edits. T028 is the gate
-check that re-runs these tests after T027 has shipped.
-
-Why file-content tests instead of parsing?
-------------------------------------------
-The command file is hand-authored markdown with prose, YAML-ish fragments,
-and bullet lists. A full markdown AST parse would be brittle and misleading
-— the user-facing contract is "the template appears in the ``all``
-expansion list and the ``exec`` alias is documented". Simple substring
-checks verify exactly that contract without coupling to formatting.
+These are file-content assertions — the command file is hand-authored
+markdown with prose, YAML-ish fragments, and bullet lists, and a full AST
+parse would be brittle. Simple substring checks verify the user-facing
+contract without coupling to formatting.
 """
 
 from __future__ import annotations
@@ -38,9 +24,8 @@ COMMAND_FILE = REPO_ROOT / ".claude" / "commands" / "tachi.infographic.md"
 def _read_command_file() -> str:
     """Read the infographic command file. Fails loudly if missing."""
     assert COMMAND_FILE.exists(), (
-        f"Command file not found: {COMMAND_FILE}. T026 expects the existing "
-        f"tachi.infographic command to be present — this test asserts content, "
-        f"not existence."
+        f"Command file not found: {COMMAND_FILE}. This test asserts content, "
+        f"not existence — the file must be present in the checked-out tree."
     )
     return COMMAND_FILE.read_text(encoding="utf-8")
 
@@ -68,11 +53,8 @@ def test_all_shorthand_includes_executive_architecture() -> None:
     """
     content = _read_command_file()
 
-    # Locate the "all expands to" expansion block. The current file uses the
-    # phrase: `"all" expands to: baseball-card, system-architecture, risk-funnel.`
-    # T027 will add `executive-architecture` to that list. Capture the full
-    # sentence (up to the next period or newline-bullet) so we can assert
-    # membership against only the expansion text.
+    # Locate the expansion sentence so we only assert membership against the
+    # expansion text, not any unrelated mention elsewhere in the file.
     match = re.search(
         r'"all"\s+expands\s+to:\s*([^\n]+)',
         content,
@@ -91,44 +73,21 @@ def test_all_shorthand_includes_executive_architecture() -> None:
         "Expected `executive-architecture` to be listed alongside "
         "baseball-card, system-architecture, and risk-funnel so that "
         "`/tachi.infographic` (default template=all) generates the executive "
-        "infographic. Fix in .claude/commands/tachi.infographic.md Step 2 "
-        "template expansion rules (T027)."
+        "infographic. Fix in .claude/commands/tachi.infographic.md Step 2."
     )
 
 
 def test_exec_alias_dispatches_to_executive_architecture() -> None:
     """The ``exec`` alias must map to ``executive-architecture``.
 
-    The existing command file documents aliases two ways:
-
-    * In the Step 0 valid-values list (``corporate-white`` appears alongside
-      the canonical template names)
-    * In the Step 0 resolution rule (``If value is `corporate-white`: resolve
-      alias to `baseball-card```)
-
-    T027 should add ``exec`` following the same convention. This test does
-    not mandate a specific format — it accepts any of:
-
-    * ``exec`` listed in the valid values enumeration AND a resolution rule
-      ``If value is `exec`: resolve alias to `executive-architecture```
-    * A one-line alias mapping like ``exec → executive-architecture``
-    * An entry in a dedicated Aliases line (``Aliases: corporate-white →
-      baseball-card, exec → executive-architecture, ...``)
-
-    The test asserts two things:
-
-    1. The token ``exec`` appears somewhere in the file as a standalone word
-       (not as a substring of ``executive-architecture``)
-    2. That standalone ``exec`` reference appears on a line that also
-       mentions ``executive-architecture`` — this proves the mapping is
-       explicit, not accidental
+    Accepts any format: a dedicated resolution rule, a one-line mapping, or an
+    entry in an Aliases line. The test asserts (1) ``exec`` appears as a standalone
+    token and (2) at least one line containing standalone ``exec`` also mentions
+    ``executive-architecture``, proving the mapping is explicit.
     """
     content = _read_command_file()
 
-    # Find every line in the file that mentions `exec` as a standalone
-    # identifier. We strip out occurrences that are just substrings of
-    # `executive-architecture` by using a negative lookahead — `exec` must
-    # NOT be followed by `utive-architecture`.
+    # Negative lookahead so `exec` inside `executive-architecture` does not match.
     standalone_exec_pattern = re.compile(r"\bexec\b(?!utive-architecture)")
 
     matching_lines: list[str] = []
@@ -138,14 +97,11 @@ def test_exec_alias_dispatches_to_executive_architecture() -> None:
 
     assert matching_lines, (
         "No standalone `exec` token found in "
-        f"{COMMAND_FILE}. T027 must document `exec` as an alias for "
-        "`executive-architecture` — add it to the Step 0 valid values list "
-        "AND the alias resolution rule, following the `corporate-white → "
+        f"{COMMAND_FILE}. Document `exec` as an alias for "
+        "`executive-architecture` following the `corporate-white → "
         "baseball-card` precedent."
     )
 
-    # At least one of those lines must also mention `executive-architecture`
-    # — that is the explicit mapping that proves `exec` is an alias.
     lines_with_mapping = [
         line for line in matching_lines if "executive-architecture" in line
     ]
@@ -154,7 +110,5 @@ def test_exec_alias_dispatches_to_executive_architecture() -> None:
         "line that also mentions `executive-architecture`. The alias "
         "mapping must be explicit — e.g. `If value is `exec`: resolve alias "
         "to `executive-architecture`` — so users and agents can trace the "
-        f"dispatch. Lines with standalone `exec`: {matching_lines!r}. "
-        "Fix in .claude/commands/tachi.infographic.md Step 0 alias "
-        "resolution rules (T027)."
+        f"dispatch. Lines with standalone `exec`: {matching_lines!r}."
     )

--- a/tests/scripts/test_extract_infographic_data.py
+++ b/tests/scripts/test_extract_infographic_data.py
@@ -1,20 +1,8 @@
-"""US-1 unit tests for the executive-architecture template in extract-infographic-data.py.
+"""Unit tests for the executive-architecture template in extract-infographic-data.py.
 
-These tests exercise the Phase 3 implementation of F-128. They use a mix of
-subprocess invocation (for end-to-end behavior and exit-code assertions) and
-direct module-level calls through the `extract_infographic_data` conftest
-fixture (for helper-function and shape assertions).
-
-Note on the test-first gate (T007):
------------------------------------
-Tests 1-11 assert behavior that does NOT yet exist in the script (the
-executive-architecture dispatch branch, helper functions, and payload shape).
-They are expected to FAIL on T007 (the gate) and PASS after T012.
-
-Test 12 (`test_existing_templates_unchanged`) compares the 5 pre-existing
-templates to golden files captured BEFORE the dispatch branch was added. It
-is expected to PASS at T007 (as a backward-compat baseline) and continue
-passing at T012.
+Exercises both subprocess invocation (for end-to-end behavior and exit codes) and
+direct module-level calls through the ``extract_infographic_data`` conftest fixture
+(for helper-function and payload-shape assertions).
 """
 
 import json
@@ -26,23 +14,14 @@ from pathlib import Path
 
 import pytest
 
-# Repository root resolved from this file's location:
-# tests/scripts/test_extract_infographic_data.py -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "extract-infographic-data.py"
 FIXTURES_DIR = REPO_ROOT / "tests" / "scripts" / "fixtures" / "exec_arch"
 GOLDEN_DIR = REPO_ROOT / "tests" / "scripts" / "fixtures" / "golden"
 
 
-# -----------------------------------------------------------------------------
-# Subprocess helper
-# -----------------------------------------------------------------------------
-
 def run_extract(target_dir, template, extra_args=None):
-    """Run extract-infographic-data.py as a subprocess.
-
-    Returns: (returncode, stdout, stderr, payload_dict_or_None)
-    """
+    """Run extract-infographic-data.py and return (returncode, stdout, stderr, payload)."""
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as f:
         output_path = f.name
     try:
@@ -72,10 +51,6 @@ def run_extract(target_dir, template, extra_args=None):
         except OSError:
             pass
 
-
-# -----------------------------------------------------------------------------
-# US-1 Tests
-# -----------------------------------------------------------------------------
 
 def test_executive_architecture_happy_path():
     """Agentic-app fixture: exit 0, ≥1 layer, ≥1 callout, skip_image=False."""
@@ -427,7 +402,7 @@ def test_build_executive_architecture_payload_helper(extract_infographic_data):
         {"id": "I-1", "component": "DB", "threat": "info disclosure",
          "risk_level": "Medium"},  # excluded
     ]
-    payload = build(None, "threats", findings, scope, "/tmp/threats.md")
+    payload = build("threats", findings, scope, "/tmp/threats.md")
     assert payload["metadata"]["template_name"] == "executive-architecture"
     assert payload["metadata"]["tier_source"] == "threats"
     assert payload["metadata"]["source_file"] == "/tmp/threats.md"
@@ -450,7 +425,7 @@ def test_build_executive_architecture_payload_helper(extract_infographic_data):
         {"id": "L-1", "component": "API Gateway", "threat": "low issue",
          "risk_level": "Low"},
     ]
-    payload = build(None, "threats", findings_low, scope, "/tmp/threats.md")
+    payload = build("threats", findings_low, scope, "/tmp/threats.md")
     assert payload["metadata"]["skip_image"] is True
     assert payload["callouts"] == []
     assert payload["severity_distribution"]["total_qualifying"] == 0
@@ -465,7 +440,7 @@ def test_build_executive_architecture_payload_helper(extract_infographic_data):
         "trust_boundaries": [],
         "boundary_crossings": [],
     }
-    payload = build(None, "threats", findings[:2], fallback_scope, "/tmp/threats.md")
+    payload = build("threats", findings[:2], fallback_scope, "/tmp/threats.md")
     assert payload["metadata"]["fallback_used"] is True
     assert all(layer["source_kind"] == "dfd_type" for layer in payload["layers"])
 
@@ -476,7 +451,7 @@ def test_build_executive_architecture_payload_helper(extract_infographic_data):
         "trust_boundaries": [],
         "boundary_crossings": [],
     }
-    result = build(None, "threats", [], empty_scope, "/tmp/threats.md")
+    result = build("threats", [], empty_scope, "/tmp/threats.md")
     assert result == {"error": "no_scope_data"}
 
 
@@ -491,11 +466,10 @@ def test_build_executive_architecture_payload_helper(extract_infographic_data):
     ],
 )
 def test_existing_templates_unchanged(template):
-    """Pre-existing templates produce byte-identical output to pre-F-128 golden files.
+    """Pre-existing templates produce byte-identical output to the frozen golden files.
 
-    The goldens in `tests/scripts/fixtures/golden/` were captured before the
-    executive-architecture dispatch branch was added. Any drift indicates a
-    backward-compatibility regression.
+    Goldens in ``tests/scripts/fixtures/golden/`` are the backward-compatibility
+    baseline — any drift indicates a regression in an existing template.
     """
     golden_path = GOLDEN_DIR / f"{template}.json"
     assert golden_path.exists(), f"Missing golden file: {golden_path}"

--- a/tests/scripts/test_extract_report_data.py
+++ b/tests/scripts/test_extract_report_data.py
@@ -1,32 +1,9 @@
-"""US-2 unit tests for the executive-architecture image detection in extract-report-data.py.
+"""Unit tests for executive-architecture image detection in extract-report-data.py.
 
-These tests exercise the Phase 4 (US-2) implementation of F-128. They invoke
-`scripts/extract-report-data.py` as a subprocess via ``sys.executable`` and
-assert against the generated ``report-data.typ`` content. Direct helper-function
-access is exposed by the ``extract_report_data`` session-scoped fixture
-declared in ``tests/conftest.py``; this file uses subprocess invocation because
-the assertions target the final emitted Typst text rather than intermediate
-Python state.
-
-Note on the test-first gate (T017):
------------------------------------
-F-128 tasks T018/T019 add the `has-executive-architecture` and
-`executive-architecture-image-path` Typst variables. At the time T016 authors
-these tests, those lines do NOT yet exist in ``extract-report-data.py``. The
-expected failure pattern is:
-
-* ``test_has_executive_architecture_true_when_image_present``   — FAIL
-* ``test_has_executive_architecture_false_when_image_absent``   — may pre-pass
-  (the absence of any ``has-executive-architecture = false`` line is what the
-  assertion actually checks for; see inline rationale below)
-* ``test_has_executive_architecture_false_when_image_zero_size`` — FAIL
-* ``test_executive_architecture_image_path_relative_to_template_dir`` — FAIL
-* ``test_existing_image_flags_unchanged``                       — PASS
-  (backward-compat baseline; must stay green before and after T018/T019)
-
-The T017 gate runs ``make test`` (or ``pytest tests/scripts/test_extract_report_data.py -v``)
-and records the expected-failure set. Once T018/T019 land, all 5 tests must
-pass, including the parametrized ``test_existing_image_flags_unchanged``.
+Invokes ``scripts/extract-report-data.py`` as a subprocess and asserts against the
+generated ``report-data.typ`` content. Subprocess invocation is used instead of
+direct module access because the assertions target the emitted Typst text rather
+than intermediate Python state.
 """
 
 import os
@@ -38,8 +15,6 @@ from pathlib import Path
 import pytest
 
 
-# Repository root resolved from this file's location:
-# tests/scripts/test_extract_report_data.py -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "extract-report-data.py"
 TEMPLATE_DIR = REPO_ROOT / "templates" / "tachi" / "security-report"
@@ -48,25 +23,8 @@ GOLDEN_EXISTING_FLAGS = FIXTURES_DIR / "golden_existing_image_flags.txt"
 AGENTIC_APP_SAMPLE = REPO_ROOT / "examples" / "agentic-app" / "sample-report"
 
 
-# -----------------------------------------------------------------------------
-# Subprocess helper
-# -----------------------------------------------------------------------------
-
 def run_extract(target_dir, template_dir=None):
-    """Run extract-report-data.py as a subprocess against a target folder.
-
-    Args:
-        target_dir: Path to the folder containing ``threats.md`` and optional
-            image files. The script writes ``report-data.typ`` into a temp
-            location; this helper returns the emitted content as a string.
-        template_dir: Optional override for ``--template-dir``. Defaults to
-            the real ``templates/tachi/security-report/`` directory so path
-            resolution matches production behavior.
-
-    Returns:
-        Tuple ``(returncode, stdout, stderr, typst_content_or_None)``. The
-        fourth element is ``None`` when the script fails to write output.
-    """
+    """Run extract-report-data.py and return (returncode, stdout, stderr, typst_content)."""
     if template_dir is None:
         template_dir = TEMPLATE_DIR
     with tempfile.NamedTemporaryFile(suffix=".typ", delete=False) as f:
@@ -95,18 +53,8 @@ def run_extract(target_dir, template_dir=None):
             pass
 
 
-# -----------------------------------------------------------------------------
-# US-2 Tests
-# -----------------------------------------------------------------------------
-
 def test_has_executive_architecture_true_when_image_present():
-    """Fixture folder with a non-zero threat-executive-architecture.jpg.
-
-    Contract: ``report-data.typ`` must contain the exact line
-    ``#let has-executive-architecture = true`` when the image file exists and
-    has non-zero size. Pre-F-128 the line is absent entirely; this test
-    therefore FAILS until T018/T019 ship.
-    """
+    """Emit ``#let has-executive-architecture = true`` when the image is present and non-zero."""
     returncode, _stdout, stderr, content = run_extract(FIXTURES_DIR / "image_present")
     assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
     assert content is not None, "Expected report-data.typ to be written"
@@ -117,18 +65,7 @@ def test_has_executive_architecture_true_when_image_present():
 
 
 def test_has_executive_architecture_false_when_image_absent():
-    """Fixture folder without the executive architecture image.
-
-    Contract: when the image file is missing, the emitted Typst file must
-    contain ``#let has-executive-architecture = false`` — i.e. the variable
-    is still declared with a false value, not omitted. This asserts the
-    variable is ALWAYS present (safe default), not that the absence of the
-    image makes the line implicitly absent.
-
-    This test will FAIL pre-F-128 because no ``has-executive-architecture``
-    line exists at all — including the ``= false`` form required by the
-    contract. It PASSES after T018/T019 ship the safe-default writer.
-    """
+    """When the image is missing, the variable must still be declared ``= false`` (safe default)."""
     returncode, _stdout, stderr, content = run_extract(FIXTURES_DIR / "image_absent")
     assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
     assert content is not None, "Expected report-data.typ to be written"
@@ -143,12 +80,7 @@ def test_has_executive_architecture_false_when_image_absent():
 
 
 def test_has_executive_architecture_false_when_image_zero_size():
-    """Fixture with an empty (zero-byte) threat-executive-architecture.jpg.
-
-    Contract: a zero-byte file is treated as absent (matches the existing
-    ``stat().st_size > 0`` convention in ``detect_images``). The emitted
-    line must be ``#let has-executive-architecture = false``.
-    """
+    """A zero-byte image file is treated as absent (matching the ``st_size > 0`` convention)."""
     returncode, _stdout, stderr, content = run_extract(FIXTURES_DIR / "image_zero_size")
     assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
     assert content is not None, "Expected report-data.typ to be written"
@@ -162,21 +94,11 @@ def test_has_executive_architecture_false_when_image_zero_size():
 
 
 def test_executive_architecture_image_path_relative_to_template_dir():
-    """When the image is present, the emitted path must be relative (not absolute).
+    """The emitted ``executive-architecture-image-path`` must be relative, not absolute.
 
-    Contract (``report-data-typst-contract.md``): the path is computed via
-    ``os.path.relpath(target_dir, template_dir)``, following the same
-    convention as the existing funnel/baseball/architecture paths. For the
-    ``image_present`` fixture living under ``tests/scripts/fixtures/report_data/``,
-    the relative path from ``templates/tachi/security-report/`` MUST begin
-    with ``..`` (parent traversal) because the fixture directory is outside
-    the template directory tree.
-
-    Additional assertions:
-
-    * The path must NOT start with ``/`` (no absolute paths).
-    * The path must end with ``threat-executive-architecture.jpg``.
-    * The line must be declared via ``#let executive-architecture-image-path =``.
+    Path is computed via ``os.path.relpath(target_dir, template_dir)`` matching the
+    existing funnel/baseball/architecture convention. The fixture lives outside the
+    template directory tree so the relative path must begin with ``..``.
     """
     returncode, _stdout, stderr, content = run_extract(FIXTURES_DIR / "image_present")
     assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
@@ -213,6 +135,33 @@ def test_executive_architecture_image_path_relative_to_template_dir():
     )
 
 
+@pytest.fixture(scope="module")
+def agentic_app_report_typst():
+    """Run extract-report-data.py once against the agentic-app sample and cache the output."""
+    returncode, _stdout, stderr, content = run_extract(AGENTIC_APP_SAMPLE)
+    assert returncode == 0, (
+        f"Expected exit 0 for agentic-app sample-report, got {returncode}. "
+        f"stderr: {stderr}"
+    )
+    assert content is not None, "Expected report-data.typ to be written"
+    return content
+
+
+@pytest.fixture(scope="module")
+def golden_image_flag_lines():
+    assert GOLDEN_EXISTING_FLAGS.exists(), (
+        f"Missing golden fixture: {GOLDEN_EXISTING_FLAGS}"
+    )
+    lines = [
+        line for line in GOLDEN_EXISTING_FLAGS.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert len(lines) == 5, (
+        f"Expected exactly 5 lines in {GOLDEN_EXISTING_FLAGS.name}, got {len(lines)}"
+    )
+    return lines
+
+
 @pytest.mark.parametrize(
     "expected_line",
     [
@@ -223,55 +172,16 @@ def test_executive_architecture_image_path_relative_to_template_dir():
         "#let has-maestro-heatmap-image = false",
     ],
 )
-def test_existing_image_flags_unchanged(expected_line):
-    """Pre-existing image flag lines are byte-identical to the pre-F-128 golden.
-
-    The golden file ``golden_existing_image_flags.txt`` was captured BEFORE
-    the executive-architecture detection branch was added to
-    ``extract-report-data.py`` by running the script against
-    ``examples/agentic-app/sample-report/``. That folder has funnel, baseball,
-    and architecture JPEGs present but no MAESTRO images, producing the 5
-    canonical flag values used as the backward-compat baseline.
-
-    This test re-runs the script against the same folder and asserts that
-    each of the 5 ``#let has-*-image = ...`` lines appears byte-identically
-    in the new output. A regression here indicates F-128 accidentally
-    modified an existing image flag's emission format, variable name, or
-    default value — all of which would break every downstream example.
-
-    Unlike the other 4 tests, this one is expected to PASS at T017 (before
-    T018/T019) and continue passing after T018/T019. It is a frozen
-    backward-compatibility baseline.
-    """
-    # Load the golden file; it must exist with exactly 5 lines.
-    assert GOLDEN_EXISTING_FLAGS.exists(), (
-        f"Missing golden fixture: {GOLDEN_EXISTING_FLAGS}"
-    )
-    golden_lines = [
-        line for line in GOLDEN_EXISTING_FLAGS.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
-    assert len(golden_lines) == 5, (
-        f"Expected exactly 5 lines in {GOLDEN_EXISTING_FLAGS.name}, "
-        f"got {len(golden_lines)}"
-    )
-    # The parametrized expected_line must be in the golden file (sanity check
-    # that the test and the golden agree).
-    assert expected_line in golden_lines, (
+def test_existing_image_flags_unchanged(
+    expected_line, agentic_app_report_typst, golden_image_flag_lines
+):
+    """Pre-existing image flag lines stay byte-identical to the frozen golden baseline."""
+    assert expected_line in golden_image_flag_lines, (
         f"Test parameter {expected_line!r} is not in golden file. "
-        f"Golden contents: {golden_lines!r}"
+        f"Golden contents: {golden_image_flag_lines!r}"
     )
 
-    # Re-run the script against the canonical agentic-app sample-report folder.
-    returncode, _stdout, stderr, content = run_extract(AGENTIC_APP_SAMPLE)
-    assert returncode == 0, (
-        f"Expected exit 0 for agentic-app sample-report, got {returncode}. "
-        f"stderr: {stderr}"
-    )
-    assert content is not None, "Expected report-data.typ to be written"
-
-    # Byte-identical line match.
-    output_lines = content.splitlines()
+    output_lines = agentic_app_report_typst.splitlines()
     assert expected_line in output_lines, (
         f"Golden flag line drifted. Expected line {expected_line!r} "
         f"not found in generated report-data.typ. Backward compatibility regression."

--- a/tests/scripts/test_pdf_page_positioning.py
+++ b/tests/scripts/test_pdf_page_positioning.py
@@ -1,39 +1,21 @@
-"""US-2 PDF page-positioning test for the Executive Threat Architecture page.
+"""PDF page-positioning tests for the Executive Threat Architecture page.
 
-This module automates the T023 manual end-to-end verification (see
-``specs/128-prd-128-executive/manual-verification.md``): it runs the full
-extraction + Typst compile pipeline against ``examples/agentic-app/sample-report/``
-with a placeholder ``threat-executive-architecture.jpg`` in place, then asserts
-that the rendered PDF places the Executive Threat Architecture page *between*
-Executive Summary and Attack Path Analysis.
+Runs the extraction + Typst compile pipeline against
+``examples/agentic-app/sample-report/`` with a placeholder
+``threat-executive-architecture.jpg`` in place, then asserts that the rendered
+PDF places the Executive Threat Architecture page *between* Executive Summary
+and Attack Path Analysis.
 
-Why relative ordering only
---------------------------
-The absolute page numbers observed in T023 (10 / 11 / 12) are example-dependent:
-the number of findings, attack trees, and optional infographic images can all
-shift the three sections forward or backward across examples. This test asserts
-*relative order* only — Executive Threat Architecture > Executive Summary AND
-Executive Threat Architecture < Attack Path Analysis — so it survives any
-legitimate content drift on the ``agentic-app`` example without needing to be
-re-baselined.
+Absolute page numbers are content-dependent (findings, attack trees, and optional
+infographic images all shift sections forward and backward), so this test asserts
+*relative order* only. That lets it survive legitimate content drift on the
+``agentic-app`` example without a baseline rebuild.
 
-Why the placeholder JPEG
-------------------------
-``examples/agentic-app/sample-report/`` does not yet contain a real
-Gemini-generated ``threat-executive-architecture.jpg``; that image will land in
-T033 (Phase 7 regeneration). Until then, the ``has-executive-architecture``
-flag in ``extract-report-data.py`` only checks for *presence* and *non-zero
-size* of the file, so we copy the existing ``threat-system-architecture.jpg``
-under the new name to satisfy the detection logic. The placeholder is removed
-in a ``try/finally`` block regardless of test outcome — leaving stale files in
-the examples tree would pollute downstream tasks.
-
-T029 placeholder
-----------------
-The skip-image branch (flag=false, page should NOT appear) is covered by T029
-in Wave 5 (US-4) via a second test function
-``test_executive_architecture_skip_image_pdf_omits_page`` that will be appended
-to this same file. This file intentionally leaves room for that second test.
+The placeholder JPEG is a copy of the real ``threat-system-architecture.jpg``
+under the executive-architecture filename, used because
+``has-executive-architecture`` in ``extract-report-data.py`` only checks for
+presence and non-zero size. The placeholder is removed in a ``try/finally``
+block regardless of test outcome so it does not pollute the examples tree.
 """
 
 import os
@@ -45,8 +27,6 @@ from pathlib import Path
 import pytest
 
 
-# Repository root resolved from this file's location:
-# tests/scripts/test_pdf_page_positioning.py -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPT_PATH = REPO_ROOT / "scripts" / "extract-report-data.py"
 TEMPLATE_DIR = REPO_ROOT / "templates" / "tachi" / "security-report"
@@ -56,14 +36,11 @@ AGENTIC_APP_SAMPLE = REPO_ROOT / "examples" / "agentic-app" / "sample-report"
 SOURCE_JPEG = AGENTIC_APP_SAMPLE / "threat-system-architecture.jpg"
 PLACEHOLDER_JPEG = AGENTIC_APP_SAMPLE / "threat-executive-architecture.jpg"
 
-# Deterministic timestamp for compile reproducibility (consistent with T024).
 SOURCE_DATE_EPOCH = "1700000000"
 
-# How many leading lines of each extracted page we scan for section headings.
-# 25 is enough to cover the typical section-divider layout (header + title +
-# leading content). TOC pages are excluded via the "Table of Contents" marker
-# (see ``_find_first_page_with_heading``), so this window can safely be a bit
-# generous without risk of capturing TOC entries.
+# 25 covers the typical section-divider layout (header + title + leading content).
+# TOC pages are filtered via the "Table of Contents" marker in
+# _find_first_page_with_heading, so this window can be generous without risk.
 PAGE_HEADING_SCAN_LINES = 25
 
 
@@ -107,28 +84,10 @@ def _find_first_page_with_heading(pages, heading):
     return None
 
 
+@pytest.mark.slow
 def test_executive_architecture_page_position(tmp_path):
-    """Verify the Executive Threat Architecture page renders between Exec Summary
-    and Attack Path Analysis when the placeholder image is present.
-
-    Pipeline:
-        1. Copy ``threat-system-architecture.jpg`` to
-           ``threat-executive-architecture.jpg`` in the agentic-app sample
-           folder (placeholder — T033 will replace with real Gemini output).
-        2. Run ``scripts/extract-report-data.py`` to emit ``report-data.typ``
-           with ``has-executive-architecture = true`` and the relative image
-           path.
-        3. Run ``typst compile`` against ``main.typ`` producing a PDF in
-           ``tmp_path``.
-        4. Extract per-page text with ``pdftotext -layout`` and split on the
-           form-feed (``\\x0c``) separator.
-        5. Locate the first page containing each of the three section
-           headings in its first 25 lines.
-        6. Assert relative ordering + small spread window.
-
-    Cleanup runs in a ``finally`` block regardless of outcome: the placeholder
-    JPEG and the intermediate ``report-data.typ`` are both deleted.
-    """
+    """Stage the placeholder JPEG, run the pipeline, and assert the Executive Threat
+    Architecture page renders between Executive Summary and Attack Path Analysis."""
     # Guard: skip if neither pdftotext nor pypdf is available. pdftotext is
     # installed on the dev machine and in CI; this is purely defensive.
     pdftotext_bin = shutil.which("pdftotext")
@@ -159,9 +118,8 @@ def test_executive_architecture_page_position(tmp_path):
     placeholder_created = False
     report_data_created = False
     try:
-        # Step 1: Stage the placeholder JPEG. Only create if not already
-        # present — if a previous test left one behind (shouldn't happen, but
-        # defensive), we don't clobber it.
+        # Stage the placeholder only if not already present — don't clobber a
+        # previous test's leftover.
         if not PLACEHOLDER_JPEG.exists():
             shutil.copyfile(SOURCE_JPEG, PLACEHOLDER_JPEG)
             placeholder_created = True
@@ -173,11 +131,9 @@ def test_executive_architecture_page_position(tmp_path):
             "detection requires non-zero size."
         )
 
-        # Deterministic env for reproducible Typst output (parity with T024)
         env = os.environ.copy()
         env["SOURCE_DATE_EPOCH"] = SOURCE_DATE_EPOCH
 
-        # Step 2: Run the extraction script against the agentic-app sample
         extract_cmd = [
             sys.executable,
             str(SCRIPT_PATH),
@@ -212,9 +168,9 @@ def test_executive_architecture_page_position(tmp_path):
             f"{report_data_content[:500]}"
         )
 
-        # Step 3: Typst compile. --root . ensures the template can resolve
-        # the relative image path computed by extract-report-data.py (which
-        # walks up from templates/tachi/security-report/ to examples/...).
+        # --root pins Typst to the repo root so it can resolve the relative
+        # image path computed by extract-report-data.py (which walks up from
+        # templates/tachi/security-report/ to examples/...).
         compile_cmd = [
             "typst",
             "compile",
@@ -237,8 +193,6 @@ def test_executive_architecture_page_position(tmp_path):
             f"typst produced no output at {tmp_pdf} (or zero-byte file)."
         )
 
-        # Step 4: Extract per-page text. Prefer pdftotext -layout (matches
-        # T023 manual verification tooling); fall back to pypdf if unavailable.
         if pdftotext_bin is not None:
             pdftotext_cmd = [
                 pdftotext_bin,
@@ -271,7 +225,6 @@ def test_executive_architecture_page_position(tmp_path):
 
         assert len(pages) > 0, "Extracted zero pages from the generated PDF."
 
-        # Step 5: Locate the three section heading pages
         exec_summary_page = _find_first_page_with_heading(
             pages, "Executive Summary"
         )
@@ -282,7 +235,6 @@ def test_executive_architecture_page_position(tmp_path):
             pages, "Attack Path Analysis"
         )
 
-        # Step 6: Assertions
         assert exec_summary_page is not None, (
             "Could not find 'Executive Summary' heading on any page "
             "(checked first %d lines of each page)." % PAGE_HEADING_SCAN_LINES
@@ -299,7 +251,6 @@ def test_executive_architecture_page_position(tmp_path):
             "%d lines of each page." % PAGE_HEADING_SCAN_LINES
         )
 
-        # Relative ordering — the core contract of T025
         assert exec_architecture_page > exec_summary_page, (
             f"Executive Threat Architecture (page {exec_architecture_page}) "
             f"must appear AFTER Executive Summary (page {exec_summary_page}). "
@@ -314,10 +265,6 @@ def test_executive_architecture_page_position(tmp_path):
         )
 
     finally:
-        # Cleanup: always remove the placeholder JPEG and the intermediate
-        # report-data.typ, even if the test failed. Leaving either behind
-        # would pollute downstream tasks (T033 writes the real JPEG; other
-        # tests expect report-data.typ to be generated fresh).
         if placeholder_created and PLACEHOLDER_JPEG.exists():
             try:
                 PLACEHOLDER_JPEG.unlink()
@@ -330,53 +277,10 @@ def test_executive_architecture_page_position(tmp_path):
                 pass
 
 
-# ---------------------------------------------------------------------------
-# T029 (Wave 5, US-4):
-# test_executive_architecture_skip_image_pdf_omits_page
-#
-# Covers the absent-image branch — the end-to-end downstream effect of
-# ``extract-infographic-data.py`` setting ``metadata.skip_image = true`` when
-# no Critical/High findings exist. Under that condition the infographic agent
-# does NOT invoke Gemini, so no ``threat-executive-architecture.jpg`` is
-# created. This test verifies that when the JPEG is absent, the rendered PDF
-# does NOT contain an Executive Threat Architecture page.
-#
-# This is the PDF-side test only. The extraction-side skip_image behavior is
-# covered by Wave 3 T006's extraction bundle
-# (``test_executive_architecture_no_critical_high_skip_image``).
-# ---------------------------------------------------------------------------
-
-
+@pytest.mark.slow
 def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
-    """Verify the Executive Threat Architecture page is OMITTED from the PDF
-    when ``threat-executive-architecture.jpg`` is absent (the skip_image=true
-    downstream effect).
-
-    Pipeline:
-        1. Assert ``threat-executive-architecture.jpg`` does NOT exist in
-           ``examples/agentic-app/sample-report/`` (skip test if it does, to
-           avoid clobbering a real Gemini output from T033).
-        2. Run ``scripts/extract-report-data.py`` against the agentic-app
-           sample folder. Because the JPEG is absent, ``detect_images()``
-           sets ``has-executive-architecture = false`` in the generated
-           ``report-data.typ``.
-        3. Run ``typst compile`` against ``main.typ`` producing a PDF in
-           ``tmp_path``. The conditional block in ``main.typ`` should skip
-           the Executive Threat Architecture page entirely.
-        4. Extract per-page text with ``pdftotext -layout`` (with a ``pypdf``
-           fallback, matching the present-branch test above).
-        5. Assert NO page's first ``PAGE_HEADING_SCAN_LINES`` lines contain
-           the literal "Executive Threat Architecture" string (modulo TOC
-           leader filtering via ``_find_first_page_with_heading``).
-        6. Sanity-assert that "Executive Summary" and "Attack Path Analysis"
-           ARE present — these sections must still render so a missing
-           heading on page 1 doesn't silently pass the omission check.
-        7. Assert the report-data.typ flag is ``false`` before cleanup.
-
-    Cleanup runs in a ``finally`` block: the intermediate ``report-data.typ``
-    is deleted. This test does NOT create any placeholder JPEG, so nothing
-    needs to be cleaned up in the examples tree.
-    """
+    """Run the pipeline without a ``threat-executive-architecture.jpg`` in place and
+    assert the Executive Threat Architecture page is omitted from the rendered PDF."""
     # Guard: skip if neither pdftotext nor pypdf is available (same pattern
     # as the present-branch test).
     pdftotext_bin = shutil.which("pdftotext")
@@ -393,12 +297,9 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
             "cannot extract per-page text from the generated PDF."
         )
 
-    # Temporarily move the JPEG aside so the test exercises the
-    # absent-image branch. After T033 landed, the real Gemini output lives at
-    # PLACEHOLDER_JPEG, so simply skipping when it exists would leave the
-    # absent-branch contract untested. Instead, stash the real file and
-    # restore it in finally, guaranteeing the committed example stays intact
-    # regardless of test outcome.
+    # Stash any real Gemini output aside for the duration of the test so the
+    # absent-branch contract stays covered even when the checked-in example
+    # has a real ``threat-executive-architecture.jpg``. Restored in finally.
     jpeg_backup = None
     if PLACEHOLDER_JPEG.exists():
         jpeg_backup = tmp_path / "threat-executive-architecture.jpg.backup"
@@ -410,13 +311,9 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
 
     report_data_created = False
     try:
-        # Deterministic env for reproducible Typst output (parity with T024)
         env = os.environ.copy()
         env["SOURCE_DATE_EPOCH"] = SOURCE_DATE_EPOCH
 
-        # Step 2: Run the extraction script against the agentic-app sample.
-        # With no JPEG in place, detect_images() must emit
-        # has-executive-architecture = false.
         extract_cmd = [
             sys.executable,
             str(SCRIPT_PATH),
@@ -451,9 +348,9 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
             f"{report_data_content[:500]}"
         )
 
-        # Step 3: Typst compile. --root . ensures the template can resolve
-        # relative image paths for the OTHER infographic images (funnel,
-        # baseball card, system architecture) which DO exist in the sample.
+        # --root pins Typst to the repo root so it can resolve the relative
+        # image paths for the OTHER infographic images (funnel, baseball card,
+        # system architecture) which DO exist in the sample.
         compile_cmd = [
             "typst",
             "compile",
@@ -476,8 +373,6 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
             f"typst produced no output at {tmp_pdf} (or zero-byte file)."
         )
 
-        # Step 4: Extract per-page text. Prefer pdftotext -layout (matches
-        # T023 manual verification tooling); fall back to pypdf if unavailable.
         if pdftotext_bin is not None:
             pdftotext_cmd = [
                 pdftotext_bin,
@@ -506,12 +401,9 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
 
         assert len(pages) > 0, "Extracted zero pages from the generated PDF."
 
-        # Step 5: Assert NO page contains "Executive Threat Architecture" in
-        # its first PAGE_HEADING_SCAN_LINES lines (after TOC filtering).
-        # Reuse _find_first_page_with_heading so the test shares the exact
-        # same TOC-filtering logic as the present-branch test — if either
-        # test drifts in what counts as a "heading match", both drift
-        # together.
+        # Reuse _find_first_page_with_heading so the TOC-filtering logic stays
+        # shared with the present-branch test; if either test drifts in what
+        # counts as a heading match, both drift together.
         exec_architecture_page = _find_first_page_with_heading(
             pages, "Executive Threat Architecture"
         )
@@ -524,11 +416,9 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
             "and extract-report-data.py's detect_images()."
         )
 
-        # Step 6: Sanity-check that the pipeline DID produce the expected
-        # surrounding sections. If Executive Summary or Attack Path Analysis
-        # are also missing, the pipeline is broken and the page-omission
-        # assertion above is a false positive (it would pass if the PDF were
-        # entirely empty).
+        # Sanity-check the surrounding sections — if Executive Summary or
+        # Attack Path Analysis are also missing, the page-omission assertion
+        # above is a false positive (it would trivially pass on an empty PDF).
         exec_summary_page = _find_first_page_with_heading(
             pages, "Executive Summary"
         )
@@ -548,11 +438,8 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
         )
 
         # With the page omitted, Attack Path Analysis should follow directly
-        # after Executive Summary (no gap page for Executive Threat
-        # Architecture in between). T023 observed page 10 → page 11 in the
-        # absent branch. We don't assert the absolute values (content drift
-        # can shift them) — we assert the gap is at most 1 page, matching the
-        # omission of exactly one page.
+        # after Executive Summary with exactly a one-page gap. Absolute page
+        # numbers can drift with content changes, so we assert the relative gap.
         gap = attack_path_page - exec_summary_page
         assert gap == 1, (
             f"Expected Attack Path Analysis (page {attack_path_page}) to "
@@ -564,9 +451,8 @@ def test_executive_architecture_skip_image_pdf_omits_page(tmp_path):
         )
 
     finally:
-        # Cleanup: always remove the intermediate report-data.typ, even if
-        # the test failed. Restore the stashed real JPEG if we moved it aside
-        # so the committed example is never left in a broken state.
+        # Restore the stashed real JPEG if we moved it aside so the committed
+        # example is never left in a broken state.
         if report_data_created and REPORT_DATA_TYP.exists():
             try:
                 REPORT_DATA_TYP.unlink()


### PR DESCRIPTION
## Summary

Post-delivery `/aod.document` quality review for Feature 128 (Executive Threat Architecture Infographic).

- **refactor(128): simplify code per /simplify review** — 660 deletions, 216 insertions. Removed duplicated severity closures (now module-level `_canonical_severity`), dead `threats_content` parameter, `_SEV_RANK` local dict (replaced by imported `_SEVERITY_ORDINAL`), task-reference comments (`# F-128`, `# T011`, `# --- Step N ---`), and oversized narrative docstrings across 5 test modules. Added `@pytest.mark.slow` to typst-compiling tests and consolidated 5 redundant subprocess runs in `test_existing_image_flags_unchanged` into a module-scoped fixture.
- **docs(128): add docstrings per docs-lint** — one-line PEP 257 summaries for `_extract_composite_score` and `_extract_description` helpers that were promoted from closures during the simplify refactor.
- **docs(128): update CHANGELOG** — appended F-128 entry to `## [Unreleased]` / `### Added` with the template description, PDF placement rationale, `exec` alias, `all` expansion inclusion, pytest bootstrap, and backward-compatibility guarantee.
- **docs(128): review KB entries** — added KB-027 capturing the magnitude of the simplify pass (31% reduction in changed-line count), recommending `/aod.document` simplify as a mandatory cleanup gate rather than optional polish.

## Verification

- Full pytest suite: 39/39 passing in ~20s
- Fast iteration: `pytest -m "not slow"` runs 32 tests in ~5s (4× faster)
- Production smoke test: `extract-infographic-data.py --template executive-architecture` against `examples/agentic-app/sample-report/` produces 3 layers, 7 Critical/High callouts, Tier 1 — identical to pre-refactor output

🤖 Generated with [Claude Code](https://claude.com/claude-code)