### PR TITLE
docs(189): post-delivery quality review

### DIFF
--- a/scripts/tachi_parsers.py
+++ b/scripts/tachi_parsers.py
@@ -619,19 +619,9 @@ def parse_resolved_findings(content: str) -> list:
     return findings
 
 
-# =============================================================================
-# Source Attribution Parser (F-A2 / Feature 189, schema 1.5)
-#
-# Q1-E serialization surface per ADR-028 Decision 2: an optional
-# ``## 9. Source Attribution`` section in threats.md containing a YAML
-# code fence keyed by finding ID with a list of ``{taxonomy, id,
-# relationship}`` records. Absent-section => absent-key on every
-# finding dict (conditional-key semantic per Feature 104 delta_status
-# precedent). Stdlib-only regex parsing preserves PAT-014 (scripts/
-# stay stdlib-only; pyyaml remains developer-only per Feature 128).
-# =============================================================================
+# Source Attribution parser — optional "## 9. Source Attribution" YAML block
+# with conditional-key emission (absent section => no key on finding dict).
 
-# Closed 5-value taxonomy enum (ADR-028 Decision 3; external frameworks only)
 VALID_SOURCE_ATTRIBUTION_TAXONOMIES = (
     "owasp",
     "mitre-attack",
@@ -640,29 +630,26 @@ VALID_SOURCE_ATTRIBUTION_TAXONOMIES = (
     "cwe",
 )
 
-# Closed 3-value relationship enum (ADR-028 Decision 4)
 VALID_SOURCE_ATTRIBUTION_RELATIONSHIPS = ("primary", "related", "derived")
 
-# Valid record key sets (V5 shape rule from data-model.md)
 _SRC_ATTR_KEYS_2 = frozenset(("taxonomy", "id"))
 _SRC_ATTR_KEYS_3 = frozenset(("taxonomy", "id", "relationship"))
 
 
-def _parse_source_attribution_flow_dict(body: str) -> dict:
-    """Parse a flow-style YAML dict body into a Python dict.
+_SRC_ATTR_KV_PATTERN = re.compile(r"\s*([a-zA-Z_][a-zA-Z_0-9]*)\s*:\s*(.*?)\s*$")
 
-    Handles the restricted shape ``key: value, key: value, ...`` used in
-    Section 9 source_attribution records. No nested dicts, no quoted
-    strings with commas, no multiline values. Stdlib-only — avoids a
-    pyyaml runtime dependency per PAT-014.
+
+def _parse_source_attribution_flow_dict(body: str) -> dict:
+    """Parse a flow-style YAML dict body (``key: value, ...``) into a Python dict.
+
+    Restricted shape: no nested dicts, no quoted commas, no multiline values.
+    Stdlib-only to keep scripts/ free of the pyyaml runtime dependency.
     """
     out: dict = {}
     for part in body.split(","):
-        kv = re.match(r"\s*([a-zA-Z_][a-zA-Z_0-9]*)\s*:\s*(.*?)\s*$", part)
+        kv = _SRC_ATTR_KV_PATTERN.match(part)
         if kv:
-            key = kv.group(1)
-            value = kv.group(2).strip().strip("'\"")
-            out[key] = value
+            out[kv.group(1)] = kv.group(2).strip().strip("'\"")
     return out
 
 
@@ -704,28 +691,14 @@ def _extract_source_attribution_block(content: str):
     return result
 
 
-def _extract_source_attribution(content: str, finding_id: str):
-    """Extract source_attribution records for one finding from Section 9.
+def _extract_source_attribution(finding_id: str, block):
+    """Resolve source_attribution records for one finding from a pre-parsed block.
 
-    Args:
-        content: full threats.md text.
-        finding_id: the finding's ``id`` field (e.g., ``"LLM-5"``).
-
-    Returns:
-        ``None`` when Section 9 is absent OR when finding_id is not keyed
-        in the block (V6 conditional-key semantic — caller MUST NOT inject
-        the ``source_attribution`` key on the finding dict).
-        ``list[dict]`` (possibly empty) when finding_id IS keyed. Each
-        emitted record has all three ``{taxonomy, id, relationship}`` keys
-        populated; ``relationship`` defaults to ``"primary"`` when absent
-        on input (V2 default injection).
-
-    Raises:
-        ValueError: V5 shape violation — record has keys outside the
-        ``{taxonomy, id}`` / ``{taxonomy, id, relationship}`` sets. The
-        message names the finding ID and the offending keys.
+    Returns None when ``block`` is None or ``finding_id`` is not keyed — caller
+    must not inject the ``source_attribution`` key (conditional-key semantic,
+    distinguishing absent from explicitly-empty). Returns list[dict] (possibly
+    empty) otherwise; missing ``relationship`` values default to ``"primary"``.
     """
-    block = _extract_source_attribution_block(content)
     if block is None or finding_id not in block:
         return None
     emit: list = []
@@ -734,18 +707,12 @@ def _extract_source_attribution(content: str, finding_id: str):
         if keys != _SRC_ATTR_KEYS_2 and keys != _SRC_ATTR_KEYS_3:
             extra = sorted(keys - _SRC_ATTR_KEYS_3)
             missing = sorted(_SRC_ATTR_KEYS_2 - keys)
-            if extra:
-                raise ValueError(
-                    f"Finding {finding_id}: unexpected key(s) in source_attribution "
-                    f"record: {extra}"
-                )
+            problem = f"unexpected key(s): {extra}" if extra else f"missing required key(s): {missing}"
             raise ValueError(
-                f"Finding {finding_id}: missing required key(s) in source_attribution "
-                f"record: {missing}"
+                f"Finding {finding_id}: {problem} in source_attribution record"
             )
         rec = dict(record)
 
-        # V1 — taxonomy enum membership (ADR-028 Decision 3)
         taxonomy = rec["taxonomy"]
         if taxonomy not in VALID_SOURCE_ATTRIBUTION_TAXONOMIES:
             raise ValueError(
@@ -753,14 +720,12 @@ def _extract_source_attribution(content: str, finding_id: str):
                 f"Allowed: {set(VALID_SOURCE_ATTRIBUTION_TAXONOMIES)}"
             )
 
-        # V3 — id non-empty string
         id_value = rec.get("id", "")
         if not isinstance(id_value, str) or id_value == "":
             raise ValueError(
                 f"Finding {finding_id}: empty or null id in source_attribution record"
             )
 
-        # V2 — relationship enum membership (after default injection per Decision 4)
         rec.setdefault("relationship", "primary")
         relationship = rec["relationship"]
         if relationship not in VALID_SOURCE_ATTRIBUTION_RELATIONSHIPS:
@@ -778,19 +743,11 @@ def parse_threats_findings(content: str) -> list:
 
     Returns list of finding dicts with Tier 3 keys.
 
-    The ``agentic_pattern`` key (Feature 142, schema 1.4) is always present
-    on every returned finding dict. When the Section 7 table contains a
-    ``Pattern`` or ``Agentic Pattern`` column (case-insensitive), the raw
-    value is routed through :func:`parse_finding_pattern` to yield a
-    canonical enum string. When no such column exists (pre-Feature-142
-    threats.md), every finding defaults to ``agentic_pattern: 'none'`` per
-    FR-017 backward compatibility.
-
-    The ``source_attribution`` key (Feature 189, schema 1.5) is
-    conditionally injected on each finding when the document carries a
-    ``## 9. Source Attribution`` block keyed by the finding's ID. Absent
-    section OR absent key in the block => omitted from the returned dict
-    entirely (V6 conditional-key semantic per ADR-028 Decision 2).
+    The ``agentic_pattern`` key is always present; if the table has no
+    ``Pattern`` / ``Agentic Pattern`` column (pre-1.4 threats.md), every
+    finding defaults to ``'none'``. The ``source_attribution`` key is
+    conditionally injected only when the finding's ID is keyed in a
+    ``## 9. Source Attribution`` block.
     """
     rows = parse_markdown_table(content, "## 7. Recommended Actions")
     if not rows:
@@ -807,6 +764,8 @@ def parse_threats_findings(content: str) -> list:
         if col.strip().lower() in ("pattern", "agentic pattern"):
             pattern_key = col
             break
+
+    source_attribution_block = _extract_source_attribution_block(content)
 
     findings = []
     for row in rows:
@@ -834,33 +793,22 @@ def parse_threats_findings(content: str) -> list:
         status = row.get("Status", "").strip()
         if status:
             finding["delta_status"] = status
-        # Source attribution (F-A2, schema 1.5): conditional-key emission
-        # per ADR-028 Decision 2 (V6 absent-vs-empty semantic preserved).
-        attribution = _extract_source_attribution(content, finding["id"])
+        attribution = _extract_source_attribution(finding["id"], source_attribution_block)
         if attribution is not None:
             finding["source_attribution"] = attribution
         findings.append(finding)
     return findings
 
 
-# =============================================================================
-# Source Attribution Validator (F-A2 / Feature 189, ADR-028 Decision 5)
-#
-# Tier 2 (referential integrity) check: every record's ``id`` MUST resolve as
-# a top-level ``- id: <value>`` key in ``schemas/taxonomy/{taxonomy}.yaml``.
-# Stdlib-only implementation: scans each catalog YAML line-by-line for the
-# ``^- id: (\S+)`` pattern. This preserves PAT-014 (scripts/ stdlib-only;
-# pyyaml is developer-only per Feature 128). Per-invocation cache is scoped
-# to a local dict in the call frame — no module-level state (ADR-021
-# determinism guarantee).
-# =============================================================================
+# Tier 2 referential-integrity validator: resolves each record's id against
+# the catalog YAMLs in schemas/taxonomy/. Stdlib-only (no pyyaml).
 
 _CATALOG_ID_PATTERN = re.compile(r"^- id: (\S+)\s*$", re.MULTILINE)
 
 
 @dataclass(frozen=True)
 class ValidationError:
-    """Structured referential-integrity validation error (ADR-028 Decision 5)."""
+    """Referential-integrity failure: a record's id did not resolve in its catalog."""
 
     finding_id: str
     record: dict
@@ -869,11 +817,7 @@ class ValidationError:
 
 
 def _load_catalog_ids(taxonomy: str, taxonomy_dir: Path) -> frozenset:
-    """Load the set of top-level ``id:`` keys from a catalog YAML.
-
-    Stdlib-only (no pyyaml). Matches ``- id: <value>`` at the start of a line
-    — the canonical shape of F-A1 catalog records per ADR-027.
-    """
+    """Return the set of top-level ``- id: <value>`` keys from a catalog YAML."""
     catalog_path = taxonomy_dir / f"{taxonomy}.yaml"
     text = catalog_path.read_text()
     return frozenset(_CATALOG_ID_PATTERN.findall(text))
@@ -883,31 +827,12 @@ def validate_source_attribution(
     findings: list,
     taxonomy_dir: Path = Path("schemas/taxonomy"),
 ) -> list:
-    """Validate referential integrity of source_attribution records (V4).
+    """Validate referential integrity of source_attribution records.
 
-    For every finding with ``source_attribution``, resolve every record's
-    ``id`` against a top-level key in ``{taxonomy_dir}/{taxonomy}.yaml``.
-    Returns a list of :class:`ValidationError` on failure; empty list on
-    full success. Callers decide whether to raise or log.
-
-    Args:
-        findings: list of parsed finding dicts (output of parse_threats_findings).
-        taxonomy_dir: path to F-A1 catalog directory. Default matches the
-            repository-root-relative layout per ADR-027.
-
-    Returns:
-        list[ValidationError]: empty on full success; one entry per
-        unresolved record id on failure.
-
-    Notes:
-        Per-invocation cache scoped to the local ``catalog_cache`` dict —
-        preserves ADR-021 determinism (no module-level mutable state). A
-        single call with N findings / M records / K unique taxonomies
-        performs at most K disk reads (not M).
-
-        Parser-tier enum errors (V1/V2/V3/V5) surface in
-        :func:`parse_threats_findings` via ``ValueError``; this validator
-        assumes its input has already passed Tier 1 checks.
+    For every finding with ``source_attribution``, resolve each record's ``id``
+    against a top-level key in ``{taxonomy_dir}/{taxonomy}.yaml``. Returns a
+    list of ValidationError (empty on success). Catalog YAMLs are read at
+    most once per call via a local cache — no module-level state.
     """
     catalog_cache: dict = {}
     errors: list = []

--- a/tests/scripts/test_source_attribution.py
+++ b/tests/scripts/test_source_attribution.py
@@ -1,20 +1,12 @@
-"""Tests for F-A2 source_attribution schema extension (Feature 189, schema 1.5).
+"""Tests for the source_attribution schema extension.
 
-Covers the three round-trip paths (absent, single-record, multi-record) and
-the three validation paths (bad taxonomy, bad relationship, bad id) plus
-edge cases per spec FR-011 / FR-012 / FR-013.
-
-User Story coverage:
-- US-189-1 (Multi-Framework Citation): test_round_trip_multi_record
-- US-189-2 (Parser Round-Trip / backward compat): test_absent_omits_key,
-  test_empty_array_preserved
-- US-189-3 (Closed-Enum + Referential Integrity): test_invalid_taxonomy_rejected,
-  test_invalid_relationship_rejected, test_relationship_defaults_to_primary,
-  test_invalid_id_detected, test_fixtures_self_consistent
+Covers round-trip paths (absent, single, multi, empty), closed-enum rejection
+(taxonomy, relationship, id), and referential integrity against F-A1 catalogs.
 """
+import sys
 from pathlib import Path
 
-import sys
+import pytest
 
 # Make scripts/ importable from tests/
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -31,171 +23,114 @@ TAXONOMY_DIR = REPO_ROOT / "schemas" / "taxonomy"
 
 
 def test_round_trip_multi_record():
-    """US-189-1 AC-3 / FR-007: three attribution records round-trip in input order."""
+    """Three attribution records round-trip in input order."""
     content = (FIXTURES / "valid_multi_record.md").read_text()
     findings = parse_threats_findings(content)
 
-    assert len(findings) == 1, "fixture defines exactly one finding (LLM-5)"
+    assert len(findings) == 1
     finding = findings[0]
     assert finding["id"] == "LLM-5"
-    assert "source_attribution" in finding, \
-        "US-189-1 AC-3: source_attribution key MUST be present when Section 9 keys this finding"
+    assert "source_attribution" in finding
 
     records = finding["source_attribution"]
-    assert len(records) == 3, "three attribution records preserved"
-
-    # Input order: owasp/LLM05, cwe/CWE-116, mitre-atlas/AML.T0051
+    assert len(records) == 3
     assert records[0] == {"taxonomy": "owasp", "id": "LLM05", "relationship": "primary"}
     assert records[1] == {"taxonomy": "cwe", "id": "CWE-116", "relationship": "primary"}
     assert records[2] == {"taxonomy": "mitre-atlas", "id": "AML.T0051", "relationship": "primary"}
 
 
 def test_round_trip_single_record():
-    """US-189-3 AC-1 / FR-004: single-record round-trip with default relationship injection."""
+    """Single-record round-trip injects the default relationship 'primary'."""
     content = (FIXTURES / "valid_single_record.md").read_text()
     findings = parse_threats_findings(content)
 
-    assert len(findings) == 1, "fixture defines exactly one finding (S-1)"
+    assert len(findings) == 1
     finding = findings[0]
     assert finding["id"] == "S-1"
-    assert "source_attribution" in finding
-
-    records = finding["source_attribution"]
-    assert len(records) == 1
-    # Input omitted relationship; parser MUST inject the default "primary"
-    assert records[0] == {"taxonomy": "owasp", "id": "A01", "relationship": "primary"}
+    # Input omitted relationship; parser injects the default.
+    assert finding["source_attribution"] == [
+        {"taxonomy": "owasp", "id": "A01", "relationship": "primary"}
+    ]
 
 
 def test_absent_omits_key():
-    """US-189-2 AC-1 / V6: absent Section 9 => ``source_attribution`` key omitted.
+    """Absent Section 9 => ``source_attribution`` key omitted from every finding.
 
-    Fixture has 3 findings, no Section 9 block. Parser MUST NOT inject the
-    ``source_attribution`` key on ANY returned finding dict — this is the
-    conditional-key precedent from Feature 104 delta_status (ADR-028 Decision 2).
+    Distinct from the empty-array case below: absent means "no claim", while
+    an explicit ``[]`` means "explicitly no attribution claimed".
     """
     content = (FIXTURES / "valid_absent.md").read_text()
     findings = parse_threats_findings(content)
 
-    assert len(findings) == 3, "fixture defines exactly three findings (S-1, T-2, I-3)"
+    assert len(findings) == 3
     for finding in findings:
         assert "source_attribution" not in finding, (
-            f"V6 violation: finding {finding['id']!r} gained a source_attribution "
-            f"key despite the fixture omitting Section 9. "
-            f"Got: {finding.get('source_attribution')!r}"
+            f"finding {finding['id']!r} gained a source_attribution key "
+            f"despite the fixture omitting Section 9"
         )
 
 
 def test_empty_array_preserved():
-    """US-189-2 AC-2 / V6: present-but-empty ``source_attribution: []`` preserved.
-
-    Fixture declares ``D-4: []`` inline under Section 9. Parser MUST emit the
-    ``source_attribution`` key with value ``[]`` — semantically distinct from
-    the absent-key case (no-claim vs explicit-no-attribution-claimed).
-    """
+    """Present-but-empty ``D-4: []`` round-trips with the key present and value []."""
     content = (FIXTURES / "valid_empty_array.md").read_text()
     findings = parse_threats_findings(content)
 
     assert len(findings) == 1
     finding = findings[0]
     assert finding["id"] == "D-4"
-    assert "source_attribution" in finding, (
-        "V6 violation: explicitly empty D-4 list MUST round-trip as "
-        "source_attribution: [] (present key, empty value)"
-    )
-    assert finding["source_attribution"] == [], (
-        f"Empty-array round-trip failed. Got: {finding['source_attribution']!r}"
-    )
+    assert finding["source_attribution"] == []
 
-
-# =============================================================================
-# US-189-3 — Closed-enum + referential-integrity tests
-# =============================================================================
 
 def test_invalid_taxonomy_rejected():
-    """US-189-3 AC-1 / V1: bad taxonomy raises at parser tier with structured message."""
-    import pytest  # local import keeps module import cheap for fast paths
+    """Bad taxonomy raises with a message naming the finding, the bad value, and the closed domain."""
     content = (FIXTURES / "invalid_taxonomy.md").read_text()
     with pytest.raises(ValueError) as excinfo:
         parse_threats_findings(content)
     message = str(excinfo.value)
-    assert "T-9" in message, f"Message must name the finding id. Got: {message!r}"
-    assert "not-a-real-taxonomy" in message, (
-        f"Message must name the bad value. Got: {message!r}"
-    )
-    # Closed-domain must appear in the error (any-order tolerant)
+    assert "T-9" in message
+    assert "not-a-real-taxonomy" in message
     for allowed in ("owasp", "mitre-attack", "mitre-atlas", "nist-ai-rmf", "cwe"):
-        assert allowed in message, (
-            f"Message must include closed-domain value {allowed!r}. Got: {message!r}"
-        )
+        assert allowed in message
 
 
 def test_invalid_relationship_rejected():
-    """US-189-3 AC-2 / V2: bad relationship raises at parser tier with structured message."""
-    import pytest
+    """Bad relationship raises with a message naming the finding, the bad value, and the closed domain."""
     content = (FIXTURES / "invalid_relationship.md").read_text()
     with pytest.raises(ValueError) as excinfo:
         parse_threats_findings(content)
     message = str(excinfo.value)
-    assert "I-7" in message, f"Message must name the finding id. Got: {message!r}"
-    assert "fabricated_value" in message, (
-        f"Message must name the bad value. Got: {message!r}"
-    )
+    assert "I-7" in message
+    assert "fabricated_value" in message
     for allowed in ("primary", "related", "derived"):
-        assert allowed in message, (
-            f"Message must include closed-domain value {allowed!r}. Got: {message!r}"
-        )
+        assert allowed in message
 
 
 def test_relationship_defaults_to_primary():
-    """US-189-3 AC-3 / V2 default-injection: absent relationship => 'primary'.
-
-    Re-exercises valid_single_record.md (from T007) at the US-189-3 boundary
-    to prove the default-injection contract is uniformly enforced.
-    """
+    """Absent relationship defaults to 'primary' during parse."""
     content = (FIXTURES / "valid_single_record.md").read_text()
     findings = parse_threats_findings(content)
-    assert len(findings) == 1
-    record = findings[0]["source_attribution"][0]
-    assert record["relationship"] == "primary", (
-        f"Default-injection must supply 'primary' when relationship is absent on input. "
-        f"Got: {record['relationship']!r}"
-    )
+    assert findings[0]["source_attribution"][0]["relationship"] == "primary"
 
 
 def test_invalid_id_detected():
-    """US-189-3 AC-4 / V4: unresolved id surfaces as a ValidationError from the validator.
-
-    Parser-tier enum checks (V1/V2/V3/V5) pass — the record is syntactically
-    valid. Only the validator-tier referential-integrity check (V4) detects
-    the non-existent catalog id per ADR-028 Decision 5.
-    """
+    """Syntactically valid but unresolvable id surfaces only at the validator tier."""
     content = (FIXTURES / "invalid_id.md").read_text()
     findings = parse_threats_findings(content)
-    assert len(findings) == 1, "parser MUST succeed (V1/V2/V3/V5 all pass)"
     assert findings[0]["source_attribution"] == [
         {"taxonomy": "owasp", "id": "NOT-A-REAL-OWASP-ID", "relationship": "primary"}
     ]
 
     errors = validate_source_attribution(findings, taxonomy_dir=TAXONOMY_DIR)
-    assert len(errors) == 1, f"Expected exactly one ValidationError. Got: {errors!r}"
+    assert len(errors) == 1
     err = errors[0]
     assert isinstance(err, ValidationError)
     assert err.finding_id == "E-2"
-    assert err.record["id"] == "NOT-A-REAL-OWASP-ID"
-    assert err.record["taxonomy"] == "owasp"
-    assert err.target_yaml_path.endswith("owasp.yaml"), (
-        f"target_yaml_path must point at the owasp catalog. Got: {err.target_yaml_path!r}"
-    )
+    assert err.record == {"taxonomy": "owasp", "id": "NOT-A-REAL-OWASP-ID", "relationship": "primary"}
+    assert err.target_yaml_path.endswith("owasp.yaml")
 
 
 def test_fixtures_self_consistent():
-    """FR-013: every valid fixture's attribution records resolve referentially.
-
-    Aggregates all valid fixtures (single, multi, absent, empty-array) and
-    asserts the validator returns zero errors — proving that fixture
-    authoring did not drift from the live F-A1 catalogs under
-    ``schemas/taxonomy/``.
-    """
+    """Every valid fixture's attribution records resolve against the live catalogs."""
     all_findings = []
     for name in (
         "valid_single_record.md",
@@ -206,7 +141,4 @@ def test_fixtures_self_consistent():
         content = (FIXTURES / name).read_text()
         all_findings.extend(parse_threats_findings(content))
 
-    errors = validate_source_attribution(all_findings, taxonomy_dir=TAXONOMY_DIR)
-    assert errors == [], (
-        f"Valid fixtures must not produce validation errors. Got: {errors!r}"
-    )
+    assert validate_source_attribution(all_findings, taxonomy_dir=TAXONOMY_DIR) == []


### PR DESCRIPTION
## Summary

Post-delivery documentation review for Feature 189 (F-A2 Source Attribution Schema Extension).

### Simplify pass

- **KB-027 narrative-comment sprawl** — 2 multi-line section banners collapsed to one-liners; inline V1/V2/V3/V5/V6 ADR-tracing comments deleted; over-long docstrings (`_extract_source_attribution`, `parse_threats_findings`, per-test preambles) pruned.
- **Efficiency** — `_extract_source_attribution_block(content)` was called once per finding inside `parse_threats_findings` (O(N×fence_size)). Hoisted to a single pre-loop call; the per-finding helper now takes a pre-parsed block dict (O(fence_size + N)).
- **Consolidated** near-duplicate `ValueError` blocks (extra keys vs missing keys) into a single raise with a ternary problem string.
- **Hoisted** `import pytest` to test module top (two inline imports had a false "cheap import" rationale — pytest is always loaded when running pytest). Promoted the flow-dict kv pattern to a module-level `re.compile` constant.

Net: `scripts/tachi_parsers.py` +35 −110, `tests/scripts/test_source_attribution.py` +40 −108. Total ≈ −143 lines.

### Skipped steps

- **Docs-Lint**: all complex functions already have docstrings.
- **CHANGELOG**: release-please PR #191 will auto-generate the F-A2 entry (same pattern as PR #188 for F-A1).
- **API Sync**: no OpenAPI spec in tachi (CLI-only tool).
- **KB Review**: KB-036 already added during `/aod.deliver` retrospective.

### Tests

Full suite: 284 passed, 1 skipped under `SOURCE_DATE_EPOCH=1700000000` — identical to pre-simplify baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)