### PR TITLE
docs(180): post-delivery quality review

### DIFF
--- a/docs/product/_backlog/BACKLOG.md
+++ b/docs/product/_backlog/BACKLOG.md
@@ -1,6 +1,6 @@
 # Backlog
 
-> Auto-generated from GitHub Issues on 2026-04-17T22:21:05Z.
+> Auto-generated from GitHub Issues on 2026-04-17T22:23:09Z.
 > Source of truth: GitHub Issues with `stage:*` labels.
 > Regenerate: `/aod.status` or `.aod/scripts/bash/backlog-regenerate.sh`
 
@@ -38,7 +38,7 @@
 
 | # | Title | Delivered | Retro | Updated |
 |---|-------|-----------|-------|---------|
-| #180 | F-A1 — Taxonomy Crosswalk Collection [Foundation] | 2026-04-17 | — | 2026-04-17 |
+| — | *No items in this stage* | | |
 
 ## Untracked
 

--- a/tests/schemas/test_taxonomy_integrity.py
+++ b/tests/schemas/test_taxonomy_integrity.py
@@ -1,17 +1,4 @@
-"""Referential integrity tests for ``schemas/taxonomy/`` (Feature 180 F-A1).
-
-Authors the 4 mandatory + 1 optional pytest test functions specified in
-``specs/180-taxonomy-crosswalk-collection/contracts/integrity-test-contract.md``
-and enumerated in ``spec.md`` FR-027 through FR-032.
-
-Offline-deterministic per ADR-021: no HTTP fetches, no external subprocesses.
-All assertions operate on committed ``schemas/taxonomy/*.yaml`` files via
-``yaml.safe_load``; citation shape is validated with a URL regex and
-filesystem ``Path.is_file()`` checks only.
-
-Stdlib + pyyaml only. Both are declared in ``requirements-dev.txt`` per
-FR-037 / Feature 128 pytest bootstrap.
-"""
+"""Referential integrity tests for ``schemas/taxonomy/``."""
 
 import re
 from pathlib import Path
@@ -20,12 +7,9 @@ import pytest
 import yaml
 
 
-# tests/schemas/test_taxonomy_integrity.py -> parents[2] == repo root
 REPO_ROOT = Path(__file__).resolve().parents[2]
 TAXONOMY_DIR = REPO_ROOT / "schemas" / "taxonomy"
 
