### PR TITLE
chore(security): bump next scaffold pin to >=16.2.3 (GHSA-q4gf-8mx6-v5v3)

### DIFF
--- a/stacks/nextjs-supabase/scaffold/package.json
+++ b/stacks/nextjs-supabase/scaffold/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "next": ">=16.1.7",
+    "next": ">=16.2.3",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "@supabase/supabase-js": ">=2.45.0",


### PR DESCRIPTION
## Summary

Closes [Dependabot alert #16](https://github.com/davidmatousek/tachi/security/dependabot/16). Bumps the Next.js pin in the `nextjs-supabase` stack pack scaffold from `>=16.1.7` to `>=16.2.3` to clear the high-severity DoS advisory.

| | |
|---|---|
| GHSA | [GHSA-q4gf-8mx6-v5v3](https://github.com/advisories/GHSA-q4gf-8mx6-v5v3) → upstream React [CVE-2026-23869](https://github.com/facebook/react/security/advisories/GHSA-479c-33wc-g2pg) |
| Severity | HIGH (CVSS 3.1: 7.5) |
| CWE | CWE-770 (Allocation of Resources Without Limits or Throttling) |
| Vulnerable 16.x range | `>= 16.0.0-beta.0, < 16.2.3` — prior pin `>=16.1.7` overlapped |
| Patched | 16.2.3 |

## Scope

Stack pack scaffold only. Not a tachi runtime dependency — the fix protects adopters who materialize the `nextjs-supabase` scaffold via `/aod.stack scaffold` from inheriting the vulnerable pin.

## Test plan

- [x] `package.json` parses as valid JSON
- [ ] Dependabot alert #16 auto-dismisses on merge once GitHub re-scans

🤖 Generated with [Claude Code](https://claude.com/claude-code)