### PR TITLE
fix(215): byte-probe image detection in detect_images

### DIFF
--- a/scripts/extract-report-data.py
+++ b/scripts/extract-report-data.py
@@ -1352,22 +1352,37 @@ def validate(data: dict) -> list:
 # Image and Brand Asset Detection
 # =============================================================================
 
+_IMAGE_FORMAT_TO_EXT = {"jpeg": ".jpg", "png": ".png"}
+
+
+def _file_format(path: Path) -> "str | None":
+    """Return 'png', 'jpeg', or None based on magic bytes."""
+    try:
+        with path.open("rb") as f:
+            head = f.read(8)
+    except OSError:
+        return None
+    if head.startswith(b"\x89PNG\r\n\x1a\n"):
+        return "png"
+    if head.startswith(b"\xff\xd8\xff"):
+        return "jpeg"
+    return None
+
+
 def detect_images(target_dir: Path, template_dir: Path) -> dict:
     """Compute image paths relative to template directory.
 
-    The infographic agent writes images whose extension matches the returned
-    Gemini MIME type — `.jpg` for `image/jpeg`, `.png` for `image/png`. Probe
-    both extensions and prefer the one that exists; if both exist, prefer
-    `.jpg` (treated as the canonical contract).
+    The infographic agent writes images whose extension is supposed to match
+    the Gemini MIME type, but the `gemini-2.5-flash-image` fallback model has
+    historically returned PNG bytes saved into `.jpg` files. Typst's decoder
+    rejects bytes that don't match the filename. Probe each candidate's magic
+    bytes (not just its extension) and pick the path whose filename matches
+    its content. If only a mislabeled candidate exists, write a corrected
+    sibling and emit that path so Typst compiles on the first attempt.
     """
-    # Compute relative path from template_dir to target_dir
-    # Template files are at templates/tachi/security-report/
-    # Images are at {target_dir}/threat-*.{jpg,png}
-    # Relative path: ../../{target_dir}/
     try:
         rel_target = os.path.relpath(str(target_dir), str(template_dir))
     except ValueError:
-        # Fallback for cross-drive paths on Windows
         rel_target = str(target_dir)
 
     images = {
@@ -1389,11 +1404,37 @@ def detect_images(target_dir: Path, template_dir: Path) -> dict:
     }
 
     for key, stem in image_stems.items():
+        candidates = []
         for ext in (".jpg", ".png"):
-            filepath = target_dir / f"{stem}{ext}"
-            if filepath.exists() and filepath.stat().st_size > 0:
-                images[key] = rel_target + "/" + f"{stem}{ext}"
+            fp = target_dir / f"{stem}{ext}"
+            if fp.exists() and fp.stat().st_size > 0:
+                candidates.append((ext, fp))
+        if not candidates:
+            continue
+
+        chosen = None
+        for ext, fp in candidates:
+            if _IMAGE_FORMAT_TO_EXT.get(_file_format(fp)) == ext:
+                chosen = fp
                 break
+
+        if chosen is None:
+            for ext, fp in candidates:
+                fmt = _file_format(fp)
+                if fmt is None:
+                    continue
+                target_path = target_dir / f"{stem}{_IMAGE_FORMAT_TO_EXT[fmt]}"
+                print(
+                    f"Image format mismatch: {fp.name} contains {fmt.upper()} bytes; "
+                    f"writing corrected sibling {target_path.name}",
+                    file=sys.stderr,
+                )
+                shutil.copyfile(fp, target_path)
+                chosen = target_path
+                break
+
+        if chosen is not None:
+            images[key] = rel_target + "/" + chosen.name
 
     return images
 

--- a/tests/scripts/test_extract_report_data.py
+++ b/tests/scripts/test_extract_report_data.py
@@ -22,6 +22,22 @@ FIXTURES_DIR = REPO_ROOT / "tests" / "scripts" / "fixtures" / "report_data"
 GOLDEN_EXISTING_FLAGS = FIXTURES_DIR / "golden_existing_image_flags.txt"
 AGENTIC_APP_SAMPLE = REPO_ROOT / "examples" / "agentic-app" / "sample-report"
 
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n"
+JPEG_MAGIC = b"\xff\xd8\xff\xe0\x00\x10JFIF"
+
+
+def _write_minimal_png(path: Path) -> None:
+    """Write a byte sequence that begins with the PNG magic header.
+
+    Only the magic bytes matter to ``detect_images`` (it reads the first 8
+    bytes). The trailing payload is arbitrary filler so ``st_size > 0``.
+    """
+    path.write_bytes(PNG_MAGIC + b"\x00" * 16)
+
+
+def _write_minimal_jpeg(path: Path) -> None:
+    path.write_bytes(JPEG_MAGIC + b"\x00" * 16)
+
 
 def run_extract(target_dir, template_dir=None):
     """Run extract-report-data.py and return (returncode, stdout, stderr, typst_content)."""