-# The 7 per-framework catalog YAMLs (FR-001 enumerates 9 files; crosswalk.yaml
-# is tested separately in FR-029; README.md is not a YAML).
 CATALOG_FILENAMES = [
     "owasp.yaml",
     "mitre-attack.yaml",
@@ -36,7 +20,6 @@ CATALOG_FILENAMES = [
     "tachi-stride-ai-category.yaml",
 ]
 
-# FR-010 closed 7-value taxonomy enum (matches the filename stems above).
 TAXONOMY_ENUM = {
     "owasp",
     "mitre-attack",
@@ -47,40 +30,27 @@ TAXONOMY_ENUM = {
     "tachi-stride-ai-category",
 }
 
-# FR-012 closed 3-value edge_type enum.
 EDGE_TYPE_ENUM = {"primary", "related", "superseded"}
 
-# FR-013 closed 3-value confidence enum.
 CONFIDENCE_ENUM = {"high", "medium", "low"}
 
-# FR-003 required keys on every catalog record.
 REQUIRED_RECORD_KEYS = {"id", "full_id", "name", "url"}
 
-# FR-009 top-level required keys on every crosswalk edge.
 REQUIRED_EDGE_KEYS = {"source", "target", "edge_type", "confidence", "citation"}
 
-# FR-009 required sub-keys on source / target dicts.
 REQUIRED_ENDPOINT_KEYS = {"taxonomy", "id"}
 
-# URL regex per contract (URL-shaped OR file-path-resolvable).
 URL_REGEX = re.compile(r"^https?://")
 
-# FR-003 `cwe_refs` item format.
 CWE_REF_REGEX = re.compile(r"^CWE-\d+$")
 
-# FR-025 primary-edge floor.
 PRIMARY_EDGE_FLOOR = 500
-
-
-# ---------------------------------------------------------------------------
-# Helpers
-# ---------------------------------------------------------------------------
 
 
 def _is_url_or_existing_file(value: str) -> bool:
     """Return True if *value* is URL-shaped OR resolves to a repo file.
 
-    Performs NO HTTP fetch — URL validation is regex-only per FR-031 / ADR-021
+    Performs NO HTTP fetch — URL validation is regex-only per ADR-021
     determinism constraint.
     """
     if not isinstance(value, str) or not value:
@@ -91,18 +61,11 @@ def _is_url_or_existing_file(value: str) -> bool:
 
 
 def _sort_key_nist(record_id: str):
-    """Sort key for ``nist-ai-rmf.yaml`` per FR-032 numeric-within-function.
+    """Numeric-within-function sort key so ``MEASURE 2.2`` precedes ``MEASURE 2.10``.
 
-    Parses an ID like ``MEASURE 2.10`` into ``('MEASURE', 2, 10)`` so that
-    ``MEASURE 2.2`` precedes ``MEASURE 2.10`` (numeric ordering matches NIST
-    publication convention). First tuple element is the function name
-    ('GOVERN', 'MAP', 'MEASURE', 'MANAGE') in alphabetical order; the next
-    two are the parsed X and Y numeric components.
-
-    Architect decision at T027: numeric-within-function is canonical for NIST
-    per ``.aod/results/architect.md`` §5.3 — pure lexicographic sort would
-    emit ``MEASURE 2.10`` before ``MEASURE 2.2`` which breaks the publication
-    ordering convention and the human-readable navigation expectation.
+    Parses ``MEASURE 2.10`` into ``('MEASURE', 2, 10)``. Pure lexicographic
+    sort would emit ``MEASURE 2.10`` before ``MEASURE 2.2``, breaking the NIST
+    publication ordering.
     """
     function_part, _, number_part = record_id.partition(" ")
     major_str, _, minor_str = number_part.partition(".")
@@ -112,11 +75,6 @@ def _sort_key_nist(record_id: str):
     except ValueError:  # malformed — fall back to string sort for stability
         return (function_part, 0, 0, record_id)
     return (function_part, major, minor)
-
-
-# ---------------------------------------------------------------------------
-# Module-scoped loaders — parse each YAML exactly once per test session
-# ---------------------------------------------------------------------------
 
 
 @pytest.fixture(scope="module")
@@ -142,38 +100,16 @@ def crosswalk():
 
 @pytest.fixture(scope="module")
 def catalog_id_index(catalogs):
-    """Build ``{taxonomy_stem: set(id)}`` for O(1) referential integrity checks.
-
-    Taxonomy stems are derived from the catalog filename (e.g. ``owasp.yaml``
-    -> ``owasp``). Matches the FR-010 7-value taxonomy enum values.
-    """
+    """Build ``{taxonomy_stem: set(id)}`` for O(1) referential integrity checks."""
     index = {}
     for filename, records in catalogs.items():
-        stem = filename[: -len(".yaml")]
+        stem = Path(filename).stem
         index[stem] = {record["id"] for record in records}
     return index
 
 
-# ---------------------------------------------------------------------------
-# FR-028 — test_framework_yamls_load
-# ---------------------------------------------------------------------------
-
-
 def test_framework_yamls_load(catalogs):
-    """Each of the 7 catalog YAMLs parses; every record has FR-003 required fields.
-
-    Per spec FR-028 and integrity-test-contract §1:
-      1. Each YAML parses via ``yaml.safe_load`` without exception (handled by
-         the ``catalogs`` fixture — any parse failure fails this test).
-      2. Each parsed structure is a non-empty list.
-      3. Each record is a dict with required keys ``{id, full_id, name, url}``.
-      4. All catalogs EXCEPT ``cwe.yaml`` carry ``cwe_refs`` on every record;
-         ``cwe_refs`` values are lists of strings matching ``^CWE-\\d+$``.
-      5. ``cwe.yaml`` records MUST NOT carry ``cwe_refs`` (FR-003 explicit
-         omission — CWE->CWE relations live in ``crosswalk.yaml``).
-      6. ``id`` is unique within each catalog file.
-      7. ``url`` is URL-shaped OR resolves to a repo-root file.
-    """
+    """Each catalog YAML parses; every record has required fields; ids unique; urls valid."""
     for filename, records in catalogs.items():
         assert isinstance(records, list), (
             f"{filename}: expected list, got {type(records).__name__}"
@@ -192,16 +128,15 @@ def test_framework_yamls_load(catalogs):
                 f"missing required fields {sorted(missing)}"
             )
 
-            # cwe_refs presence rules (FR-003).
             if filename == "cwe.yaml":
                 assert "cwe_refs" not in record, (
                     f"{filename}: record {index} (id={record['id']!r}) MUST NOT "
-                    f"carry cwe_refs per FR-003 (CWE->CWE relations belong in crosswalk.yaml)"
+                    f"carry cwe_refs (CWE->CWE relations belong in crosswalk.yaml)"
                 )
             else:
                 assert "cwe_refs" in record, (
                     f"{filename}: record {index} (id={record['id']!r}) missing "
-                    f"required field 'cwe_refs' (per FR-003; only cwe.yaml omits it)"
+                    f"required field 'cwe_refs' (only cwe.yaml omits it)"
                 )
                 cwe_refs = record["cwe_refs"]
                 assert isinstance(cwe_refs, list), (
@@ -214,14 +149,12 @@ def test_framework_yamls_load(catalogs):
                         f"{ref!r} does not match ^CWE-\\d+$"
                     )
 
-            # FR-004 id uniqueness within each catalog file.
             record_id = record["id"]
             assert record_id not in seen_ids, (
                 f"{filename}: duplicate id {record_id!r} at record index {index}"
             )
             seen_ids.add(record_id)
 
-            # FR-007 url shape: URL-regex OR existing repo file.
             url = record["url"]
             assert _is_url_or_existing_file(url), (
                 f"{filename}: record {record_id!r}: url {url!r} is neither "
@@ -229,26 +162,8 @@ def test_framework_yamls_load(catalogs):
             )
 
 
-# ---------------------------------------------------------------------------
-# FR-029 — test_crosswalk_loads
-# ---------------------------------------------------------------------------
-
-
 def test_crosswalk_loads(crosswalk):
-    """crosswalk.yaml parses; every edge has FR-009 required fields; no duplicates.
-
-    Per spec FR-029 and integrity-test-contract §2:
-      1. ``crosswalk.yaml`` parses via ``yaml.safe_load`` without exception
-         (handled by the ``crosswalk`` fixture).
-      2. Parsed structure is a list of dicts.
-      3. Each dict has exactly the top-level keys
-         ``{source, target, edge_type, confidence, citation}`` (no extras).
-      4. ``source`` and ``target`` are dicts with exactly ``{taxonomy, id}``.
-      5. No two edges share the same
-         ``(source.taxonomy, source.id, target.taxonomy, target.id, edge_type)``
-         5-tuple — duplicate edges fail the test.
-      6. FR-025 primary-edge floor: ``len(edge_type=='primary') >= 500``.
-    """
+    """crosswalk.yaml parses; edges have required fields; no duplicates; primary-edge floor met."""
     assert isinstance(crosswalk, list), (
         f"crosswalk.yaml: expected list, got {type(crosswalk).__name__}"
     )
@@ -268,7 +183,7 @@ def test_crosswalk_loads(crosswalk):
         )
         assert not extras, (
             f"crosswalk.yaml: edge {index} has unexpected extra fields "
-            f"{sorted(extras)} (FR-009 forbids extras)"
+            f"{sorted(extras)} (schema forbids extras)"
         )
 
         for endpoint_name in ("source", "target"):
@@ -304,37 +219,15 @@ def test_crosswalk_loads(crosswalk):
             )
         seen_edge_keys[dedupe_key] = index
 
-    # FR-025 primary-edge floor.
     primary_count = sum(1 for edge in crosswalk if edge["edge_type"] == "primary")
     assert primary_count >= PRIMARY_EDGE_FLOOR, (
-        f"crosswalk.yaml: {primary_count} primary edges below FR-025 floor "
+        f"crosswalk.yaml: {primary_count} primary edges below floor "
         f"of {PRIMARY_EDGE_FLOOR}"
     )
 
 
-# ---------------------------------------------------------------------------
-# FR-030 — test_crosswalk_referential_integrity
-# ---------------------------------------------------------------------------
-
-
 def test_crosswalk_referential_integrity(crosswalk, catalog_id_index):
-    """Every edge's source/target resolves; every enum value is in its closed domain.
-
-    Per spec FR-030 and integrity-test-contract §3:
-      1. ``source.taxonomy`` ∈ 7-value enum.
-      2. ``target.taxonomy`` ∈ 7-value enum.
-      3. ``source.id`` resolves in the catalog named by ``source.taxonomy``.
-      4. ``target.id`` resolves in the catalog named by ``target.taxonomy``.
-      5. ``edge_type`` ∈ ``{primary, related, superseded}``.
-      6. ``confidence`` ∈ ``{high, medium, low}``.
-
-    Note (2026-04-17 T028): this test is EXPECTED TO FAIL at T028 commit time
-    because 38 pre-existing drifted edges (22 Surface B dash-format + 16
-    Surface C semantically incorrect targets) reference IDs absent from the
-    canonical catalog records. T029 resolves the drift by removing those
-    edges per architect's Option (c) decision at `.aod/results/architect.md`.
-    The test is CORRECT; the data has drift the test is designed to catch.
-    """
+    """Every edge's source/target resolves in its catalog; every enum value is closed."""
     for index, edge in enumerate(crosswalk):
         source_tax = edge["source"]["taxonomy"]
         target_tax = edge["target"]["taxonomy"]
@@ -360,7 +253,6 @@ def test_crosswalk_referential_integrity(crosswalk, catalog_id_index):
             f"not in {sorted(CONFIDENCE_ENUM)}"
         )
 
-        # Referential integrity: source.id must exist in catalog_id_index[source_tax].
         assert source_id in catalog_id_index[source_tax], (
             f"crosswalk.yaml: edge {index}: source.id={source_id!r} not found "
             f"in {source_tax}.yaml "
@@ -373,20 +265,8 @@ def test_crosswalk_referential_integrity(crosswalk, catalog_id_index):
         )
 
 
-# ---------------------------------------------------------------------------
-# FR-031 — test_citation_shape
-# ---------------------------------------------------------------------------
-
-
 def test_citation_shape(crosswalk):
-    """Every citation is non-empty AND (URL-regex OR existing repo file).
-
-    Per spec FR-031 and integrity-test-contract §4:
-      1. ``citation`` is a non-empty string for every edge.
-      2. Each citation matches ``^https?://`` OR resolves to an existing repo
-         file path.
-      3. NO HTTP fetches are performed at test time (ADR-021 determinism).
-    """
+    """Every citation is non-empty and is URL-shaped OR resolves to a repo file (no HTTP fetches)."""
     for index, edge in enumerate(crosswalk):
         citation = edge["citation"]
         assert isinstance(citation, str) and citation, (
@@ -405,24 +285,8 @@ def test_citation_shape(crosswalk):
         )
 
 
-# ---------------------------------------------------------------------------
-# FR-032 — test_records_sorted (optional per architect directive)
-# ---------------------------------------------------------------------------
-
-
 def test_records_sorted(catalogs):
-    """Each catalog is sorted per FR-032 conventions.
-
-    Per spec FR-032 amendment (2026-04-17, architect T027):
-      - ``nist-ai-rmf.yaml``: sort key is ``(function, X_int, Y_int)`` where
-        function ∈ {GOVERN, MAP, MEASURE, MANAGE} (alphabetical) and ``X.Y``
-        is the dotted numeric component parsed as a 2-tuple of ints. This
-        matches the NIST publication convention where ``MEASURE 2.2``
-        precedes ``MEASURE 2.10`` (numeric-within-function).
-      - Other 6 catalogs: lexicographic sort on the ``id`` field.
-
-    Fails with the first divergence point (name of file + index + id).
-    """
+    """nist-ai-rmf uses numeric-within-function sort; others use lexicographic id sort."""
     for filename, records in catalogs.items():
         ids = [record["id"] for record in records]
 


### PR DESCRIPTION
## Summary

Post-delivery documentation review for Feature 180 (F-A1 Taxonomy Crosswalk Collection).

- refactor(180): simplify `tests/schemas/test_taxonomy_integrity.py` per /simplify review — stripped FR-NNN/task-reference narrative and reduced spec-restatement docstrings to one-liners; kept all assertion error messages (contract surface) and hidden-invariant comments (e.g., "NO HTTP fetch" determinism note). 440 → 304 lines (-31%); 5/5 tests still pass in 0.55s.

Non-applicable steps skipped: docs-lint (all functions already have docstrings), CHANGELOG (release-please PR #187 will auto-generate), API sync (no OpenAPI spec), KB review (KB-035 authored inline during retrospective, already accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)