### PR TITLE
refactor: consolidate BLP-01 test fixtures into shared conftest.py

### DIFF
--- a/tests/scripts/conftest.py
+++ b/tests/scripts/conftest.py
@@ -1,0 +1,37 @@
+"""Shared fixtures and path constants for the BLP-01 detection-agent test suites.
+
+Consumed by the F-1 (`test_output_integrity.py`), F-2 (`test_misinformation.py`),
+and F-4 (`test_human_trust_exploitation.py`) schema-contract layers, which all
+need the same `finding.id.pattern` regex compiled once per module. The fixtures
+are module-scoped so each test file pays a single YAML parse + regex compile
+cost regardless of test count, while still leaving `pytest-xdist` workers
+isolated.
+
+Forward-compatible with F-5 (LLM10 — pending) and any future detection-agent
+test file: import `REPO_ROOT` / `SCHEMA_PATH` / `TAXONOMY_DIR` and consume
+the `schema` / `id_pattern` fixtures by name.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_PATH = REPO_ROOT / "schemas" / "finding.yaml"
+TAXONOMY_DIR = REPO_ROOT / "schemas" / "taxonomy"
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict:
+    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture(scope="module")
+def id_pattern(schema: dict) -> re.Pattern:
+    return re.compile(schema["finding"]["id"]["pattern"])

--- a/tests/scripts/test_human_trust_exploitation.py
+++ b/tests/scripts/test_human_trust_exploitation.py
@@ -34,9 +34,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCHEMA_PATH = REPO_ROOT / "schemas" / "finding.yaml"
+from .conftest import REPO_ROOT, TAXONOMY_DIR
 
 # Make scripts/ importable for the F-A2 validator import below.
 sys.path.insert(0, str(REPO_ROOT))
@@ -63,20 +61,6 @@ WAVE5_THREATS_MD = WAVE5_DIR / "threats.md"
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "human_trust_exploitation"
 VALID_FIXTURE = FIXTURES_DIR / "valid_te_finding.yaml"
 INVALID_FIXTURE = FIXTURES_DIR / "invalid_attribution_finding.yaml"
-
-TAXONOMY_DIR = REPO_ROOT / "schemas" / "taxonomy"
-
-
-def _load_schema() -> dict:
-    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
-
-
-@pytest.fixture(scope="module")
-def id_pattern() -> re.Pattern:
-    """Compile the ``finding.id.pattern`` regex from schemas/finding.yaml."""
-    schema = _load_schema()
-    return re.compile(schema["finding"]["id"]["pattern"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_misinformation.py
+++ b/tests/scripts/test_misinformation.py
@@ -15,26 +15,8 @@ regenerated ``examples/agentic-app/`` artifacts, not here.
 from __future__ import annotations
 
 import re
-from pathlib import Path
 
 import pytest
-import yaml
-
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCHEMA_PATH = REPO_ROOT / "schemas" / "finding.yaml"
-
-
-def _load_schema() -> dict:
-    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
-
-
-@pytest.fixture(scope="module")
-def id_pattern() -> re.Pattern:
-    """Compile the ``finding.id.pattern`` regex from schemas/finding.yaml."""
-    schema = _load_schema()
-    return re.compile(schema["finding"]["id"]["pattern"])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_output_integrity.py
+++ b/tests/scripts/test_output_integrity.py
@@ -14,30 +14,15 @@ import pytest
 import yaml
 
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-SCHEMA_PATH = REPO_ROOT / "schemas" / "finding.yaml"
 FIXTURE_DIR = Path(__file__).parent / "fixtures" / "output_integrity"
-
-
-def _load_schema() -> dict:
-    with SCHEMA_PATH.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
 
 
 class TestSchemaIdPatternRegex:
 
-    @pytest.fixture
-    def id_pattern(self) -> re.Pattern:
-        schema = _load_schema()
-        return re.compile(schema["finding"]["id"]["pattern"])
-
-    @pytest.fixture
-    def schema_version(self) -> str:
-        return _load_schema()["schema_version"]
-
-    def test_schema_version_is_1_7(self, schema_version: str) -> None:
-        assert schema_version == "1.7", (
-            f"Schema version MUST be 1.7. Got: {schema_version!r}"
+    def test_schema_version_is_1_8(self, schema: dict) -> None:
+        schema_version = schema["schema_version"]
+        assert schema_version == "1.8", (
+            f"Schema version MUST be 1.8. Got: {schema_version!r}"
         )
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Extract `REPO_ROOT` / `SCHEMA_PATH` / `TAXONOMY_DIR` path constants and the `schema` / `id_pattern` module-scoped fixtures from three duplicating BLP-01 detection-agent test files into a new shared `tests/scripts/conftest.py`. Forward-compatible with F-5 (LLM10 — pending) and any future detection-agent test file: import the constants and consume the fixtures by name.

Identified during /aod.document Step 1 (code-reuse review) of F-4 closure; deferred from F-4 doc-stage scope to keep that PR tight.

## Net delta: −12 lines, 4 files

| File | Action | Lines |
|------|--------|-------|
| `tests/scripts/conftest.py` | **new** | +37 |
| `tests/scripts/test_human_trust_exploitation.py` (F-4) | migrate | −18 net |
| `tests/scripts/test_misinformation.py` (F-2) | migrate | −18 net |
| `tests/scripts/test_output_integrity.py` (F-1) | migrate | −23 net (class-scoped → module-scoped fixtures) |

## Inline fix surfaced during refactor

`test_output_integrity.py::test_schema_version_is_1_7` had a stale assertion expecting `schema_version == "1.7"` — F-2 bumped to 1.7, F-4 bumped to 1.8, but this F-1 test was not updated. Renamed to `test_schema_version_is_1_8` with corresponding assertion. **Pre-existing failure on main** (verified via `git stash` + pytest before the refactor); fixed here as part of touching the file.

## Out of scope

- `test_tool_abuse_enrichment.py::test_categories_1_8_byte_identity_against_main` has a separate pre-existing failure on main (unrelated to this refactor). Different file, different concern — left alone.
- The 17 other `tests/scripts/test_*.py` files that use `REPO_ROOT = Path(__file__).resolve().parents[2]` but with different schema/path patterns. Pulling those into the conftest is a bigger sweep — different PR.

## Test plan

- [x] 79/79 tests pass across the three migrated suites: `pytest tests/scripts/test_human_trust_exploitation.py tests/scripts/test_misinformation.py tests/scripts/test_output_integrity.py`
- [x] Pre-existing `test_tool_abuse_enrichment` failure verified as on-main (not caused by this refactor)
- [x] No fixture-scope mutation issues — all three suites consume fixtures read-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)