### PR TITLE
fix: auto-detect newest docs/security run directory in tachi commands

### DIFF
--- a/.claude/commands/tachi.compensating-controls.md
+++ b/.claude/commands/tachi.compensating-controls.md
@@ -23,7 +23,9 @@ Consider user input before proceeding (if not empty).
 4. Default: `output_dir = null` (outputs written to same directory as input risk-scores)
 
 5. Remaining `$ARGUMENTS` is treated as the risk-score input directory path.
-6. Default input directory: current working directory (`.`)
+6. If no input directory was provided in `$ARGUMENTS`:
+   - If `./docs/security/` exists in cwd: glob `docs/security/*/`, sort directory names descending (ISO-like `YYYY-MM-DDTHH-MM-SS` timestamps sort correctly as strings), and select the newest directory that contains `risk-scores.md` or `risk-scores.sarif`. Set `input_dir` to that path and display: `Auto-detected input: {input_dir}`.
+   - Otherwise, default to current working directory (`.`).
 
 ## Overview
 

--- a/.claude/commands/tachi.infographic.md
+++ b/.claude/commands/tachi.infographic.md
@@ -84,12 +84,15 @@ Single-command entry point for tachi threat infographic generation — the visua
    - Set `data_source_dir` to the directory containing the file
 
    **If no explicit path** (auto-detect):
-   - Scan current working directory for `compensating-controls.md`
-     - If found: set `primary_file = compensating-controls.md`, type is `compensating-controls`
-   - If `compensating-controls.md` not found, scan for `risk-scores.md`
-     - If found: set `primary_file = risk-scores.md`, type is `risk-scores`
-   - If `risk-scores.md` not found, scan for `threats.md`
-     - If found: set `primary_file = threats.md`, type is `threats`
+   - Determine scan directory:
+     - If `./docs/security/` exists in cwd: glob `docs/security/*/`, sort directory names descending (ISO-like `YYYY-MM-DDTHH-MM-SS` timestamps sort correctly as strings), and select the newest directory that contains at least one of `compensating-controls.md`, `risk-scores.md`, or `threats.md`. Set `data_source_dir` to that path and display: `Auto-detected data source dir: {data_source_dir}`.
+     - Otherwise, set `data_source_dir` to current working directory.
+   - Scan `data_source_dir` for `compensating-controls.md`
+     - If found: set `primary_file = {data_source_dir}/compensating-controls.md`, type is `compensating-controls`
+   - If `compensating-controls.md` not found, scan `data_source_dir` for `risk-scores.md`
+     - If found: set `primary_file = {data_source_dir}/risk-scores.md`, type is `risk-scores`
+   - If `risk-scores.md` not found, scan `data_source_dir` for `threats.md`
+     - If found: set `primary_file = {data_source_dir}/threats.md`, type is `threats`
    - If none found, display:
      ```
      NO DATA SOURCE FILES FOUND
@@ -101,7 +104,6 @@ Single-command entry point for tachi threat infographic generation — the visua
      Then optionally: /risk-score → /compensating-controls for richer data.
      ```
    - Halt if none found.
-   - Set `data_source_dir` to current working directory
 
 3. **Co-located threats.md check** (when type is `risk-scores` or `compensating-controls`):
    - Verify `threats.md` exists in `data_source_dir`

--- a/.claude/commands/tachi.risk-score.md
+++ b/.claude/commands/tachi.risk-score.md
@@ -18,7 +18,9 @@ Consider user input before proceeding (if not empty).
 2. Default: `output_dir = null` (outputs written to same directory as input)
 
 3. Remaining `$ARGUMENTS` is treated as the input directory path.
-4. Default input directory: current working directory (`.`)
+4. If no input directory was provided in `$ARGUMENTS`:
+   - If `./docs/security/` exists in cwd: glob `docs/security/*/`, sort directory names descending (ISO-like `YYYY-MM-DDTHH-MM-SS` timestamps sort correctly as strings), and select the newest directory that contains `threats.md` or `threats.sarif`. Set `input_dir` to that path and display: `Auto-detected input: {input_dir}`.
+   - Otherwise, default to current working directory (`.`).
 
 ## Overview
 

--- a/.claude/commands/tachi.security-report.md
+++ b/.claude/commands/tachi.security-report.md
@@ -23,7 +23,9 @@ Consider user input before proceeding (if not empty).
 4. Default: `title_override = null` (auto-detected from `threats.md` frontmatter in agent)
 
 5. Remaining `$ARGUMENTS` is treated as the target directory path.
-6. Default: `target_dir = current working directory`
+6. If no target directory was provided in `$ARGUMENTS`:
+   - If `./docs/security/` exists in cwd: glob `docs/security/*/`, sort directory names descending (ISO-like `YYYY-MM-DDTHH-MM-SS` timestamps sort correctly as strings), and select the newest directory that contains `threats.md` (the minimum required artifact). Set `target_dir` to that path and display: `Auto-detected target: {target_dir}`.
+   - Otherwise, default to current working directory (`.`).
 
 ## Overview
 


### PR DESCRIPTION
## Summary

- Sidecar bugfix surfaced during Feature 129 delivery. Four downstream tachi commands silently defaulted to cwd when invoked without an input path, missing user data sitting in `docs/security/<timestamp>/`.
- Adds consistent auto-detection: if `./docs/security/` exists, glob `docs/security/*/`, sort descending (ISO timestamps sort correctly as strings), and pick the newest directory that contains the required artifact for that command.
- Required-artifact gating per command:
  - `tachi.risk-score` → `threats.md` or `threats.sarif`
  - `tachi.compensating-controls` → `risk-scores.md` or `risk-scores.sarif`
  - `tachi.infographic` → `compensating-controls.md` or `risk-scores.md` or `threats.md`
  - `tachi.security-report` → `threats.md` (minimum required)
- Backward compatible — explicit path argument still overrides; cwd fallback preserved.
- `tachi.infographic` also drops a redundant trailing `Set data_source_dir to current working directory` line that ran after per-file path resolution.

## Test plan

- [x] Run each of the four commands without arguments from a directory containing `docs/security/2026-04-14T22-30-00/threats.md` — expect `Auto-detected input/target: docs/security/2026-04-14T22-30-00`
- [x] Run each command with an explicit path argument — expect that path to be used (no auto-detect message)
- [x] Run each command from a directory that has no `docs/security/` — expect cwd default behavior unchanged
- [x] Verify with multiple timestamped runs that the newest is selected (string sort on ISO timestamps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)