### PR TITLE
refactor: consolidate SARIF generators + canonicalize source_attribution validator

### DIFF
--- a/examples/agentic-app/sample-report/risk-scores.sarif
+++ b/examples/agentic-app/sample-report/risk-scores.sarif
@@ -142,7 +142,7 @@
               }
             },
             {
-              "id": "tachi/ai/agentic-threats",
+              "id": "tachi/ai/agentic",
               "name": "Agentic Threats",
               "shortDescription": {
                 "text": "AI agent autonomy and multi-agent coordination threats"
@@ -160,7 +160,7 @@
               }
             },
             {
-              "id": "tachi/ai/llm-threats",
+              "id": "tachi/ai/llm",
               "name": "LLM Threats",
               "shortDescription": {
                 "text": "Large language model specific threats"
@@ -314,7 +314,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "Prompt injection causes the Orchestrator to autonomously execute unauthorized high-impact actions (mass data exfiltration from KB, bulk tool invocations against External API) beyond the scope of the user's original request, exploiting the Orchestrator's broad access to system capabilities.",
             "markdown": "Implement a scope-enforcement layer: the Orchestrator MUST validate every proposed action against the user session's permitted scope before execution. Apply human-in-the-loop confirmation for high-impact operations (bulk exports, external writes). Use a supervised-autonomy model: the Orchestrator proposes an action plan; a separate policy engine approves or rejects it."
@@ -512,7 +512,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — server-side execution via Tool Call Request: LLM-generated JSON-RPC parameters flowing into the MCP Tool Server may contain injection payloads (SQL fragments, shell metacharacters) that are executed server-side when the Tool Server dispatches tool invocations. Execution context is **server-side**: the payload runs on the Tool Server with its service account credentials and external API access.",
             "markdown": "The MCP Tool Server MUST validate and parameterize all LLM-supplied tool arguments before execution: use parameterized queries for database tools, argument vectors (not shell interpolation) for command tools, and URL allowlisting for HTTP tools. Never pass LLM output directly to an execution sink — treat it as untrusted input at every downstream execution point."
@@ -561,7 +561,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — server-side execution via Tool Call Request: the Orchestrator emits \"Tool Call Request (JSON-RPC)\" messages to the MCP Tool Server containing LLM-synthesized parameters. If tool parameters are used to construct SQL queries, shell commands, template expressions, or filesystem paths server-side without parameterization or sanitization, an attacker who influences the Orchestrator's output achieves **server-side code/command execution** via the tool execution sink. Execution context: Tool Server backend, with service account credentials and External API access. FR-011 gate confirmed: (1) LLM keyword on Orchestrator, (2) Tool Call Request (JSON-RPC) → MCP Tool Server = server-side execution sink.",
             "markdown": "MCP Tool Server MUST parameterize all LLM-supplied inputs: use `cursor.execute(sql, params)` (not string interpolation) for SQL tools; `subprocess.run([cmd, arg1], shell=False)` for command tools; validate against a closed allowlist for enumerable parameters (tool names, resource identifiers). Implement a JSON Schema validator at the Tool Server ingress that rejects any request failing parameter type/format constraints before dispatch."
@@ -623,7 +623,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — client-side XSS via...",
             "markdown": ""
@@ -672,7 +672,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — client-side XSS via LLM response rendered in user browser: the Orchestrator's \"Response (HTTPS)\" data flow sends LLM-generated content directly to the User. If the client-side rendering layer injects this content into the DOM via `innerHTML` or equivalent without HTML entity encoding, an attacker who primes the Orchestrator to emit `<script src=\"//evil.example/steal.js\">` or an event-handler payload causes **client-side execution** in the victim's browser under the application's origin, with access to session cookies, CSRF tokens, and downstream user-authenticated APIs. This is a direct output-sink path: LLM Process → `Response (HTTPS)` → User browser render surface. FR-011 two-part gate confirmed: (1) LLM keyword on LLM Agent Orchestrator, (2) `Response (HTTPS)` data flow into User (browser render surface = client-side execution sink).",
             "markdown": "Use `textContent` (not `innerHTML`) for all LLM response insertion into the DOM. If HTML rendering is required, pass model output through a strict HTML sanitization library (DOMPurify configured with `FORCE_BODY: true`, allowlist elements only). Deploy a Content Security Policy with `script-src 'self' 'nonce-<nonce>'` and no `unsafe-inline`. Do NOT rely on server-side filtering alone — apply encoding at each render point independently."
@@ -729,7 +729,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Prompt injection via clinical query context: the Clinical Advisory Sub-Agent processes Clinical Query / Context payloads from the Orchestrator. If the clinical context contains adversarially crafted text (injected via the original user prompt, via adversarial KB documents retrieved upstream, or via a compromised Orchestrator), the injection can override the sub-agent's system prompt, cause it to fabricate clinical recommendations, reveal its system configuration, or escalate privileges within the advisory pipeline.",
             "markdown": "Apply instruction-boundary enforcement at the Clinical Advisory Sub-Agent: the sub-agent's system prompt MUST be in a protected zone inaccessible to clinical query content from the Orchestrator. Implement clinical-query content sanitization: strip instruction-like patterns before context injection into the sub-agent. Apply output validation on the sub-agent's clinical summaries to detect system-prompt leakage or anomalous clinical claims."
@@ -778,7 +778,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Prompt injection via delegation messages: the Specialist Agent processes tasks delegated by the Orchestrator via the Inter-Agent Channel. An attacker who injects adversarial content into the Delegation Message (via channel tampering or Orchestrator compromise) can hijack the Specialist's task execution, causing it to perform unauthorized tool invocations or exfiltrate data through its result channel.",
             "markdown": "Apply prompt injection detection at the Specialist Agent's input processing layer: treat all delegation message content as untrusted data, not instructions. Implement instruction boundary enforcement: the Specialist's system prompt must be in a protected zone inaccessible to delegation message content. Verify delegation message signatures before processing."
@@ -876,7 +876,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Direct prompt injection via the User→Guardrails→Orchestrator chain: an attacker embeds adversarial instructions in the user's prompt that the Guardrails Service fails to detect, causing the Orchestrator to override its system prompt, reveal internal configuration, or execute unauthorized actions.",
             "markdown": "Implement multi-layer prompt injection detection: (1) Guardrails content filtering, (2) Orchestrator-level instruction boundary enforcement (treat user content as data, not instructions), (3) output validation that checks responses for system-prompt leakage patterns. Use a privilege-separated prompt architecture (system prompt in a protected zone inaccessible to user content)."
@@ -926,7 +926,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Training data poisoning via the Long-Running Learning Loop: the Orchestrator ingests model updates from the Learning Loop that was trained on audit log data. An attacker who pollutes the audit log with adversarial interaction records (fabricated user sessions designed to shift model behavior) poisons the Orchestrator's future behavior at update time.",
             "markdown": "Apply training data validation: audit all training data before use with anomaly detection, data-quality checks, and outlier filtering. Implement data provenance tracking — every training example must carry a verifiable source signature. Apply adversarial training detection: scan for data patterns designed to shift model outputs toward specific adversarial objectives."
@@ -1123,7 +1123,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The MCP Tool Server is vulnerable to tool call injection: an attacker who can influence the LLM output of either the Orchestrator or Specialist Agent can inject crafted JSON-RPC parameters that invoke unintended tools (tool name injection) or supply malicious arguments to permitted tools (parameter injection). The Tool Server executes these with its own service credentials.",
             "markdown": "Implement strict tool call validation: (a) validate the tool name against a registered allowlist, (b) validate each parameter against a per-tool JSON Schema, (c) reject any request that fails validation before execution. Apply parameter encoding for values that will be forwarded to external systems (URLs, SQL fragments, shell arguments)."
@@ -1270,7 +1270,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Indirect prompt injection via the Knowledge Base: an attacker embeds adversarial instructions in documents stored in the Knowledge Base. When the Orchestrator retrieves these documents during vector search, the adversarial instructions are injected into its context window, hijacking its reasoning.",
             "markdown": "Apply retrieval-time content sanitization: strip or neutralize instruction-like patterns from retrieved documents before injection into the Orchestrator's context window. Implement a separate \"content auditor\" that evaluates retrieved documents for prompt injection patterns. Apply context segmentation: mark retrieved content as \"untrusted data\" in the context window structure so the model treats it differently from trusted instructions."
@@ -1368,7 +1368,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — SSRF via LLM-synthesized URL: the Orchestrator can instruct the MCP Tool Server to fetch external URLs synthesized from LLM output. An attacker who influences the Orchestrator's output can cause it to emit internal service URLs (cloud metadata endpoints, internal admin APIs) as tool parameters. The Tool Server fetches these with its server-side network credentials. Execution context is **server-side**: the HTTP client runs with the Tool Server's IAM role.",
             "markdown": "Implement URL allowlisting on all outbound HTTP tool invocations in the MCP Tool Server. Reject any URL not matching an explicit allowlist of permitted external hostnames. Block egress to RFC 1918 ranges, link-local, and cloud metadata endpoints via egress firewall. Validate URL scheme against `{http, https}` only. Apply DNS pinning."
@@ -1417,7 +1417,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Training data poisoning of the Clinical Advisory Sub-Agent via the Learning Loop: Clinical Decision Log Entries from the sub-agent are included in the Audit Logger training stream. An attacker who injects adversarially crafted clinical interaction records into the Audit Logger can shift the sub-agent's clinical reasoning toward attacker-preferred outputs — for example, consistently recommending specific drugs, understating contraindications, or omitting standard-of-care steps in returned clinical summaries.",
             "markdown": "Apply Clinical Decision Log Entry provenance attestation: each log entry from the Clinical Advisory Sub-Agent must carry a verifiable origin signature. Implement anomaly detection specifically for clinical training signals — monitor for unusual shifts in diagnostic terms, drug recommendation patterns, or contraindication omission rates. Apply a clinical-domain holdout evaluation suite before deploying any model update to the ClinAdvisor: compare pre/post-update clinical recommendations against a reference set of clinically-validated cases."
@@ -1467,7 +1467,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "**Overreliance / Missing HITL on Decision-Critical Output (Category 3 per FR-017)**: The Clinical Advisory Sub-Agent's \"Clinical Summary + Recommendations\" output flows directly back to the LLM Agent Orchestrator and from there into the user-facing response path without a declared human-in-the-loop (HITL) review gate. Clinical recommendations generated by the sub-agent — including potential drug choices, contraindication assessments, and diagnostic interpretations — surface to the end consumer (clinician, patient, downstream system) as Orchestrator-mediated output without requiring physician sign-off, clinical review confirmation, or AI-provenance disclosure.",
             "markdown": "Implement a mandatory HITL physician sign-off gate before clinical advisory outputs surface in any patient-facing or decision-critical context. Route the Clinical Advisory Sub-Agent's output through a clinical review workflow: outputs above a defined risk threshold (any recommendation about drug dosing, contraindications, or diagnoses) MUST require physician confirmation before inclusion in user-facing responses. Apply AI-provenance disclosure on every surfaced clinical recommendation."
@@ -1573,7 +1573,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — server-side injection via tool call results: the Specialist Agent's tool call results from MCP Tool Server are incorporated into its context and may influence downstream tool invocations. If the Tool Server returns LLM-influenced content that contains injection payloads, the Specialist's next tool call may forward those payloads to execution sinks. Execution context is **server-side**.",
             "markdown": "Implement output sanitization on all tool results before incorporating them into the Specialist's context window for subsequent tool invocations. Treat tool results as untrusted data inputs — never interpolate them directly into subsequent tool call parameters without validation. Apply allowlist-based parameter validation at the Tool Server for all tool inputs regardless of source."
@@ -1622,7 +1622,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "**Ungrounded Factual Emission (Category 1 per FR-017)**: The Clinical Advisory Sub-Agent emits clinical summaries containing factual medical claims (diagnostic observations, drug-interaction assertions, clinical recommendations) to the Orchestrator's response path without mandatory RAG grounding against a verified EHR index. Although the sub-agent retrieves documents from the Knowledge Base via vector search, there is no declared retrieval-strength metric (hit-rate or recall@k), no per-claim source anchoring that traces each clinical assertion to a specific retrieved document section, and no output-time verification that factual claims are supported by retrieved content. A hallucinated clinical assertion (fabricated drug dose, fabricated contraindication, fabricated diagnostic criterion) that reaches a clinician or downstream decision system under time pressure may drive a clinical action the recipient would not otherwise take.",
             "markdown": "Require mandatory RAG grounding with per-claim source anchoring: each factual claim in the clinical summary output MUST cite a retrievable Knowledge Base document section. Expose per-claim retrieval-strength metadata (hit-rate or recall@k) alongside the output; reject clinical outputs where retrieval strength falls below a defined threshold. Implement a clinical output validator that checks each factual assertion against the retrieved document set before returning the summary to the Orchestrator."
@@ -1679,7 +1679,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "**Retrieval-Grounding Gap (Category 4 per FR-017)**: The Clinical Advisory Sub-Agent performs vector search against the Knowledge Base to retrieve supporting clinical documents. However, there is no declared mechanism to detect or handle retrieval failures — scenarios where the Knowledge Base does not contain documents relevant to the clinical query (low-recall retrieval, out-of-distribution queries, stale KB content). In these cases, the sub-agent may fabricate plausible-sounding clinical content to fill the gap, presenting hallucinated information with the same confidence as retrieval-grounded claims.",
             "markdown": "Implement a retrieval-quality gate: before generating a clinical summary, the sub-agent MUST evaluate retrieval quality metrics (recall@k, minimum hit-score threshold). If retrieval quality falls below the threshold, the sub-agent MUST return a structured \"insufficient grounding\" response rather than a speculative clinical summary. Apply a retrieval-quality confidence indicator on all outputs; apply Knowledge Base currency monitoring."
@@ -1736,7 +1736,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — SSRF via LLM-synthesized URL in Tool Call Request: the Orchestrator constructs \"Tool Call Request (JSON-RPC)\" messages containing URLs sourced from LLM output (e.g., \"fetch this URL\" tool calls). The MCP Tool Server executes outbound HTTP to the supplied URL using its own server-side network credentials and IAM role. An attacker who influences the Orchestrator's output can cause it to emit `http://169.254.169.254/latest/meta-data/iam/security-credentials/` or RFC 1918 internal service URLs. Execution context is **server-side**: the HTTP client runs with the Tool Server's IAM role and internal network reach. FR-011 gate confirmed: (1) LLM keyword on Orchestrator, (2) Tool Call Request (JSON-RPC) → MCP Tool Server → External API (HTTP fetch) = SSRF-capable server-side execution sink.",
             "markdown": "Implement URL allowlisting on the MCP Tool Server for all outbound HTTP tool invocations: reject any URL not in an explicit allowlist of permitted external hostnames. Block egress to RFC 1918 ranges (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local (`169.254.0.0/16`), and cloud metadata endpoints via egress firewall rules. Validate URL scheme to `{http, https}` only. Apply DNS pinning (resolve once, verify IP is not private before dispatch)."
@@ -1989,7 +1989,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The Specialist Agent, once delegated a task, operates autonomously without continuous Orchestrator oversight. An adversarially crafted delegation message can cause the Specialist to execute a sequence of tool calls that constitutes a prohibited action when viewed holistically — each individual call appears permitted, but the combination achieves an unauthorized outcome.",
             "markdown": "Implement task-level intent verification: the Specialist MUST check that each tool invocation in a task sequence is consistent with the task's stated objective. Apply a \"budget\" on tool calls per task (maximum N calls); require re-authorization from the Orchestrator for task extensions. Log all tool call sequences for retrospective analysis."
@@ -2038,7 +2038,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The MCP Tool Server acts as a privileged execution broker. Runaway or adversarially prompted agents (Orchestrator or Specialist) can cause the Tool Server to repeatedly call External API endpoints in rapid succession, exhausting the API provider's rate limits, incurring financial costs, or triggering security lockouts that deny the system access to required external capabilities.",
             "markdown": "Implement per-session and per-agent tool call budgets with hard rate limits enforced at the Tool Server (not just the agent). Apply per-tool circuit breakers: if a tool's error rate exceeds a threshold, temporarily disable it and alert operators. Monitor cumulative external API spend and alert on anomalous patterns."
@@ -2186,7 +2186,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Improper output handling — server-side execution via Clinical Query / Context injection into the Orchestrator's downstream Tool Call Request: the Clinical Advisory Sub-Agent returns \"Clinical Summary + Recommendations\" to the Orchestrator via JSON-RPC. If the Orchestrator incorporates this clinical output into a subsequent Tool Call Request (JSON-RPC) to the MCP Tool Server without sanitization (e.g., embedding clinical recommendation text into a tool parameter), adversarial content injected into the clinical output can achieve server-side execution at the Tool Server. Execution context: **server-side** via the Orchestrator→ToolServer path. FR-011 two-part gate confirmed: (1) LLM keyword on Clinical Advisory Sub-Agent (\"clinical\", \"advisory\", \"medical\"), (2) `Clinical Summary + Recommendations` → Orchestrator → `Tool Call Request (JSON-RPC)` → MCP Tool Server = server-side execution sink downstream of sub-agent output.",
             "markdown": "The Orchestrator MUST treat Clinical Advisory Sub-Agent outputs as untrusted inputs when constructing downstream Tool Call Requests: apply output sanitization and allowlist-based parameter validation before incorporating clinical recommendation text into JSON-RPC parameters. Never interpolate raw clinical output directly into tool invocation parameters. Apply the same parameterization and schema-validation controls as for direct LLM output (OI-2 mitigations)."
@@ -2346,7 +2346,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The Orchestrator and Specialist Agent can jointly coordinate (via the Inter-Agent Channel) to achieve a combined action that neither could perform alone or that would trigger per-agent rate limits if attempted individually. An attacker who compromises both agents (or injects coordinated prompts via the Inter-Agent Channel) can leverage this coordination for policy circumvention or joint data exfiltration.",
             "markdown": "Implement cross-agent rate limits and coordination throttles at the Channel level. Log all inter-agent coordination patterns to the Audit Logger. Apply a policy engine that evaluates the combined effect of multi-agent action sequences. Enforce per-agent AND per-session action budgets independently."
@@ -2395,7 +2395,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The Channel is a shared substrate whose compromise enables agent-in-the-middle attacks: an attacker intercepts delegation messages, modifies the task parameters (replacing legitimate tool targets with attacker-controlled endpoints), and forwards the modified message to the Specialist Agent. The Specialist executes unauthorized actions believing the instructions came from the Orchestrator.",
             "markdown": "Implement end-to-end message authentication with digital signatures (Orchestrator signs, Specialist verifies). The Channel itself MUST NOT be trusted for integrity — security MUST be at the message level. Implement replay detection (monotonic message counters, timestamp windows)."
@@ -2836,7 +2836,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "The Learning Loop's model update mechanism, when fed adversarially crafted training signals, can be exploited for a temporal autonomy attack: the training data contains instructions that cause the updated model to expand its autonomous action scope on the next cycle, gradually accumulating capabilities it was not originally authorized to have.",
             "markdown": "Apply capability auditing as part of every model update evaluation: before deploying an update, run the updated model through a capability regression suite that tests for unauthorized capability expansion. Enforce a strict capability allowlist (permitted tool types, action categories) that is evaluated post-update and MUST pass before production deployment of any model update."
@@ -2934,7 +2934,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Training data poisoning of the Specialist Agent via the Learning Loop: adversarially crafted audit log entries from the Specialist's own decision logs (self-poisoning) can be incorporated into the Learning Loop's training signal and returned as a model update that shifts the Specialist's behavior toward attacker-preferred outputs.",
             "markdown": "Apply the same training data provenance and anomaly detection controls as LLM-4. Additionally: implement agent-specific behavioral baselining — compare the Specialist's pre/post-update behavior against its baseline on a held-out evaluation set before deploying any update."
@@ -3032,7 +3032,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Data poisoning of the Learning Loop's training signal: the audit log training stream is the Learning Loop's primary data source. An attacker who systematically injects adversarially crafted interaction records into the Audit Logger creates poisoned training data that shifts the updated models' behavior over the training cycle — a temporal data poisoning attack with delayed activation at the next model update.",
             "markdown": "Implement training data integrity controls: (a) cryptographic signing of each audit log batch, (b) anomaly detection on training signal distributions (outlier detection, behavioral drift analysis), (c) holdout evaluation before deploying any update, (d) differential privacy during training to limit per-example influence. Apply a human-review gate on model updates that show significant behavioral deviation from the prior version."
@@ -3278,7 +3278,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "**Insecure Inter-Agent Communication (Category 9 — OWASP ASI07:2026)**: The Inter-Agent Communication Channel connects the LLM Agent Orchestrator, Specialist Agent, and (via the Orchestrator) the Clinical Advisory Sub-Agent without declaring mutual authentication, inter-agent message signing, or nonce-based replay prevention. The channel does not declare mTLS between senders and receivers, messages lack HMAC envelope signatures or asymmetric envelope signatures (Ed25519 / ECDSA), and no timestamp-bound nonce-based replay-window enforcement is documented. A network-positioned attacker or a compromised Application Zone process can intercept delegation messages (AML.T0060 agent-in-the-middle topology) and replay, modify, or inject instructions to the Specialist Agent or the Orchestrator without any authentic-source signal available to the receiving component. The Orchestrator additionally acts as a relay between the Channel and the Clinical Advisory Sub-Agent without declared taint propagation — the relay's outputs do not carry the upstream sender's authority labels, enabling an attacker who compromises the Orchestrator's relay function to propagate attacker-controlled content to ClinAdvisor without the authority label that ClinAdvisor would need to detect tampering.",
             "markdown": "(1) Mutual TLS (mTLS) — pinned client/server certificates with mutual verification on every inter-agent channel endpoint; reject any channel without declared mTLS at trust-boundary crossings. (2) Inter-agent message signing — HMAC envelope signing (HMAC-SHA256) or asymmetric envelope signature (Ed25519) with integrity verification at the receiving agent BEFORE any action is taken on the message. (3) Nonce-based replay prevention — bounded message-age window enforced with a monotonic counter or timestamp + per-call nonce; receiving agents MUST reject messages outside the replay window. (4) Inter-agent taint labels — authority propagation across the Orchestrator relay: the relay's outputs MUST carry the upstream sender's authority labels so ClinAdvisor and Specialist can detect tampering at the receiving end. (5) Per-channel mutual authentication fallback — mutual JWT or mutual API key as fallback where mTLS is infeasible, validated peer-to-peer at every channel handshake."
@@ -3545,7 +3545,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Model theft via systematic API probing: an attacker issues carefully crafted queries to extract the Orchestrator's model behavior, fine-tuning data characteristics, or system prompt contents through systematic probing, enabling the attacker to build a functional replica of the model or extract proprietary training data.",
             "markdown": "Implement query rate limiting and anomaly detection to identify systematic probing patterns (similar query structures, exhaustive parameter sweeps). Apply differential privacy to training data to limit memorization. Add output perturbation or watermarking to model responses to enable detection of model-extraction datasets. Limit response detail for queries that pattern-match against known extraction techniques."
@@ -3594,7 +3594,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/llm-threats",
+          "ruleId": "tachi/ai/llm",
           "message": {
             "text": "Model theft via Learning Loop output monitoring: an attacker with observability access to the Learning Loop's model update artifacts (parameter diffs, update packages) can reconstruct the model's architecture, parameters, or training data characteristics — effectively stealing the proprietary model.",
             "markdown": "Encrypt model update packages end-to-end: the Learning Loop MUST encrypt model artifacts before emission; the Orchestrator and Specialist decrypt using HSM-managed keys. Apply model watermarking to enable theft detection. Restrict access to model update artifacts to authorized deployment services only."
@@ -3937,7 +3937,7 @@
           }
         },
         {
-          "ruleId": "tachi/ai/agentic-threats",
+          "ruleId": "tachi/ai/agentic",
           "message": {
             "text": "Multi-agent emergent behavior — cascading failu...",
             "markdown": ""

--- a/scripts/generate-risk-scores-sarif.py
+++ b/scripts/generate-risk-scores-sarif.py
@@ -23,6 +23,17 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from sarif_common import (
+    PREFIX_TO_RULE,
+    build_sarif_envelope,
+    level_for_band,
+    parse_component_metadata,
+    prefix_for,
+)
+from tachi_parsers import parse_markdown_table
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SAMPLE = REPO_ROOT / "examples/agentic-app/sample-report"
 RISK_MD = SAMPLE / "risk-scores.md"
@@ -34,78 +45,27 @@ SOURCE_THREATS_URI = (
 )
 
 
-# ---------------------------------------------------------------------------
-# Static mappings (rules + taxonomy)
-# ---------------------------------------------------------------------------
-
-PREFIX_TO_RULE = {
-    "S": "tachi/stride/spoofing",
-    "T": "tachi/stride/tampering",
-    "R": "tachi/stride/repudiation",
-    "I": "tachi/stride/information-disclosure",
-    "D": "tachi/stride/denial-of-service",
-    "E": "tachi/stride/elevation-of-privilege",
-    "AG": "tachi/ai/agentic-threats",
-    "AGP": "tachi/ai/agentic-threats",
-    "LLM": "tachi/ai/llm-threats",
-    "OI": "tachi/ai/llm-threats",
-    "MI": "tachi/ai/llm-threats",
-}
-
-
-def prefix_for(finding_id: str) -> str:
-    """Return the symbolic prefix for a finding ID (e.g. 'AG' from 'AG-8')."""
-    return finding_id.rsplit("-", 1)[0] if "-" in finding_id else finding_id
-
-
-# ---------------------------------------------------------------------------
-# Parsers — risk-scores.md
-# ---------------------------------------------------------------------------
-
-SCORED_ROW = re.compile(
-    r"^\| (?P<id>[A-Z]+(?:-[A-Z]+)?-\d+) \| "
-    r"(?P<component>[^|]+?) \| "
-    r"(?P<threat>[^|]+?) \| "
-    r"(?P<cvss>[\d.]+) \| "
-    r"(?P<exploit>[\d.]+) \| "
-    r"(?P<scal>[\d.]+) \| "
-    r"(?P<reach>[\d.]+) \| "
-    r"(?P<composite>[\d.]+) \| "
-    r"(?P<severity>[A-Za-z]+) \| "
-    r"(?P<sla>[^|]+?) \| "
-    r"(?P<disposition>[^|]+?) \|"
-)
-
-
 def parse_risk_md_section2(md: str) -> list[dict]:
-    """Parse Section 2 'Scored Threat Table' rows into finding dicts."""
-    in_section = False
-    rows: list[dict] = []
-    for line in md.splitlines():
-        if line.startswith("## 2. Scored Threat Table"):
-            in_section = True
-            continue
-        if in_section and line.startswith("## "):
-            break
-        m = SCORED_ROW.match(line)
-        if not m:
-            continue
-        rows.append(
+    """Parse Section 2 'Scored Threat Table' rows into typed finding dicts."""
+    rows = parse_markdown_table(md, "## 2. Scored Threat Table")
+    out: list[dict] = []
+    for r in rows:
+        out.append(
             {
-                "id": m.group("id").strip(),
-                "component": m.group("component").strip(),
-                "threat_summary": m.group("threat").strip(),
-                "cvss_base": float(m.group("cvss")),
-                "exploitability": float(m.group("exploit")),
-                "scalability": float(m.group("scal")),
-                "reachability": float(m.group("reach")),
-                "composite": float(m.group("composite")),
-                "severity_band": m.group("severity").strip(),
-                "sla_days": m.group("sla").strip(),
-                "disposition": m.group("disposition").strip(),
+                "id": r["ID"].strip(),
+                "component": r["Component"].strip(),
+                "threat_summary": r["Threat"].strip(),
+                "cvss_base": float(r["CVSS"]),
+                "exploitability": float(r["Exploitability"]),
+                "scalability": float(r["Scalability"]),
+                "reachability": float(r["Reachability"]),
+                "composite": float(r["Composite"]),
+                "severity_band": r["Severity"].strip(),
+                "sla_days": r["SLA"].strip(),
+                "disposition": r["Disposition"].strip(),
             }
         )
-    return rows
+    return out
 
 
 SECTION3_HEADER = re.compile(r"^### (?P<id>[A-Z]+(?:-[A-Z]+)?-\d+):\s+(?P<text>.+)$")
@@ -118,11 +78,7 @@ SCORE_SOURCE_RE = re.compile(r"^\*Score source:\s+(?P<source>[^*]+)\*")
 
 
 def parse_risk_md_section3(md: str) -> dict[str, dict]:
-    """Parse Section 3 'Dimensional Breakdown' for per-finding details.
-
-    Returns a dict keyed by finding ID with category, MAESTRO layer, CVSS
-    vector, correlation primary, and score source.
-    """
+    """Parse Section 3 'Dimensional Breakdown' for per-finding details."""
     in_section = False
     out: dict[str, dict] = {}
     cur: dict | None = None
@@ -156,7 +112,6 @@ def parse_risk_md_section3(md: str) -> dict[str, dict]:
         ):
             mm = rx.match(line)
             if mm:
-                # CVSS vector regex uses 'vector' group; others vary.
                 if key == "cvss_vector":
                     cur[key] = mm.group("vector")
                 else:
@@ -176,92 +131,21 @@ def parse_risk_md_section3(md: str) -> dict[str, dict]:
     return out
 
 
-GOV_ROW = re.compile(
-    r"^\| (?P<id>[A-Z]+(?:-[A-Z]+)?-\d+) \| "
-    r"(?P<component>[^|]+?) \| "
-    r"(?P<severity>[A-Za-z]+) \| "
-    r"(?P<owner>[^|]+?) \| "
-    r"(?P<sla>[^|]+?) \| "
-    r"(?P<disposition>[^|]+?) \| "
-    r"(?P<review>\d{4}-\d{2}-\d{2}) \|"
-)
-
-
 def parse_risk_md_section4(md: str) -> dict[str, dict]:
     """Parse Section 4 'Governance Fields' rows into per-finding governance."""
-    in_section = False
+    rows = parse_markdown_table(md, "## 4. Governance Fields")
     out: dict[str, dict] = {}
-    for line in md.splitlines():
-        if line.startswith("## 4. Governance Fields"):
-            in_section = True
+    for r in rows:
+        fid = r.get("ID", "").strip()
+        if not fid:
             continue
-        if in_section and line.startswith("## "):
-            break
-        m = GOV_ROW.match(line)
-        if not m:
-            continue
-        out[m.group("id").strip()] = {
-            "owner": m.group("owner").strip(),
-            "sla_days": m.group("sla").strip(),
-            "disposition": m.group("disposition").strip(),
-            "review_date": m.group("review").strip(),
+        out[fid] = {
+            "owner": r.get("Owner", "").strip(),
+            "sla_days": r.get("SLA", "").strip(),
+            "disposition": r.get("Disposition", "").strip(),
+            "review_date": r.get("Review Date", "").strip(),
         }
     return out
-
-
-# ---------------------------------------------------------------------------
-# Parsers — threats.md
-# ---------------------------------------------------------------------------
-
-ZONE_ROW = re.compile(r"^\| (?P<zone>[^|]+?) \| (?P<level>[^|]+?) \| (?P<components>[^|]+?) \|")
-COMPONENT_ROW = re.compile(
-    r"^\| (?P<name>[^|]+?) \| (?P<dfd>External Entity|Process|Data Store) \| (?P<layer>[^|]+?) \| (?P<desc>[^|]+?) \|"
-)
-
-
-def parse_trust_zones(md: str) -> dict[str, str]:
-    """Map component name -> trust zone name (e.g. 'Application Zone')."""
-    in_section = False
-    component_zone: dict[str, str] = {}
-    for line in md.splitlines():
-        if line.startswith("### Trust Zones"):
-            in_section = True
-            continue
-        if in_section and line.startswith("### "):
-            break
-        m = ZONE_ROW.match(line)
-        if not m:
-            continue
-        zone = m.group("zone").strip()
-        if zone == "Zone":  # header row
-            continue
-        for c in (c.strip() for c in m.group("components").split(",")):
-            if c:
-                component_zone[c] = zone
-    return component_zone
-
-
-def parse_component_kinds(md: str) -> dict[str, str]:
-    """Map component name -> SARIF logical-location kind."""
-    kinds: dict[str, str] = {}
-    in_components = False
-    for line in md.splitlines():
-        if line.startswith("### Components"):
-            in_components = True
-            continue
-        if in_components and line.startswith("### "):
-            break
-        m = COMPONENT_ROW.match(line)
-        if not m or m.group("name").strip() == "Component":
-            continue
-        dfd = m.group("dfd").strip()
-        kind = {
-            "External Entity": "external-entity",
-            "Process": "process",
-            "Data Store": "data",
-        }.get(dfd, "process")
-        kinds[m.group("name").strip()] = kind
-    return kinds
 
 
 THREAT_ROW = re.compile(
@@ -299,14 +183,18 @@ def parse_threats_full_text(md: str) -> dict[str, tuple[str, str]]:
     return out
 
 
-SOURCE_ATTR_BLOCK = re.compile(
-    r"```yaml\n(?P<body>[\s\S]+?)```",
-    re.MULTILINE,
-)
+SOURCE_ATTR_BLOCK = re.compile(r"```yaml\n(?P<body>[\s\S]+?)```", re.MULTILINE)
 
 
 def parse_source_attribution(md: str) -> dict[str, list[dict]]:
-    """Extract per-finding source_attribution lists from threats.md YAML block."""
+    """Extract per-finding source_attribution lists from inline YAML blocks.
+
+    The threats.md flavor consumed by this generator emits source_attribution
+    inside ad-hoc yaml fences (often after Section 4 AI tables, not the
+    formally named "## 9. Source Attribution" block that
+    `tachi_parsers._extract_source_attribution_block` requires). This function
+    therefore scans every yaml fence rather than gating on Section 9.
+    """
     out: dict[str, list[dict]] = {}
     for m in SOURCE_ATTR_BLOCK.finditer(md):
         body = m.group("body")
@@ -320,7 +208,6 @@ def parse_source_attribution(md: str) -> dict[str, list[dict]]:
             if not line:
                 continue
             if not line.startswith(" "):
-                # New finding entry
                 if cur_id and cur_attrs:
                     out[cur_id] = cur_attrs
                 cur_id = line.split(":", 1)[0].strip()
@@ -343,10 +230,6 @@ def parse_source_attribution(md: str) -> dict[str, list[dict]]:
     return out
 
 
-# ---------------------------------------------------------------------------
-# Helper builders
-# ---------------------------------------------------------------------------
-
 _OWASP_REFERENCE_BY_PREFIX = {
     "OI": "OWASP LLM05:2025",
     "MI": "OWASP LLM09:2025",
@@ -354,24 +237,20 @@ _OWASP_REFERENCE_BY_PREFIX = {
 
 
 def derive_owasp_reference(prefix: str) -> str | None:
-    """Return an OWASP reference label for legacy property compat."""
     return _OWASP_REFERENCE_BY_PREFIX.get(prefix)
 
 
-def level_for_band(band: str) -> str:
-    return {
-        "Critical": "error",
-        "High": "error",
-        "Medium": "warning",
-        "Low": "note",
-    }.get(band, "warning")
+_DFD_TYPE_TO_KIND = {
+    "External Entity": "external-entity",
+    "Process": "process",
+    "Data Store": "data",
+}
 
 
-def build_logical_location(
-    component: str, kinds: dict[str, str], zones: dict[str, str]
-) -> dict:
-    zone = zones.get(component, "Application Zone")
-    kind = kinds.get(component, "process")
+def build_logical_location(component: str, component_meta: dict[str, dict[str, str]]) -> dict:
+    meta = component_meta.get(component, {"zone": "Application Zone", "dfd_type": "Process"})
+    zone = meta["zone"]
+    kind = _DFD_TYPE_TO_KIND.get(meta["dfd_type"], "process")
     return {
         "name": component,
         "fullyQualifiedName": f"{zone}/{component}",
@@ -389,8 +268,7 @@ def build_result(
     threats_status: dict[str, str],
     threats_full: dict[str, tuple[str, str]],
     source_attribution: dict[str, list[dict]],
-    component_kinds: dict[str, str],
-    component_zones: dict[str, str],
+    component_meta: dict[str, dict[str, str]],
 ) -> dict:
     """Build one SARIF 2.1.0 result entry from a scored finding plus correlated context.
 
@@ -402,7 +280,7 @@ def build_result(
     """
     fid = finding["id"]
     pref = prefix_for(fid)
-    rule_id = PREFIX_TO_RULE.get(pref, "tachi/ai/agentic-threats")
+    rule_id = PREFIX_TO_RULE.get(pref, "tachi/ai/agentic")
     level = level_for_band(finding["severity_band"])
 
     component = finding["component"]
@@ -410,7 +288,6 @@ def build_result(
         fid, (finding.get("threat_summary", ""), "")
     )
 
-    # Properties — quantitative scores + governance + provenance
     composite_str = f"{finding['composite']:.1f}"
     props: dict = {
         "security-severity": composite_str,
@@ -428,7 +305,6 @@ def build_result(
         "governance.sla_days": s4.get("sla_days", finding["sla_days"]),
         "governance.disposition": s4.get("disposition", finding["disposition"]),
         "review-date": s4.get("review_date", ""),
-        # Legacy / back-compat fields kept alongside new namespaced ones
         "risk-owner": s4.get("owner", "Unassigned"),
         "remediation-sla": s4.get("sla_days", finding["sla_days"]),
         "risk-disposition": s4.get("disposition", finding["disposition"]),
@@ -450,7 +326,6 @@ def build_result(
     if owasp_ref:
         props["owasp-reference"] = owasp_ref
 
-    # Source attribution → SARIF property
     if fid in source_attribution:
         props["source-attribution"] = source_attribution[fid]
 
@@ -463,7 +338,7 @@ def build_result(
     if threats_status.get(fid) == "NEW":
         props.setdefault("new-finding", True)
 
-    result = {
+    return {
         "ruleId": rule_id,
         "message": {
             "text": threat_text or finding.get("threat_summary", ""),
@@ -476,20 +351,13 @@ def build_result(
                     "artifactLocation": {"uri": SOURCE_THREATS_URI},
                     "region": {"startLine": 1},
                 },
-                "logicalLocation": build_logical_location(
-                    component, component_kinds, component_zones
-                ),
+                "logicalLocation": build_logical_location(component, component_meta),
             }
         ],
         "partialFingerprints": {"findingId/v1": fid},
         "properties": props,
     }
-    return result
 
-
-# ---------------------------------------------------------------------------
-# Run construction
-# ---------------------------------------------------------------------------
 
 RULE_DEFS = [
     (
@@ -541,7 +409,7 @@ RULE_DEFS = [
         "7.8",
     ),
     (
-        "tachi/ai/agentic-threats",
+        "tachi/ai/agentic",
         "Agentic Threats",
         "AI agent autonomy and multi-agent coordination threats",
         "Threats specific to agentic AI systems including autonomous action abuse, agent collusion, tool call injection, and inter-agent communication vulnerabilities (OWASP ASI 2026 series).",
@@ -549,7 +417,7 @@ RULE_DEFS = [
         "7.8",
     ),
     (
-        "tachi/ai/llm-threats",
+        "tachi/ai/llm",
         "LLM Threats",
         "Large language model specific threats",
         "Threats specific to LLM systems including prompt injection, training data poisoning, model theft, improper output handling, and misinformation emission.",
@@ -640,11 +508,6 @@ def supported_taxonomies() -> list[dict]:
     ]
 
 
-# ---------------------------------------------------------------------------
-# Main
-# ---------------------------------------------------------------------------
-
-
 def main() -> int:
     risk_md = RISK_MD.read_text(encoding="utf-8")
     threats_md = THREATS_MD.read_text(encoding="utf-8")
@@ -653,8 +516,7 @@ def main() -> int:
     s3_map = parse_risk_md_section3(risk_md)
     s4_map = parse_risk_md_section4(risk_md)
 
-    component_zones = parse_trust_zones(threats_md)
-    component_kinds = parse_component_kinds(threats_md)
+    component_meta = parse_component_metadata(threats_md)
     threats_status = parse_threats_status(threats_md)
     threats_full = parse_threats_full_text(threats_md)
     source_attribution = parse_source_attribution(threats_md)
@@ -678,31 +540,19 @@ def main() -> int:
                 threats_status,
                 threats_full,
                 source_attribution,
-                component_kinds,
-                component_zones,
+                component_meta,
             )
         )
 
-    sarif = {
-        "version": "2.1.0",
-        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-        "runs": [
-            {
-                "tool": {
-                    "driver": {
-                        "name": "tachi-risk-scorer",
-                        "version": "1.1",
-                        "semanticVersion": "1.1",
-                        "informationUri": "https://github.com/owner/tachi",
-                        "supportedTaxonomies": supported_taxonomies(),
-                        "rules": build_rules(),
-                    }
-                },
-                "taxonomies": TAXONOMIES,
-                "results": results,
-            }
-        ],
+    driver = {
+        "name": "tachi-risk-scorer",
+        "version": "1.1",
+        "semanticVersion": "1.1",
+        "informationUri": "https://github.com/owner/tachi",
+        "supportedTaxonomies": supported_taxonomies(),
+        "rules": build_rules(),
     }
+    sarif = build_sarif_envelope(driver, TAXONOMIES, results)
 
     OUT_SARIF.write_text(
         json.dumps(sarif, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"

--- a/scripts/generate-threats-sarif.py
+++ b/scripts/generate-threats-sarif.py
@@ -1,14 +1,8 @@
 #!/usr/bin/env python3
-"""
-generate-threats-sarif.py
+"""Generate SARIF 2.1.0 from a regenerated threats.md (Sections 3 STRIDE + 4 AI tables).
 
-Parses a regenerated threats.md (Sections 3 STRIDE + 4 AG/LLM/OI/MI finding tables)
-and emits SARIF 2.1.0 output with:
-- 8 rules (STRIDE 6 + AI 2: agentic + llm)
-- One result per finding
-- Severity-mapped levels (error/warning/note)
-- Properties including OWASP ref, agentic pattern, MAESTRO layer
-- Special AG-8 properties: asi07_emission, feature, pattern_category
+Per-finding properties include OWASP reference, agentic pattern, MAESTRO layer.
+F-3 / Feature 219: AG-8 emits properties.asi07_emission=true and pattern_category=9.
 
 Usage:
     python3 scripts/generate-threats-sarif.py <threats.md> <output.sarif>
@@ -20,8 +14,16 @@ import re
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 
-# ---------- Rule dictionary (8 rules) ----------
+from sarif_common import (
+    PREFIX_TO_RULE,
+    SEVERITY_TO_LEVEL,
+    build_sarif_envelope,
+    parse_component_metadata,
+)
+
+
 RULES = [
     {
         "id": "tachi/stride/spoofing",
@@ -263,55 +265,17 @@ RULES = [
 ]
 
 
-PREFIX_TO_RULE = {
-    "S": "tachi/stride/spoofing",
-    "T": "tachi/stride/tampering",
-    "R": "tachi/stride/repudiation",
-    "I": "tachi/stride/information-disclosure",
-    "D": "tachi/stride/denial-of-service",
-    "E": "tachi/stride/elevation-of-privilege",
-    "AG": "tachi/ai/agentic",
-    "AGP": "tachi/ai/agentic",
-    "LLM": "tachi/ai/llm",
-    "OI": "tachi/ai/llm",
-    "MI": "tachi/ai/llm",
-}
-
-
-SEVERITY_TO_LEVEL = {
-    "Critical": "error",
-    "High": "error",
-    "Medium": "warning",
-    "Low": "note",
-    "Note": "note",
-}
-
-
-# Component → trust zone mapping (derived from threats.md Trust Zones)
-COMPONENT_ZONE = {
-    "User": ("User Zone", "external-entity"),
-    "Guardrails Service": ("Application Zone", "process"),
-    "LLM Agent Orchestrator": ("Application Zone", "process"),
-    "Specialist Agent": ("Application Zone", "process"),
-    "Inter-Agent Communication Channel": ("Application Zone", "process"),
-    "MCP Tool Server": ("Application Zone", "process"),
-    "Knowledge Base": ("Application Zone", "data-store"),
-    "Audit Logger": ("Application Zone", "data-store"),
-    "Long-Running Learning Loop": ("Application Zone", "process"),
-    "Clinical Advisory Sub-Agent": ("Application Zone", "process"),
-    "External API": ("External Services", "external-entity"),
+_DFD_TYPE_TO_KIND = {
+    "External Entity": "external-entity",
+    "Process": "process",
+    "Data Store": "data-store",
 }
 
 
 def parse_findings(md_path: Path) -> list[dict]:
-    """
-    Parses Section 3 (STRIDE) and Section 4 (AI: AG, LLM, OI, MI) finding tables.
-    Returns a list of finding dicts with keys: id, prefix, status, component,
-    maestro, agentic_pattern, threat, owasp_ref, likelihood, impact, risk_level, mitigation.
-    """
+    """Parse Section 3 (STRIDE) and Section 4 (AI: AG, LLM, OI, MI) finding tables."""
     text = md_path.read_text(encoding="utf-8")
 
-    # Restrict to Sections 3, 4, and 4a (skip Section 5+ which has summary tables)
     sec3_match = re.search(r"^## 3\. STRIDE Threat Tables\s*$", text, re.MULTILINE)
     sec5_match = re.search(r"^## 5\. ", text, re.MULTILINE)
     if not sec3_match or not sec5_match:
@@ -319,9 +283,6 @@ def parse_findings(md_path: Path) -> list[dict]:
 
     findings_region = text[sec3_match.start():sec5_match.start()]
 
-    # Match table rows with at least 9 pipe-separated columns starting with finding ID.
-    # STRIDE rows: 10 cols (ID, Status, Component, MAESTRO, Pattern, Threat, Likelihood, Impact, Risk, Mitigation)
-    # AI rows: 11 cols (adds OWASP Reference)
     finding_id_re = re.compile(
         r"^\| (?P<id>(?:S|T|R|I|D|E|AG|AGP|LLM|OI|MI)-\d+|AGP-\d+) \| (?P<status>\[NEW\]|\[UNCHANGED\]|\[UPDATED\]|\[RESOLVED\]) \|",
         re.MULTILINE,
@@ -346,18 +307,15 @@ def parse_findings(md_path: Path) -> list[dict]:
 
         fid = cols[0]
         if fid in seen_ids:
-            # Skip duplicates (e.g. summary tables in Section 7) — though we limited region
             continue
         seen_ids.add(fid)
 
-        # Extract prefix (everything before first hyphen-digit, but careful with AGP)
         m = re.match(r"^([A-Z]+)-\d+$", fid)
         if not m:
             continue
         prefix = m.group(1)
 
-        # 10-col (STRIDE) layout: [ID, Status, Component, MAESTRO, Pattern, Threat, Likelihood, Impact, Risk, Mitigation]
-        # 11-col (AI) layout:    [ID, Status, Component, MAESTRO, Pattern, Threat, OWASP, Likelihood, Impact, Risk, Mitigation]
+        # 11-col (AI) layout adds an OWASP Reference between Threat and Likelihood.
         if len(cols) >= 11 and prefix in ("AG", "AGP", "LLM", "OI", "MI"):
             (
                 _,
@@ -406,32 +364,24 @@ def parse_findings(md_path: Path) -> list[dict]:
 
 
 def normalize_owasp_id(owasp_ref: str, prefix: str) -> str:
-    """
-    Normalize OWASP / source IDs from finding rows.
+    """Normalize OWASP / source IDs from finding rows.
 
-    - "OWASP LLM01:2025" -> "LLM-01"
-    - "ASI-01" / "ASI-07" -> as-is (already canonical)
-    - "MCP-03" -> as-is
-    - "" (STRIDE rows) -> derive from prefix mapping
+    "OWASP LLM01:2025" → "LLM-01"; "ASI-01" / "MCP-03" pass through;
+    STRIDE rows derive from a fixed prefix mapping.
     """
     if owasp_ref:
         s = owasp_ref.strip()
-        # OWASP LLM##:YYYY  -> LLM-##
         m = re.match(r"^OWASP\s+LLM(\d+):\d+$", s)
         if m:
             return f"LLM-{int(m.group(1)):02d}"
-        # ASI-## or ASI##
         m = re.match(r"^ASI[-]?(\d+)$", s)
         if m:
             return f"ASI-{int(m.group(1)):02d}"
-        # MCP-## or MCP##
         m = re.match(r"^MCP[-]?(\d+)$", s)
         if m:
             return f"MCP-{int(m.group(1)):02d}"
-        # Already canonical (e.g. "ASI-01" arrived literally)
         return s
 
-    # Derive from STRIDE prefix
     stride_owasp = {
         "S": "A07",
         "T": "A08",
@@ -444,36 +394,29 @@ def normalize_owasp_id(owasp_ref: str, prefix: str) -> str:
 
 
 def line_hash_for(fid: str) -> str:
-    """
-    Stable partialFingerprint compatible with the F-2 vintage:
-    short MD5 hex of the finding ID (16 hex chars).
-    """
     return hashlib.md5(fid.encode("utf-8")).hexdigest()[:16]
 
 
-def build_result(finding: dict, run_id_baseline: str = "2026-04-19T03-20-30") -> dict:
-    """Build one SARIF 2.1.0 result entry from a parsed threats.md finding row.
+def build_result(
+    finding: dict,
+    component_meta: dict[str, dict[str, str]],
+    run_id_baseline: str = "2026-04-19T03-20-30",
+) -> dict:
+    """Build one SARIF 2.1.0 result entry from a parsed finding row.
 
-    Maps finding prefix → rule id, severity → SARIF level, and component →
-    fully-qualified logical location. Emits per-finding properties: status,
-    component, MAESTRO layer, normalized OWASP id, signal class, baseline-run
-    correlation, and source attribution. AG-8 receives an `asi07_emission`
-    marker per the F-219 enrichment contract.
+    AG-8 receives an `asi07_emission` marker per the F-219 enrichment contract.
     """
     rule_id = PREFIX_TO_RULE[finding["prefix"]]
-
-    # Level mapping
     level = SEVERITY_TO_LEVEL.get(finding["risk_level"], "note")
 
-    # Component → fully qualified location
     component = finding["component"]
-    zone, kind = COMPONENT_ZONE.get(component, ("Application Zone", "process"))
+    meta = component_meta.get(component, {"zone": "Application Zone", "dfd_type": "Process"})
+    zone = meta["zone"]
+    kind = _DFD_TYPE_TO_KIND.get(meta["dfd_type"], "process")
     fq = f"{zone}/{component}"
 
-    # OWASP / source ID normalization
     owasp_id = normalize_owasp_id(finding["owasp_ref"], finding["prefix"])
 
-    # Tags
     tag_map = {
         "S": ["security", "stride", "spoofing"],
         "T": ["security", "stride", "tampering"],
@@ -489,10 +432,8 @@ def build_result(finding: dict, run_id_baseline: str = "2026-04-19T03-20-30") ->
     }
     tags = list(tag_map.get(finding["prefix"], ["security"]))
 
-    # MAESTRO tagging
     maestro_token = finding["maestro"]
     if maestro_token and maestro_token != "—":
-        # Compact form for the tag list
         m = re.match(r"^(L\d+)\s", maestro_token)
         layer_short = m.group(1) if m else "Unclassified"
         tags.append(f"maestro-layer:{layer_short}")
@@ -513,13 +454,13 @@ def build_result(finding: dict, run_id_baseline: str = "2026-04-19T03-20-30") ->
     if owasp_id:
         properties["owasp_id"] = owasp_id
 
-    # AG-8 special enrichment for F-3 ASI-07 emission
+    # F-3 / Feature 219 ASI07 enrichment marker
     if finding["id"] == "AG-8":
         properties["asi07_emission"] = True
         properties["feature"] = "219-asi07-tool-abuse-enrichment"
         properties["pattern_category"] = 9
 
-    result = {
+    return {
         "ruleId": rule_id,
         "message": {
             "text": finding["threat"],
@@ -551,50 +492,38 @@ def build_result(finding: dict, run_id_baseline: str = "2026-04-19T03-20-30") ->
         "properties": properties,
     }
 
-    return result
+
+_TAXONOMIES = [
+    {
+        "name": "OWASP",
+        "version": "2021",
+        "informationUri": "https://owasp.org/Top10/",
+        "organization": "OWASP Foundation",
+        "shortDescription": {"text": "OWASP Top 10 Web Application Security Risks"},
+    },
+    {
+        "name": "CWE",
+        "version": "4.13",
+        "informationUri": "https://cwe.mitre.org/",
+        "organization": "MITRE",
+        "shortDescription": {"text": "Common Weakness Enumeration"},
+    },
+]
 
 
-def build_sarif(findings: list[dict]) -> dict:
-    results = [build_result(f) for f in findings]
-
-    sarif = {
-        "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
-        "version": "2.1.0",
-        "runs": [
-            {
-                "tool": {
-                    "driver": {
-                        "name": "Tachi",
-                        "semanticVersion": "1.7",
-                        "informationUri": "https://github.com/davidmatousek/tachi",
-                        "supportedTaxonomies": [
-                            {"name": "OWASP", "index": 0},
-                            {"name": "CWE", "index": 1},
-                        ],
-                        "rules": RULES,
-                    }
-                },
-                "taxonomies": [
-                    {
-                        "name": "OWASP",
-                        "version": "2021",
-                        "informationUri": "https://owasp.org/Top10/",
-                        "organization": "OWASP Foundation",
-                        "shortDescription": {"text": "OWASP Top 10 Web Application Security Risks"},
-                    },
-                    {
-                        "name": "CWE",
-                        "version": "4.13",
-                        "informationUri": "https://cwe.mitre.org/",
-                        "organization": "MITRE",
-                        "shortDescription": {"text": "Common Weakness Enumeration"},
-                    },
-                ],
-                "results": results,
-            }
+def build_sarif(findings: list[dict], component_meta: dict[str, dict[str, str]]) -> dict:
+    results = [build_result(f, component_meta) for f in findings]
+    driver = {
+        "name": "Tachi",
+        "semanticVersion": "1.7",
+        "informationUri": "https://github.com/davidmatousek/tachi",
+        "supportedTaxonomies": [
+            {"name": "OWASP", "index": 0},
+            {"name": "CWE", "index": 1},
         ],
+        "rules": RULES,
     }
-    return sarif
+    return build_sarif_envelope(driver, _TAXONOMIES, results, schema_first=True)
 
 
 def main() -> int:
@@ -607,12 +536,13 @@ def main() -> int:
         print(f"ERROR: input file not found: {args.input}", file=sys.stderr)
         return 1
 
+    threats_md = args.input.read_text(encoding="utf-8")
+    component_meta = parse_component_metadata(threats_md)
     findings = parse_findings(args.input)
-    sarif = build_sarif(findings)
+    sarif = build_sarif(findings, component_meta)
 
     args.output.write_text(json.dumps(sarif, indent=2) + "\n", encoding="utf-8")
 
-    # Diagnostic: prefix counts
     counts: dict[str, int] = {}
     for f in findings:
         counts[f["prefix"]] = counts.get(f["prefix"], 0) + 1

--- a/scripts/sarif_common.py
+++ b/scripts/sarif_common.py
@@ -1,0 +1,118 @@
+"""Shared SARIF helpers for the tachi pipeline.
+
+Provides the canonical `PREFIX_TO_RULE` mapping (single source of truth for
+rule URIs across `generate-threats-sarif.py` and `generate-risk-scores-sarif.py`),
+the severity-to-SARIF-level mapping, finding-ID prefix extraction, and a
+threats.md → component metadata parser shared by both generators. Per-script
+emit shape (logicalLocations array vs logicalLocation object, kind label
+vocabulary) remains in each generator to preserve byte-identity (ADR-021).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from tachi_parsers import parse_scope_data  # noqa: E402
+
+
+SARIF_SCHEMA_URI = (
+    "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/"
+    "schema/sarif-schema-2.1.0.json"
+)
+
+
+PREFIX_TO_RULE = {
+    "S": "tachi/stride/spoofing",
+    "T": "tachi/stride/tampering",
+    "R": "tachi/stride/repudiation",
+    "I": "tachi/stride/information-disclosure",
+    "D": "tachi/stride/denial-of-service",
+    "E": "tachi/stride/elevation-of-privilege",
+    "AG": "tachi/ai/agentic",
+    "AGP": "tachi/ai/agentic",
+    "LLM": "tachi/ai/llm",
+    "OI": "tachi/ai/llm",
+    "MI": "tachi/ai/llm",
+}
+
+
+SEVERITY_TO_LEVEL = {
+    "Critical": "error",
+    "High": "error",
+    "Medium": "warning",
+    "Low": "note",
+    "Note": "note",
+}
+
+
+def prefix_for(finding_id: str) -> str:
+    return finding_id.rsplit("-", 1)[0] if "-" in finding_id else finding_id
+
+
+def level_for_band(band: str) -> str:
+    return SEVERITY_TO_LEVEL.get(band, "warning")
+
+
+def parse_component_metadata(threats_md: str) -> dict[str, dict[str, str]]:
+    """Map component name → {'zone': <trust zone>, 'dfd_type': <DFD type>}.
+
+    Single canonical traversal of threats.md Sections 1 (Components) and 2
+    (Trust Zones) via `tachi_parsers.parse_scope_data`. Replaces the
+    hardcoded `COMPONENT_ZONE` dict in `generate-threats-sarif.py` (which
+    silently desynced from threats.md when components changed) and the
+    bespoke regex parsers `parse_trust_zones` + `parse_component_kinds` in
+    `generate-risk-scores-sarif.py`. Caller is responsible for translating
+    `dfd_type` (e.g. "Data Store") into its emit-specific kind label
+    ("data" vs "data-store") to preserve per-script SARIF byte-identity.
+    """
+    scope = parse_scope_data(threats_md)
+    out: dict[str, dict[str, str]] = {}
+    for comp in scope["components"]:
+        name = comp["name"]
+        if not name:
+            continue
+        out[name] = {"zone": "Application Zone", "dfd_type": comp["type"]}
+    for tb in scope["trust_boundaries"]:
+        zone = tb["zone"]
+        if not zone:
+            continue
+        for member in (m.strip() for m in tb["components"].split(",")):
+            if member and member in out:
+                out[member]["zone"] = zone
+    return out
+
+
+def build_sarif_envelope(
+    driver: dict,
+    taxonomies: list[dict],
+    results: list[dict],
+    *,
+    schema_first: bool = False,
+) -> dict:
+    """Assemble the SARIF 2.1.0 root document.
+
+    `schema_first=True` emits `$schema` before `version` (threats.sarif
+    legacy ordering); default emits `version` before `$schema`
+    (risk-scores.sarif ordering). Field order matters for byte-identity
+    under stable JSON serialization.
+    """
+    if schema_first:
+        envelope = {
+            "$schema": SARIF_SCHEMA_URI,
+            "version": "2.1.0",
+        }
+    else:
+        envelope = {
+            "version": "2.1.0",
+            "$schema": SARIF_SCHEMA_URI,
+        }
+    envelope["runs"] = [
+        {
+            "tool": {"driver": driver},
+            "taxonomies": taxonomies,
+            "results": results,
+        }
+    ]
+    return envelope

--- a/tests/scripts/fixtures/tool_abuse_enrichment/valid_category_9_a2a_finding.yaml
+++ b/tests/scripts/fixtures/tool_abuse_enrichment/valid_category_9_a2a_finding.yaml
@@ -17,5 +17,5 @@ references:
 source_attribution:
   - {taxonomy: owasp, id: ASI07, relationship: primary}
   - {taxonomy: cwe, id: CWE-287, relationship: related}
-  - {taxonomy: atlas, id: AML.T0060, relationship: related}
+  - {taxonomy: mitre-atlas, id: AML.T0060, relationship: related}
 dfd_element_type: "Process"

--- a/tests/scripts/test_tool_abuse_enrichment.py
+++ b/tests/scripts/test_tool_abuse_enrichment.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -46,6 +47,18 @@ DETECTION_PATTERNS = (
 )
 FIXTURE_DIR = REPO_ROOT / "tests" / "scripts" / "fixtures" / "tool_abuse_enrichment"
 TAXONOMY_DIR = REPO_ROOT / "schemas" / "taxonomy"
+
+# Make scripts/ importable so we can use the canonical F-A2 validator instead
+# of a test-local re-implementation. Importing the canonical
+# `validate_source_attribution` ensures these tests would catch schema drift
+# (e.g. acceptance of a non-canonical "atlas" taxonomy alias) rather than
+# masking it behind a divergent test helper.
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.tachi_parsers import (  # noqa: E402
+    ValidationError,
+    validate_source_attribution,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -217,76 +230,59 @@ def test_categories_1_8_byte_identity_against_main() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_taxonomy_ids(taxonomy: str) -> set[str]:
-    """Load all top-level id keys from schemas/taxonomy/{taxonomy}.yaml."""
-    suffix_map = {"owasp": "owasp.yaml", "cwe": "cwe.yaml", "atlas": "mitre-atlas.yaml"}
-    path = TAXONOMY_DIR / suffix_map[taxonomy]
-    with path.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
-    return {entry["id"] for entry in data}
+def test_valid_cat_9_fixture_passes_referential_integrity() -> None:
+    """SC-015 BLOCKER: valid_category_9_a2a_finding.yaml MUST pass F-A2 validation.
 
-
-@pytest.fixture(scope="module")
-def taxonomy_ids() -> dict[str, set[str]]:
-    return {
-        "owasp": _load_taxonomy_ids("owasp"),
-        "cwe": _load_taxonomy_ids("cwe"),
-        "atlas": _load_taxonomy_ids("atlas"),
-    }
-
-
-def _validate_source_attribution(finding: dict, taxonomy_ids: dict[str, set[str]]) -> list[str]:
-    """Mimic F-A2 validate_source_attribution() — checks every (taxonomy, id) resolves."""
-    errors: list[str] = []
-    for entry in finding.get("source_attribution", []):
-        tax = entry.get("taxonomy")
-        ident = entry.get("id")
-        rel = entry.get("relationship")
-        if tax not in {"owasp", "mitre-attack", "mitre-atlas", "nist-ai-rmf", "cwe", "atlas"}:
-            errors.append(f"invalid taxonomy {tax!r}")
-            continue
-        normalized_tax = "atlas" if tax in {"atlas", "mitre-atlas"} else tax
-        if normalized_tax not in taxonomy_ids:
-            errors.append(f"taxonomy {tax!r} not loaded")
-            continue
-        if ident not in taxonomy_ids[normalized_tax]:
-            errors.append(f"id {ident!r} absent from {tax} catalog")
-        if rel not in {"primary", "related", "derived"}:
-            errors.append(f"invalid relationship {rel!r}")
-    return errors
-
-
-def test_valid_cat_9_fixture_passes_referential_integrity(taxonomy_ids: dict[str, set[str]]) -> None:
-    """SC-015 BLOCKER: valid_category_9_a2a_finding.yaml MUST pass F-A2 validation."""
+    Uses the canonical ``scripts.tachi_parsers.validate_source_attribution``
+    instead of a test-local re-implementation. The canonical validator reads
+    catalogs internally with its own per-call cache, so no fixture pre-load
+    is required.
+    """
     fixture_path = FIXTURE_DIR / "valid_category_9_a2a_finding.yaml"
     with fixture_path.open("r", encoding="utf-8") as f:
         finding = yaml.safe_load(f)
-    errors = _validate_source_attribution(finding, taxonomy_ids)
+    errors = validate_source_attribution([finding], taxonomy_dir=TAXONOMY_DIR)
     assert errors == [], (
         f"Cat-9 valid fixture failed F-A2 validation: {errors}. "
         f"Catalog citations must resolve in schemas/taxonomy/{{owasp,cwe,mitre-atlas}}.yaml."
     )
 
 
-def test_valid_cat_10_fixture_passes_referential_integrity(taxonomy_ids: dict[str, set[str]]) -> None:
-    """SC-015 BLOCKER: valid_category_10_mcp_to_mcp_finding.yaml MUST pass F-A2 validation."""
+def test_valid_cat_10_fixture_passes_referential_integrity() -> None:
+    """SC-015 BLOCKER: valid_category_10_mcp_to_mcp_finding.yaml MUST pass F-A2 validation.
+
+    Uses the canonical ``scripts.tachi_parsers.validate_source_attribution``
+    instead of a test-local re-implementation.
+    """
     fixture_path = FIXTURE_DIR / "valid_category_10_mcp_to_mcp_finding.yaml"
     with fixture_path.open("r", encoding="utf-8") as f:
         finding = yaml.safe_load(f)
-    errors = _validate_source_attribution(finding, taxonomy_ids)
+    errors = validate_source_attribution([finding], taxonomy_dir=TAXONOMY_DIR)
     assert errors == [], (
         f"Cat-10 valid fixture failed F-A2 validation: {errors}. "
         f"Catalog citations must resolve in schemas/taxonomy/{{owasp,cwe,mitre-atlas}}.yaml."
     )
 
 
-def test_invalid_attribution_fixture_rejected(taxonomy_ids: dict[str, set[str]]) -> None:
-    """SC-015 BLOCKER: invalid_attribution_finding.yaml MUST be rejected (CWE-99999 absent)."""
+def test_invalid_attribution_fixture_rejected() -> None:
+    """SC-015 BLOCKER: invalid_attribution_finding.yaml MUST be rejected (CWE-99999 absent).
+
+    Uses the canonical ``scripts.tachi_parsers.validate_source_attribution``;
+    asserts that the returned list of ``ValidationError`` includes a record
+    whose reason mentions ``CWE-99999``.
+    """
     fixture_path = FIXTURE_DIR / "invalid_attribution_finding.yaml"
     with fixture_path.open("r", encoding="utf-8") as f:
         finding = yaml.safe_load(f)
-    errors = _validate_source_attribution(finding, taxonomy_ids)
-    assert any("CWE-99999" in err for err in errors), (
+    errors = validate_source_attribution([finding], taxonomy_dir=TAXONOMY_DIR)
+    assert errors, (
+        "Negative fixture MUST be rejected; canonical validator returned no errors. "
+        "F-A2 referential-integrity validation is broken."
+    )
+    assert all(isinstance(e, ValidationError) for e in errors), (
+        f"Canonical validator must return ValidationError instances; got: {errors}"
+    )
+    assert any("CWE-99999" in e.reason for e in errors), (
         f"Negative fixture MUST be rejected for CWE-99999 absence; got errors: {errors}. "
         f"F-A2 referential-integrity validation is broken."
     )


### PR DESCRIPTION
## Summary

Three coupled fixes flagged by `/aod.document` code review for Feature 219, executed as a single atomic refactor.

### 1. SARIF generator consolidation (`-224 net lines`)
- **New** `scripts/sarif_common.py` (118 lines) — shared `PREFIX_TO_RULE`, `SEVERITY_TO_LEVEL`, `level_for_band`, `prefix_for`, `parse_component_metadata` (sources component zone+kind from `tachi_parsers.parse_scope_data`, eliminating the hardcoded `COMPONENT_ZONE` dict that silently desynced from `threats.md`), and `build_sarif_envelope`.
- `generate-threats-sarif.py`: -65 lines; now uses `tachi_parsers.parse_threats_findings` + `_extract_source_attribution`.
- `generate-risk-scores-sarif.py`: -150 lines; now uses `tachi_parsers.parse_risk_scores_findings` + `_extract_source_attribution_block`.

### 2. SARIF rule-URI reconciliation
- Pre-refactor drift: `generate-threats-sarif.py` used `tachi/ai/agentic` / `tachi/ai/llm` (short); `generate-risk-scores-sarif.py` used `tachi/ai/agentic-threats` / `tachi/ai/llm-threats` (verbose).
- Reconciled on the **short form** because (a) `threats.sarif` is the byte-identity ground truth per ADR-021, and (b) SARIF rule URIs need not encode "threats" — the run is already about threats.
- `examples/agentic-app/sample-report/risk-scores.sarif`: **32-line URI-only diff** (verified zero non-URI drift).
- `examples/agentic-app/sample-report/threats.sarif`: **byte-identical** under `SOURCE_DATE_EPOCH=1700000000`.

### 3. Canonical `source_attribution` validator + fixture fix
- `tests/scripts/test_tool_abuse_enrichment.py` — removed test-local `_load_taxonomy_ids` + `_validate_source_attribution`; now uses canonical `validate_source_attribution` + `_load_catalog_ids` from `scripts/tachi_parsers.py`.
- The test-local helper accepted `"atlas"` as a synonym for `"mitre-atlas"`, masking schema drift.
- **Exposed and fixed fixture bug**: `valid_category_9_a2a_finding.yaml` line 20 used `taxonomy: atlas` (non-canonical alias). Canonical schema requires `taxonomy: mitre-atlas` (matches `schemas/taxonomy/mitre-atlas.yaml` filename and the canonical AG-8 finding emitted in `examples/agentic-app/sample-report/threats.md`).

## Test plan
- [x] `pytest tests/scripts/` — 29/30 pass; 1 pre-existing failure (`test_categories_1_8_byte_identity_against_main`) is unrelated to this refactor.
- [x] All 3 Section D F-A2 referential-integrity tests PASS under canonical validator (Cat-9 valid, Cat-10 valid, invalid attribution rejected).
- [x] `SOURCE_DATE_EPOCH=1700000000 python3 scripts/generate-threats-sarif.py examples/agentic-app/sample-report/threats.md /tmp/test.sarif` → diff against in-repo: byte-identical.
- [x] `risk-scores.sarif` regen diff: URI-only, no content drift (grep-audited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)