@@ -185,4 +201,122 @@ def test_existing_image_flags_unchanged(
     assert expected_line in output_lines, (
         f"Golden flag line drifted. Expected line {expected_line!r} "
         f"not found in generated report-data.typ. Backward compatibility regression."
+    )
+
+
+# =============================================================================
+# Byte-probe image detection (Issue #215 regression coverage)
+# =============================================================================
+
+
+def _build_byte_probe_fixture(tmp_path: Path) -> Path:
+    """Set up a minimal target dir: copy threats.md from image_present fixture."""
+    fixture = tmp_path / "target"
+    fixture.mkdir()
+    (fixture / "threats.md").write_bytes(
+        (FIXTURES_DIR / "image_present" / "threats.md").read_bytes()
+    )
+    return fixture
+
+
+def test_mislabeled_jpg_with_png_bytes_emits_png_path_and_writes_sibling(tmp_path):
+    """A `.jpg` file whose bytes are PNG must produce a corrected `.png` sibling.
+
+    Reproduces the production failure mode: assessment directories generated
+    against the `gemini-2.5-flash-image` fallback model contain `.jpg` files
+    with PNG bytes. Typst rejects mismatched bytes/extension. The extractor
+    must (a) detect the mismatch via magic-byte probe, (b) write a correctly
+    named sibling, (c) emit the corrected `.png` path in `report-data.typ`.
+    """
+    fixture = _build_byte_probe_fixture(tmp_path)
+    mislabeled = fixture / "threat-executive-architecture.jpg"
+    _write_minimal_png(mislabeled)
+
+    returncode, _stdout, stderr, content = run_extract(fixture)
+    assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
+    assert content is not None, "Expected report-data.typ to be written"
+
+    sibling = fixture / "threat-executive-architecture.png"
+    assert sibling.exists(), (
+        "Expected a `.png` sibling to be written next to the mislabeled `.jpg`."
+    )
+    assert sibling.read_bytes().startswith(PNG_MAGIC), (
+        "Sibling must contain the original PNG bytes (not be empty/corrupt)."
+    )
+
+    path_lines = [
+        line for line in content.splitlines()
+        if line.startswith("#let executive-architecture-image-path")
+    ]
+    assert len(path_lines) == 1, f"Expected one path line, got: {path_lines!r}"
+    assert path_lines[0].rstrip().endswith('threat-executive-architecture.png"'), (
+        f"Expected emitted path to be the `.png` sibling, got: {path_lines[0]!r}"
+    )
+
+    assert "Image format mismatch" in stderr, (
+        "Expected a stderr note announcing the corrected sibling write."
+    )
+    assert "PNG bytes" in stderr, (
+        "Expected the format-mismatch note to identify the actual format."
+    )
+
+
+def test_mixed_extensions_prefers_self_consistent_png_over_stale_jpg(tmp_path):
+    """When both `.jpg` (PNG bytes, stale) and `.png` (PNG bytes, fresh) exist,
+    pick the `.png` whose extension matches its bytes — never the stale `.jpg`.
+
+    Models the cross-version re-run case: a previous fallback-model run
+    produced the `.jpg`; a fresh run produced the `.png`. The `.jpg`-first
+    preference of the old code would silently pick the stale file.
+    """
+    fixture = _build_byte_probe_fixture(tmp_path)
+    stale = fixture / "threat-executive-architecture.jpg"
+    fresh = fixture / "threat-executive-architecture.png"
+    _write_minimal_png(stale)
+    _write_minimal_png(fresh)
+
+    returncode, _stdout, stderr, content = run_extract(fixture)
+    assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
+    assert content is not None, "Expected report-data.typ to be written"
+
+    path_lines = [
+        line for line in content.splitlines()
+        if line.startswith("#let executive-architecture-image-path")
+    ]
+    assert len(path_lines) == 1, f"Expected one path line, got: {path_lines!r}"
+    assert path_lines[0].rstrip().endswith('threat-executive-architecture.png"'), (
+        f"Expected the `.png` (self-consistent) to be selected, got: {path_lines[0]!r}"
+    )
+
+    assert "Image format mismatch" not in stderr, (
+        "Best-match path must not trip the recovery branch — no warning expected."
+    )
+
+
+def test_clean_jpeg_emits_jpg_path_without_warning(tmp_path):
+    """Backward compatibility: a true JPEG `.jpg` file must keep emitting the
+    `.jpg` path with no recovery activity. Guards against false-positive
+    warnings during normal operation.
+    """
+    fixture = _build_byte_probe_fixture(tmp_path)
+    clean = fixture / "threat-executive-architecture.jpg"
+    _write_minimal_jpeg(clean)
+
+    returncode, _stdout, stderr, content = run_extract(fixture)
+    assert returncode == 0, f"Expected exit 0, got {returncode}. stderr: {stderr}"
+    assert content is not None, "Expected report-data.typ to be written"
+
+    path_lines = [
+        line for line in content.splitlines()
+        if line.startswith("#let executive-architecture-image-path")
+    ]
+    assert len(path_lines) == 1, f"Expected one path line, got: {path_lines!r}"
+    assert path_lines[0].rstrip().endswith('threat-executive-architecture.jpg"'), (
+        f"Expected `.jpg` to be preserved for clean JPEG input, got: {path_lines[0]!r}"
+    )
+    assert "Image format mismatch" not in stderr, (
+        "Clean JPEG must not emit the format-mismatch warning."
+    )
+    assert not (fixture / "threat-executive-architecture.png").exists(), (
+        "Clean JPEG must not trigger sibling creation."
     )

--- a/tests/scripts/test_extractor_contract_fixes.py
+++ b/tests/scripts/test_extractor_contract_fixes.py
@@ -172,20 +172,30 @@ def test_bug3_narrative_fallback_to_full_section1_prose(extract_report_data):
 # Bug 4 — detect_images finds both .jpg and .png
 # ---------------------------------------------------------------------------
 
-@pytest.mark.parametrize("extension", [".jpg", ".png"])
-def test_bug4_detect_images_finds_both_extensions(tmp_path, extract_report_data, extension):
+# Issue #215 follow-up tightened the contract: detect_images now selects by
+# magic bytes, not just by filename presence. The bytes below are the minimum
+# headers required to be recognized as JPEG/PNG by the byte probe.
+_JPEG_MAGIC_BYTES = b"\xff\xd8\xff\xe0\x00\x10JFIF" + b"\x00" * 16
+_PNG_MAGIC_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 16
+
+
+@pytest.mark.parametrize(
+    "extension,payload",
+    [(".jpg", _JPEG_MAGIC_BYTES), (".png", _PNG_MAGIC_BYTES)],
+)
+def test_bug4_detect_images_finds_both_extensions(
+    tmp_path, extract_report_data, extension, payload
+):
     """Gemini's ``gemini-2.5-flash-image`` fallback returns PNG bytes; the agent
     now writes ``threat-*.png`` when the MIME is ``image/png``. detect_images
-    must probe both ``.jpg`` (canonical) and ``.png`` so the report-assembler
-    doesn't need a copy-to-sibling workaround.
+    must accept both ``.jpg`` (canonical) and ``.png`` when the bytes match.
     """
     template_dir = tmp_path / "templates"
     template_dir.mkdir()
     target_dir = tmp_path / "target"
     target_dir.mkdir()
 
-    # Create a funnel image with the parametrized extension (at least 1 byte)
-    (target_dir / f"threat-risk-funnel{extension}").write_bytes(b"fake-image-bytes")
+    (target_dir / f"threat-risk-funnel{extension}").write_bytes(payload)
 
     images = extract_report_data.detect_images(target_dir, template_dir)
 


### PR DESCRIPTION
## Summary

Closes #215. Follow-up to #209 Bug 4 — the previous patch fixed the producer side (`tachi-threat-infographic` agent now writes extensions matching the Gemini MIME), but the consumer side (`scripts/extract-report-data.py::detect_images`) still preferred `.jpg` by filename. Typst's image decoder rejects bytes that don't match the filename extension, so any assessment directory generated against the `gemini-2.5-flash-image` fallback model (PNG bytes saved into `.jpg`) failed to compile on the first attempt.

Reporter: `/Users/david/Projects/second-brain-mcp/docs/security/2026-04-23T23-02-25/TACHI_BUG_REPORT_2_FOLLOWUP.md`.

## What changed

`detect_images` now probes the **magic bytes** of each candidate (`.jpg`, `.png`) and picks the path whose filename matches its content. If no candidate is self-consistent, the function writes a correctly named sibling for the first byte-readable candidate and emits that path with a stderr note (`Image format mismatch: ... writing corrected sibling ...`).

### Failure-mode coverage

| Scenario | Old behavior | New behavior |
|----------|--------------|--------------|
| `.jpg` (real JPEG bytes) only | Emits `.jpg` ✓ | Emits `.jpg` ✓ |
| `.jpg` (PNG bytes) only | Emits `.jpg` → Typst fails | Writes `.png` sibling, emits `.png` ✓ |
| `.png` (real PNG bytes) only | Emits `.png` ✓ | Emits `.png` ✓ |
| Both `.jpg` (PNG bytes, stale) and `.png` (PNG bytes, fresh) | Emits stale `.jpg` → Typst fails | Emits fresh `.png` ✓ |
| Both `.jpg` (real JPEG) and `.png` (real PNG) | Emits `.jpg` (first match) | Emits `.jpg` (first byte-consistent match) ✓ |

## Files

- `scripts/extract-report-data.py` — `_file_format` helper + rewritten `detect_images` (~30 LOC delta)
- `tests/scripts/test_extract_report_data.py` — 3 new regression tests covering the mislabeled-only, mixed-extension, and clean-jpeg cases
- `tests/scripts/test_extractor_contract_fixes.py` — tightened the existing Bug 4 test to use real PNG/JPEG magic bytes (the old `b"fake-image-bytes"` fixture is incompatible with the byte probe; the test's intent — "both extensions are accepted" — is preserved)

## Test plan

- [x] `python3 -m pytest tests/scripts/test_extract_report_data.py tests/scripts/test_extractor_contract_fixes.py -v` — 18/18 pass
- [x] `python3 -m pytest tests/ -q` — 386 pass, 1 pre-existing skip
- [ ] Verify on a real assessment directory: re-run `/tachi.security-report` against `docs/security/2026-04-23T23-02-25/` and confirm Typst compiles on the first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)