### PR TITLE
feat(256): file-size cap + regular-file check on KV loader

### DIFF
--- a/.aod/scripts/bash/template-config-load.sh
+++ b/.aod/scripts/bash/template-config-load.sh
@@ -110,9 +110,19 @@ aod_template_load_kv_file() {
         return 1
     fi
 
-    # ---- Step 2: file existence -----------------------------------------
-    if [ ! -f "$path" ]; then
+    # ---- Step 2: file existence + regular-file check --------------------
+    # `[ ! -e ]` covers truly-absent paths; `[ ! -f ]` rejects sockets,
+    # FIFOs, character/block devices, and directories that would otherwise
+    # blow up later (`cat` on a FIFO would block; `cat` on a directory
+    # exits with "Is a directory" via stderr but Step 3 only inspects
+    # cat's rc + the empty buffer). Splitting the two cases gives the
+    # caller a direct diagnostic for each.
+    if [ ! -e "$path" ]; then
         echo "[aod] ERROR: config file does not exist: $path" >&2
+        return 3
+    fi
+    if [ ! -f "$path" ]; then
+        echo "[aod] ERROR: config path is not a regular file: $path" >&2
         return 3
     fi
 
@@ -142,6 +152,18 @@ aod_template_load_kv_file() {
     _nonnul_size=$(LC_ALL=C tr -d '\000' < "$path" | wc -c)
     if [ "$_raw_size" != "$_nonnul_size" ]; then
         echo "[aod] ERROR: file contains NUL byte (rejected): $path" >&2
+        return 8
+    fi
+
+    # ---- Step 2c: file-size cap (DoS mitigation) ------------------------
+    # Default 64 KiB matches the typical knip.jsonc / personalization.env
+    # ceiling by an order of magnitude. Override via env for one-off cases
+    # (CI fixtures with large allow-list arrays, etc.). The intent is to
+    # bound the memory footprint of the Step 3 `cat` buffer + Step 4 line
+    # iteration on adversarial fixtures (multi-MB "configs").
+    local _max_bytes="${AOD_KV_MAX_BYTES:-65536}"
+    if [ "$_raw_size" -gt "$_max_bytes" ] 2>/dev/null; then
+        echo "[aod] ERROR: config file exceeds AOD_KV_MAX_BYTES=$_max_bytes (size=$_raw_size): $path" >&2
         return 8
     fi
 

--- a/tests/scripts/test_template_config_load_unit.py
+++ b/tests/scripts/test_template_config_load_unit.py
@@ -506,6 +506,42 @@ KV_CASES: list[dict] = [
         "expected_stderr_substr": "key_case",
         "marker": "<key_case>=mixed rejected exit 1 (Q-2.5)",
     },
+    # -----------------------------------------------------------------
+    # Case 28: file-size cap — fixture exceeds AOD_KV_MAX_BYTES default
+    # 65536. DoS hardening: caps the Step 3 cat buffer to a reasonable
+    # ceiling for the typical knip.jsonc / personalization.env workloads.
+    # 9000 lines of "K####=v\n" (~72 KB) trips the default cap.
+    # -----------------------------------------------------------------
+    {
+        "id": "case_28_size_cap_returns_8",
+        "fixture": b"".join(
+            f"K{i:04d}=v\n".encode() for i in range(9000)
+        ),
+        "var_prefix": "T_",
+        "allowed_keys": None,
+        "key_case": None,
+        "expected_rc": 8,
+        "expected_assignments": None,
+        "expected_stderr_substr": "AOD_KV_MAX_BYTES",
+        "marker": "fixture > AOD_KV_MAX_BYTES default 65536 → exit 8",
+    },
+    # -----------------------------------------------------------------
+    # Case 29: directory at <path> — the tmp_path itself is passed (it's
+    # a directory, not a regular file). [ ! -f ] catches it and emits a
+    # distinct "not a regular file" diagnostic separate from "does not
+    # exist" so the caller can distinguish the two failure modes.
+    # -----------------------------------------------------------------
+    {
+        "id": "case_29_directory_path_returns_3",
+        "fixture": "__USE_DIRECTORY_PATH__",
+        "var_prefix": "T_",
+        "allowed_keys": None,
+        "key_case": None,
+        "expected_rc": 3,
+        "expected_assignments": None,
+        "expected_stderr_substr": "not a regular file",
+        "marker": "directory <path> → exit 3 with regular-file diagnostic",
+    },
 ]
 
 
@@ -613,6 +649,8 @@ def test_template_config_load(case: dict, tmp_path: Path) -> None:
         fixture_path = ""
     elif case["fixture"] == "__USE_NONEXISTENT_PATH__":
         fixture_path = str(tmp_path / "does_not_exist.env")
+    elif case["fixture"] == "__USE_DIRECTORY_PATH__":
+        fixture_path = str(tmp_path)
     else:
         fixture_path = _write_fixture(tmp_path, case["fixture"])
 


### PR DESCRIPTION
Closes #256 (post-#257 follow-up).

## Context

This PR was originally a parallel implementation of the Issue #256 hardening pass. PR #257 (squash-merged 24 min after this one was opened) shipped the canonical primitive `aod_template_load_kv_file`, ADR-040, and the test corpus.

Per the maintainer's path-A guidance, **rebased onto post-#257 main and scoped down to just the two security knobs that were genuinely novel here, both layered on top of #257's helper.**

## What's left in this PR

Two additions to `.aod/scripts/bash/template-config-load.sh`, slotted into the existing Step 2 / Step 2c argument-validation block:

### 1. `AOD_KV_MAX_BYTES` file-size cap (default 65536)

DoS-hardens the Step 3 `cat` buffer. Multi-MB "configs" no longer blow up RAM — bound the memory footprint to a reasonable ceiling for the typical knip.jsonc / personalization.env workloads. Override via env for one-off cases (CI fixtures with large allow-list arrays).

### 2. Regular-file check via `[ ! -f ]` after `[ ! -e ]`

Splits the existence error from the not-a-regular-file error so the caller can distinguish the two failure modes. Rejects directories / FIFOs / sockets / character+block devices with a distinct diagnostic ("not a regular file: …" vs the existing "does not exist: …").

## Tests

Two new cases in `tests/scripts/test_template_config_load_unit.py`, alongside the existing 27:

- **`case_28_size_cap_returns_8`** — fixture of 9000 lines `K####=v\n` (~72 KB) trips the default 65 KB cap → rc=8.
- **`case_29_directory_path_returns_3`** — passing `tmp_path` itself (a directory) → rc=3 with "not a regular file" diagnostic.

Full template-config-load unit suite **31/31 green** locally.

## Diff size

2 files, +62/-2.