### PR TITLE
feat(260): asset-sensitivity tag prototype

### DIFF
--- a/.claude/agents/tachi/risk-scorer.md
+++ b/.claude/agents/tachi/risk-scorer.md
@@ -30,6 +30,7 @@ Load domain knowledge on-demand from the `tachi-risk-scoring` skill using the Re
 | Severity bands | `.claude/skills/tachi-risk-scoring/references/severity-bands.md` | Composite calculation, governance (Sections 7-8) |
 | Trust zones | `.claude/skills/tachi-risk-scoring/references/trust-zones.md` | Trust zone extraction (Section 2) |
 | Reachability | `.claude/skills/tachi-risk-scoring/references/reachability-analysis.md` | Reachability assessment (Section 6) |
+| Asset modifiers | `.claude/skills/tachi-risk-scoring/references/asset-modifiers.md` | Asset-sensitivity impact-bit floor pass (Section 3.5, prototype per Issue #260) |
 | Output formatting | `.claude/skills/tachi-risk-scoring/references/output-formatting.md` | Markdown output generation (Section 9) |
 | Severity bands (shared) | `.claude/skills/tachi-shared/references/severity-bands-shared.md` | Composite scoring / severity assignment |
 | Finding format (shared) | `.claude/skills/tachi-shared/references/finding-format-shared.md` | Input parsing / output formatting |
@@ -42,7 +43,7 @@ The scoring pipeline processes threat findings through six sequential phases:
 
 1. **Threat Parsing** -- Extract findings from input (threats.md or threats.sarif)
 2. **Trust Zone Extraction** -- Map components to trust zones for reachability scoring
-3. **Dimensional Scoring** -- Assess each finding on four dimensions (CVSS, exploitability, scalability, reachability)
+3. **Dimensional Scoring** -- Assess each finding on four dimensions (CVSS, exploitability, scalability, reachability). When the architecture description carries `[asset:...]` tags, an asset-sensitivity modifier pass (Section 3.5, prototype per Issue #260) elevates CVSS impact bits after the bounded-scoring clamp.
 4. **Composite Calculation** -- Compute weighted composite score and map to severity band
 5. **Governance Fields** -- Attach remediation tracking metadata based on severity
 6. **Output Generation** -- Produce risk-scores.md and risk-scores.sarif
@@ -268,6 +269,30 @@ When a finding has `delta_status: NEW` (discovered in Phase 2 of a baseline-awar
 **When bounding applies**: Only to `NEW` findings from Phase 2 isolated discovery. `UPDATED` findings are re-scored fresh without bounding (they have established context). `UNCHANGED` and `RESOLVED` findings inherit scores verbatim.
 
 **When no baseline is present**: Bounding does not apply. All findings are scored using the standard CVSS assessment without constraints.
+
+### 3.5. Asset-Sensitivity Modifier (Prototype, Issue #260)
+
+**MANDATORY**: Read `.claude/skills/tachi-risk-scoring/references/asset-modifiers.md` for the full modifier specification including tag vocabulary, floor-only semantics, modifier ceiling, parsing rules, and worked examples.
+
+After the bounded-scoring clamp completes, apply optional asset-sensitivity modifiers when the architecture description carries `[asset:tag1,tag2]` annotations on its components. The modifier pass closes the asset-value gap in the four-dimensional composite — reachability scores how exposed a component is, asset modifiers score what would be lost if it were compromised.
+
+**Inputs**:
+
+1. `component_asset_map` (optional): produced by scanning the architecture description for inline `[asset:tag1,tag2]` annotations on Mermaid node labels. The reference parser is `parse_component_asset_map()` in `scripts/tachi_parsers.py`. When the architecture description contains no asset blocks, the map is empty and this phase is a no-op.
+2. `asset_modifiers` table from `schemas/risk-scoring.yaml`: closed six-tag enum (`pii | phi | auth | secrets | financial | safety`) with per-tag impact-bit floors (`C:H`, `I:H`, `A:H`) and a `modifier_ceiling` cap on the recomputed `cvss_base`.
+
+**Order**: Apply modifiers **after** the `score_bounds` +/-1.0 clamp from Section 3. The clamp encodes "average" category behavior; the modifier's purpose is to elevate when the target component carries high-value assets. Clamping after the modifier would defeat its purpose.
+
+For each finding:
+
+1. Look up the finding's target component in `component_asset_map` using the same case-insensitive + fuzzy-match cascade as Reachability Analysis Section 6f. If no match, skip — the finding is unmodified.
+2. Union the forced impact bits across every tag the component carries.
+3. Elevate the assessed CVSS vector by taking the per-bit max with the forced bits (`H > L > N`, floor-only).
+4. Recompute `cvss_base` from the elevated vector.
+5. Clamp the recomputed score at `asset_modifiers.modifier_ceiling`.
+6. Overwrite the finding's `cvss_vector` and `cvss_base` with the elevated values. Record the original (pre-modifier) score in the dimensional breakdown narrative (Section 9d) so the modifier's effect is auditable.
+
+**When this phase is skipped**: `UNCHANGED` and `RESOLVED` findings inherit baseline scores verbatim and never re-enter dimensional scoring. Only `NEW` and `UPDATED` findings receive modifier treatment.
 
 ---
 

--- a/.claude/skills/tachi-risk-scoring/references/asset-modifiers.md
+++ b/.claude/skills/tachi-risk-scoring/references/asset-modifiers.md
@@ -8,7 +8,7 @@ version: 1.0.0
 
 Apply optional CVSS impact-bit floors to a finding based on tags declared on its target component in the architecture description. Closes the asset-value gap in the four-dimensional composite — the existing reachability dimension scores how exposed a component is, and this dimension scores what would be lost if it were compromised.
 
-> **Status**: prototype for [Issue #260](https://github.com/davidmatousek/tachi/issues/260). The tag vocabulary, modifier ceiling, and exact application order are pinned during architect review when the formal spec opens. Until then, treat this as illustrative.
+> **Status**: prototype for [Issue #260](https://github.com/davidmatousek/tachi/issues/260). The tag vocabulary and exact application order are pinned during architect review when the formal spec opens. Modifier ceiling pinned at `9.2` during PR #262 architect review (2026-05-06). Until the formal spec opens, treat the rest as illustrative.
 
 ## Where This Sits in the Pipeline
 
@@ -50,7 +50,7 @@ Modifiers raise impact bits but never lower them. If a category default already 
 
 ## Modifier Ceiling
 
-After bit elevation and CVSS base recomputation, clamp the result at `asset_modifiers.modifier_ceiling` (prototype default `9.5`) so a single tag cannot push a finding to `10.0`. The ceiling is pinned during architect review when the spec opens.
+After bit elevation and CVSS base recomputation, clamp the result at `asset_modifiers.modifier_ceiling` (architect-pinned at `9.2` during PR #262 review, 2026-05-06) so a single tag cannot push a finding to `10.0`. The ceiling pin is defensive: it preserves modifier band-crossing for genuinely-elevated findings while requiring non-CVSS signal for Critical-band entry. The full rationale lives in the schema comment block above `asset_modifiers` in `schemas/risk-scoring.yaml`.
 
 ```
 cvss_base_after_modifier = min(modifier_ceiling, recompute_cvss(elevated_vector))

--- a/.claude/skills/tachi-risk-scoring/references/asset-modifiers.md
+++ b/.claude/skills/tachi-risk-scoring/references/asset-modifiers.md
@@ -1,0 +1,148 @@
+---
+source_agent: risk-scorer
+extracted_from: .claude/agents/tachi/risk-scorer.md
+version: 1.0.0
+---
+
+# Asset-Sensitivity Modifier Reference
+
+Apply optional CVSS impact-bit floors to a finding based on tags declared on its target component in the architecture description. Closes the asset-value gap in the four-dimensional composite — the existing reachability dimension scores how exposed a component is, and this dimension scores what would be lost if it were compromised.
+
+> **Status**: prototype for [Issue #260](https://github.com/davidmatousek/tachi/issues/260). The tag vocabulary, modifier ceiling, and exact application order are pinned during architect review when the formal spec opens. Until then, treat this as illustrative.
+
+## Where This Sits in the Pipeline
+
+The modifier pass is the final step of Section 3 (CVSS 3.1 Base Scoring), executed **after** the `score_bounds` +/-1.0 clamp from `schemas/risk-scoring.yaml -> category_defaults`:
+
+1. Assess the finding's CVSS vector and base score against the category default.
+2. **Clamp** to `[category_default - 1.0, category_default + 1.0]` for `delta_status: NEW` findings (Phase 2 bounded discovery).
+3. **Apply asset modifiers** (this reference): force impact bits to `H` when the finding's target component carries asset tags; recompute `cvss_base` from the elevated vector; clamp at `modifier_ceiling`.
+4. Continue to Section 4 (Exploitability).
+
+The clamp-then-modify order is deliberate. The clamp encodes "what info-disclosure looks like on average for this category." The modifier's purpose is "this isn't average — the target stores PHI." Clamping after the modifier would defeat it; modifying after the clamp lets a high-asset target's CVSS exceed the category default range as intended.
+
+## Tag Vocabulary
+
+A closed six-value enum at the prototype stage. Each tag forces one or more CVSS impact bits to `H` when the finding's target component carries the tag.
+
+| Tag | Forces | Rationale |
+|------|--------|-----------|
+| `pii` | `C:H` | Personally Identifiable Information loss is a confidentiality-high event regardless of category default. |
+| `phi` | `C:H` | Protected Health Information attracts the same confidentiality floor as PII (HIPAA, GDPR-special-category). |
+| `auth` | `C:H` + `I:H` | Authentication material loss compromises both confidentiality (credential disclosure) and integrity (impersonation). |
+| `secrets` | `C:H` + `I:H` | Long-lived secrets (API keys, signing keys, vault contents) carry the same C:H + I:H floor as auth material. |
+| `financial` | `I:H` | Financial data integrity is the dominant impact axis — unauthorized modification drives losses regardless of confidentiality posture. |
+| `safety` | `A:H` | Safety-critical components (life-safety, control loops) treat availability loss as the dominant impact axis. |
+
+Unknown tags are dropped at parser time with a stderr warning and never reach this table. Widening the enum is a minor schema bump on `schemas/risk-scoring.yaml` per ADR-026 Complex-Shape Addition Clarifier.
+
+## Floor-Only Semantics
+
+Modifiers raise impact bits but never lower them. If a category default already specifies `C:H` (e.g., `info-disclosure`), the `pii` tag is a no-op on that bit. The composition rule is simple: take the per-bit max of the assessed vector and every tag's forced bits.
+
+| Category Default | Component Tags | Resulting Impact Bits |
+|------------------|----------------|----------------------|
+| `C:H/I:N/A:N` (info-disclosure) | `pii` | `C:H/I:N/A:N` (no change — already H on C) |
+| `C:N/I:H/A:L` (tampering) | `financial` | `C:N/I:H/A:L` (no change — already H on I) |
+| `C:H/I:N/A:N` (info-disclosure) | `secrets` | `C:H/I:H/A:N` (I elevated N→H) |
+| `C:N/I:N/A:H` (denial-of-service) | `safety` | `C:N/I:N/A:H` (no change — already H on A) |
+| `C:N/I:H/A:L` (tampering) | `pii, auth` | `C:H/I:H/A:L` (C elevated N→H by pii+auth, I already H) |
+
+## Modifier Ceiling
+
+After bit elevation and CVSS base recomputation, clamp the result at `asset_modifiers.modifier_ceiling` (prototype default `9.5`) so a single tag cannot push a finding to `10.0`. The ceiling is pinned during architect review when the spec opens.
+
+```
+cvss_base_after_modifier = min(modifier_ceiling, recompute_cvss(elevated_vector))
+```
+
+The ceiling applies to the modifier-recomputed score only — findings that organically score above the ceiling without modifiers retain their assessed value.
+
+## Architecture Tag Syntax
+
+Asset tags live inline in Mermaid node labels using the `[asset:tag1,tag2]` syntax. Embed the asset block inside a quoted label so the Mermaid grammar parses cleanly:
+
+```mermaid
+flowchart TD
+    PostgresDB[("Postgres DB<br/>[asset:pii,auth]")]
+    SecretsVault["Secrets Vault<br/>[asset:secrets]"]
+    Cache[("Rate-Limit Cache")]
+    LearningLoop["Long-Running Learning Loop<br/>[asset:safety]"]
+```
+
+Inline placement (vs a sidecar `assets.yaml`) mirrors the existing trust-zone declaration pattern: trust zones are declared inline via Mermaid `subgraph` containment, and asset tags are declared inline via the label suffix. Single source of truth, no diagram-vs-sidecar drift.
+
+### Parsing Rules
+
+| Rule | Behavior |
+|------|----------|
+| Asset block must live inside a quoted label (`"..."`). | Avoids ambiguity with Mermaid's `[]` bracket grammar. |
+| Tag names are case-insensitive. | Stored canonical lowercase. |
+| Multiple tags separated by commas. | Whitespace around commas tolerated. |
+| Unknown tags produce a stderr warning and are dropped. | Valid tags from the same node are still retained. |
+| Multiple node declarations for the same component merge tag sets. | Stable warning emitted on merge so authors can collapse duplicates. |
+| Components with no asset block produce no map entry. | Absence == default behavior, no modifier. |
+| Outside of `` ```mermaid `` fences, `[asset:...]` text is ignored. | Avoids false matches in prose paragraphs. |
+
+The reference parser is `parse_component_asset_map()` in `scripts/tachi_parsers.py` (stdlib-only per PAT-014).
+
+## component_asset_map Shape
+
+Mirrors `component_zone_map` from Trust Zone Extraction so the modifier pass can join the two on display name:
+
+```python
+component_asset_map = {
+    "Postgres DB": ["auth", "pii"],
+    "Secrets Vault": ["secrets"],
+    "Long-Running Learning Loop": ["safety"],
+}
+```
+
+Keys are component display names (label content with the asset block and `<br/>` removed) — same lookup contract as `component_zone_map`. Tag lists are sorted, lowercase, and deduplicated.
+
+## Per-Finding Application
+
+For each scored finding:
+
+1. **Look up the target component** in `component_asset_map` using the same case-insensitive + fuzzy-match cascade as Reachability Analysis Section 6f. If no match, skip — the finding is unmodified.
+2. **Collect forced bits** by unioning `asset_modifiers.tags[<tag>].forces` across every tag the component carries.
+3. **Elevate the assessed vector** by taking the per-bit max with the forced bits (`H > L > N`).
+4. **Recompute** `cvss_base` from the elevated vector using the standard CVSS 3.1 formula.
+5. **Clamp** at `asset_modifiers.modifier_ceiling`.
+6. **Update** `cvss_vector` to the elevated string and overwrite `cvss_base` with the recomputed score.
+
+Record the original (pre-modifier) score in the finding's dimensional breakdown narrative (Section 9d of `risk-scores.md`) so the modifier's effect is auditable.
+
+## Worked Example
+
+Finding `I-3` is an info-disclosure threat against the `Knowledge Base` component. The Knowledge Base node label declares `[asset:pii]`.
+
+- **Category default**: `info-disclosure` -> `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`, base `6.5`.
+- **Assessed vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`, base `6.5` (within +/-1.0 of the category default).
+- **Asset tags on Knowledge Base**: `["pii"]`.
+- **Forced bits**: `{C:H}`.
+- **Elevated vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N` — no change, the category default already has `C:H`.
+- **Final `cvss_base`**: `6.5`. The modifier was a no-op.
+
+Now consider finding `T-2`, a tampering threat against the same `Knowledge Base` component.
+
+- **Category default**: `tampering` -> `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`, base `7.1`.
+- **Assessed vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:N/I:H/A:L`, base `7.1`.
+- **Asset tags**: `["pii"]` -> forces `{C:H}`.
+- **Elevated vector**: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:L`.
+- **Recomputed `cvss_base`**: `8.3` (CVSS 3.1 calculator).
+- **Ceiling**: `9.5` — no clamp needed.
+- **Final `cvss_base`**: `8.3`. Tampering on a PII store now scores higher than tampering on the same component without the tag, reflecting the asset value.
+
+The composite score (Section 7) reflects this elevated CVSS base via the `0.35` weight, which propagates to the severity band and SARIF `security-severity` per finding.
+
+## When This Phase Is Skipped
+
+The modifier pass is a no-op (and silently skipped) under any of these conditions:
+
+- The architecture description does not contain `[asset:...]` blocks (`component_asset_map` is empty).
+- The finding's component does not appear in `component_asset_map`.
+- The finding has `delta_status: UNCHANGED` or `RESOLVED` — those inherit baseline scores verbatim and never re-enter the dimensional scoring pipeline.
+- The finding has `score_source: inherited` — same reason.
+
+`UPDATED` and `NEW` findings receive modifier treatment.

--- a/examples/agentic-app/architecture-with-asset-tags.md
+++ b/examples/agentic-app/architecture-with-asset-tags.md
@@ -1,0 +1,101 @@
+# Agentic AI Application — Architecture with Asset-Sensitivity Tags
+
+Worked example for [Issue #260](https://github.com/davidmatousek/tachi/issues/260) — the asset-sensitivity tag prototype. This file is a copy of `architecture.md` with `[asset:tag1,tag2]` annotations added to the components that store or process high-value data. The risk-scorer's Section 3.5 modifier pass (see `.claude/skills/tachi-risk-scoring/references/asset-modifiers.md`) consumes these annotations to elevate CVSS impact bits on findings whose target component carries asset tags.
+
+> **Status**: prototype demonstration. The canonical `architecture.md` is unchanged so existing byte-identical baselines under `SOURCE_DATE_EPOCH=1700000000` continue to pass. To exercise the modifier pipeline against this variant, run `/tachi.threat-model examples/agentic-app/architecture-with-asset-tags.md` followed by `/tachi.risk-score`.
+
+format: mermaid
+
+```mermaid
+flowchart TD
+    User[User]
+
+    subgraph User Zone
+        User
+    end
+
+    subgraph Application Zone
+        Guardrails[Guardrails Service]
+        Orchestrator[LLM Agent Orchestrator]
+        Specialist[Specialist Agent]
+        Channel[Inter-Agent Communication Channel]
+        ToolServer[MCP Tool Server]
+        KB[("Knowledge Base<br/>[asset:pii,phi]")]
+        AuditLog[("Audit Logger<br/>[asset:auth]")]
+        LearningLoop["Long-Running Learning Loop<br/>[asset:safety]"]
+        ClinAdvisor["Clinical Advisory Sub-Agent<br/>[asset:phi]"]
+    end
+
+    subgraph External Services
+        ExtAPI[External API]
+    end
+
+    User -->|"Prompt / Query (HTTPS)"| Guardrails
+    Guardrails -->|"Validated Prompt"| Orchestrator
+    Guardrails -->|"Rejected Prompt + Reason"| User
+    Orchestrator -->|"Context Retrieval (Vector Search)"| KB
+    KB -->|"Retrieved Documents"| Orchestrator
+    Orchestrator -->|"Delegation Message"| Channel
+    Channel -->|"Delegated Task"| Specialist
+    Specialist -->|"Specialist Result"| Channel
+    Channel -->|"Aggregated Result"| Orchestrator
+    Orchestrator -->|"Tool Call Request (JSON-RPC)"| ToolServer
+    Specialist -->|"Tool Call Request (JSON-RPC)"| ToolServer
+    ToolServer -->|"Tool Result (JSON-RPC)"| Orchestrator
+    ToolServer -->|"Tool Result (JSON-RPC)"| Specialist
+    ToolServer -->|"API Request (HTTPS)"| ExtAPI
+    ExtAPI -->|"API Response (HTTPS)"| ToolServer
+    Orchestrator -->|"Response (HTTPS)"| User
+    Orchestrator -->|"Decision Log Entry"| AuditLog
+    Specialist -->|"Decision Log Entry"| AuditLog
+    ToolServer -->|"Tool Execution Log"| AuditLog
+    Guardrails -->|"Filtering Event Log"| AuditLog
+    AuditLog -->|"Training Signal Stream"| LearningLoop
+    LearningLoop -->|"Periodic Model Update"| Orchestrator
+    LearningLoop -->|"Periodic Model Update"| Specialist
+    Orchestrator -->|"Clinical Query / Context (JSON-RPC)"| ClinAdvisor
+    ClinAdvisor -->|"Context Retrieval (Vector Search)"| KB
+    KB -->|"Retrieved Documents"| ClinAdvisor
+    ClinAdvisor -->|"Clinical Summary + Recommendations"| Orchestrator
+    ClinAdvisor -->|"Clinical Decision Log Entry"| AuditLog
+    LearningLoop -->|"Periodic Model Update"| ClinAdvisor
+```
+
+## Asset Annotations
+
+| Component | Tags | Rationale |
+|-----------|------|-----------|
+| Knowledge Base | `pii, phi` | Stores user prompts, conversation history, and retrieved clinical documents — both PII and PHI. |
+| Audit Logger | `auth` | Holds authentication artifacts and decision logs that double as session-replay material. |
+| Long-Running Learning Loop | `safety` | Periodic-update path into the production model; corruption here propagates to every downstream agent decision. |
+| Clinical Advisory Sub-Agent | `phi` | Generates clinical summaries grounded in PHI retrieved from the knowledge base. |
+
+The remaining components (Guardrails Service, Orchestrator, Specialist Agent, Channel, MCP Tool Server, External API) carry no tags — they preserve the existing scoring behavior exactly.
+
+## Expected Modifier Effect
+
+Findings whose target component carries asset tags receive CVSS impact-bit elevation per `.claude/skills/tachi-risk-scoring/references/asset-modifiers.md`. CVSS values below are computed from the category-default vectors in `schemas/risk-scoring.yaml` using the standard CVSS 3.1 base-score formula.
+
+| Finding shape | Component | Tags | cvss_base before | cvss_base after | Composite delta (x0.35) |
+|---------------|-----------|------|------------------|-----------------|-------------------------|
+| Tampering on Knowledge Base | KB | `pii, phi` | `C:N/I:H/A:L` -> 7.1 | `C:H/I:H/A:L` -> 8.3 | +0.42 |
+| Repudiation on Audit Logger | AuditLog | `auth` | `C:N/I:L/A:N` -> 4.3 | `C:H/I:H/A:N` -> 8.1 | +1.33 |
+| Tampering on Long-Running Learning Loop | LearningLoop | `safety` | `C:N/I:H/A:L` -> 7.1 | `C:N/I:H/A:H` -> 8.1 | +0.35 |
+| Info-disclosure on Knowledge Base | KB | `pii, phi` | `C:H/I:N/A:N` -> 6.5 | `C:H/I:N/A:N` -> 6.5 | 0 (no-op) |
+
+Severity bands are computed from the four-dimensional composite (`0.35*CVSS + 0.30*Exploitability + 0.15*Scalability + 0.20*Reachability`), not from `cvss_base` alone, so a CVSS bump translates to a smaller composite delta. The most dramatic case is the repudiation row: `auth` forces both `C:H` and `I:H`, lifting `cvss_base` by 3.8 points and the composite by ~1.3 — enough to cross the Medium -> High band threshold on borderline findings.
+
+The "no-op" row is the key correctness check — modifiers are floor-only and never lower a category default. Info-disclosure already treats confidentiality as the dominant axis, so the `pii`/`phi` tags add nothing on that finding shape; they only matter when the dominant axis differs (e.g., tampering's `I:H` baseline gains `C:H` from PII).
+
+## How to Reproduce
+
+```bash
+# Generate threats + risk scores against the asset-tagged variant
+/tachi.threat-model examples/agentic-app/architecture-with-asset-tags.md
+/tachi.risk-score docs/security/<run-timestamp>/
+
+# Compare against the canonical baseline
+diff examples/agentic-app/sample-report/risk-scores.md docs/security/<run-timestamp>/risk-scores.md
+```
+
+Findings on tagged components should show elevated `cvss_base` values and (for borderline cases) crossed severity-band thresholds. The dimensional breakdown narrative (`risk-scores.md` Section 9d) records the original (pre-modifier) score so the elevation is auditable.

--- a/schemas/risk-scoring.yaml
+++ b/schemas/risk-scoring.yaml
@@ -118,6 +118,50 @@ category_defaults:
   agentic:             "CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:H/A:L"   # Agent misuse (PR:L to avoid ceiling effect)
   llm:                 "CVSS:3.1/AV:N/AC:L/PR:N/UI:R/S:C/C:H/I:H/A:N"   # Prompt injection
 
+# Asset-Sensitivity Modifiers (Issue #260 prototype, additive, opt-in)
+#
+# Applied during risk-scorer Section 3 (CVSS base scoring) AFTER the
+# score_bounds +/-1.0 clamp. Each tag forces the named CVSS impact bit(s) to
+# `H` when the finding's target component carries the tag in its
+# component_asset_map entry. Modifiers are floor-only — they raise impact
+# bits but never lower a category default. Components with no tag preserve
+# the existing scoring behavior exactly.
+#
+# Tag vocabulary is closed at the prototype stage (per Issue #260 direction
+# from davidmatousek 2026-05-05): "Hardcoded enum first. Extensibility is
+# YAGNI until a real custom-tag use case shows up." Widening the enum is a
+# minor schema bump per ADR-026 Complex-Shape Addition Clarifier.
+#
+# Modifier ceiling: the recomputed cvss_base after impact-bit elevation is
+# clamped at `modifier_ceiling` so a single tag cannot push a finding to
+# 10.0 — pinned during architect review, prototype default 9.5.
+#
+# See .claude/skills/tachi-risk-scoring/references/asset-modifiers.md for
+# the per-tag rationale, parsing rules, and worked examples.
+
+asset_modifiers:
+  modifier_ceiling: 9.5
+
+  tags:
+    pii:
+      forces: ["C:H"]
+      rationale: "Personally Identifiable Information loss is a confidentiality-high event regardless of category default."
+    phi:
+      forces: ["C:H"]
+      rationale: "Protected Health Information attracts the same confidentiality floor as PII (HIPAA, GDPR-special-category)."
+    auth:
+      forces: ["C:H", "I:H"]
+      rationale: "Authentication material loss compromises both confidentiality (credential disclosure) and integrity (impersonation)."
+    secrets:
+      forces: ["C:H", "I:H"]
+      rationale: "Long-lived secrets (API keys, signing keys, vault contents) carry the same C:H + I:H floor as auth material."
+    financial:
+      forces: ["I:H"]
+      rationale: "Financial data integrity is the dominant impact axis — unauthorized modification drives losses regardless of confidentiality posture."
+    safety:
+      forces: ["A:H"]
+      rationale: "Safety-critical components (life-safety, control loops) treat availability loss as the dominant impact axis."
+
 # Composite Weights
 weights:
   cvss_base: 0.35

--- a/schemas/risk-scoring.yaml
+++ b/schemas/risk-scoring.yaml
@@ -134,13 +134,19 @@ category_defaults:
 #
 # Modifier ceiling: the recomputed cvss_base after impact-bit elevation is
 # clamped at `modifier_ceiling` so a single tag cannot push a finding to
-# 10.0 — pinned during architect review, prototype default 9.5.
+# 10.0. Architect review (PR #262, 2026-05-06) pinned modifier_ceiling: 9.2 —
+# defensive default for the prototype phase. Retains modifier band-crossing
+# for genuinely-elevated findings while requiring non-CVSS signal for
+# Critical-band entry; 9.5 was rejected as too aggressive (lets a single
+# tag mint Critical findings on near-boundary composites), 9.0 as too
+# conservative (defeats modifier participation in band crossings even when
+# CVSS-after-elevation organically exceeds 9.0 for auth/secrets cases).
 #
 # See .claude/skills/tachi-risk-scoring/references/asset-modifiers.md for
 # the per-tag rationale, parsing rules, and worked examples.
 
 asset_modifiers:
-  modifier_ceiling: 9.5
+  modifier_ceiling: 9.2
 
   tags:
     pii:

--- a/scripts/tachi_parsers.py
+++ b/scripts/tachi_parsers.py
@@ -62,6 +62,20 @@ VALID_AGENTIC_PATTERNS = (
     "multiple",
 )
 
+# Closed asset-sensitivity tag enum consumed by the risk-scorer's CVSS impact-bit
+# floor pass (see schemas/risk-scoring.yaml -> asset_modifiers and
+# .claude/skills/tachi-risk-scoring/references/asset-modifiers.md). Tags are
+# normalized to lowercase before comparison; unknown tags are dropped with a
+# stderr warning and never reach the modifier table.
+VALID_ASSET_TAGS = (
+    "pii",
+    "phi",
+    "auth",
+    "secrets",
+    "financial",
+    "safety",
+)
+
 
 # =============================================================================
 # Utility Functions
@@ -1449,3 +1463,142 @@ def _parse_chain_breaking_controls(section_text: str) -> list:
         controls.append(current)
 
     return controls
+
+
+# =============================================================================
+# Asset-Sensitivity Tag Parser (Issue #260 prototype)
+# =============================================================================
+#
+# Extracts inline [asset:tag1,tag2] annotations from Mermaid node labels in an
+# architecture description, producing a component-to-asset-tag mapping
+# consumed by the risk-scorer's CVSS impact-bit floor pass. Mirrors the
+# component_zone_map shape produced by Trust Zone Extraction so the modifier
+# pass can join the two on display name.
+#
+# Recognized syntax (the asset block lives inside a quoted Mermaid label):
+#
+#     PostgresDB[("Postgres DB<br/>[asset:pii,auth]")]
+#     SecretsVault["Secrets Vault<br/>[asset:secrets]"]
+#
+# Unknown tags are dropped with a stderr warning. Components without tags are
+# omitted from the result entirely (absent == default behavior, no modifier).
+
+_ASSET_BLOCK_PATTERN = re.compile(r"\[asset:\s*([^\]]+?)\s*\]", re.IGNORECASE)
+_QUOTED_NODE_WITH_ASSET_PATTERN = re.compile(
+    r'\b([A-Za-z_]\w*)\s*[\[\(\{]+\s*"([^"]*\[asset:[^\]]+\][^"]*)"',
+    re.IGNORECASE,
+)
+_BR_TAG_PATTERN = re.compile(r"<br\s*/?>", re.IGNORECASE)
+
+
+def parse_component_asset_map(content: str) -> dict:
+    """Extract component-to-asset-tag mapping from a Mermaid architecture file.
+
+    Scans Mermaid node declarations inside `````mermaid`` fenced
+    blocks (or the whole content when no fence is present) for the
+    ``[asset:tag1,tag2]`` pattern embedded in a quoted node label. Returns a
+    dict keyed by the component's display name (label content with the asset
+    block and ``<br/>`` removed) mapping to a sorted list of valid tag
+    strings drawn from :data:`VALID_ASSET_TAGS`.
+
+    Parsing is intentionally permissive about Mermaid bracket shape (rectangle,
+    rounded, cylinder, subroutine all accepted) and case-insensitive on tag
+    names. Asset tags MUST be embedded inside quoted labels — unquoted labels
+    with bracket-style asset blocks are not parsed because Mermaid's bracket
+    grammar already uses ``[`` / ``]`` and disambiguating without a full
+    parser is fragile.
+
+    Returns an empty dict when ``content`` is empty, when no ``[asset:...]``
+    block is present, or when every tag is unknown. Unknown tags produce a
+    stderr warning per occurrence; valid tags from the same node are still
+    retained.
+    """
+    result: dict = {}
+    if not content:
+        return result
+
+    scan_blocks = _select_mermaid_scan_blocks(content)
+
+    for block in scan_blocks:
+        for match in _QUOTED_NODE_WITH_ASSET_PATTERN.finditer(block):
+            node_id = match.group(1)
+            label_content = match.group(2)
+
+            asset_match = _ASSET_BLOCK_PATTERN.search(label_content)
+            if asset_match is None:
+                continue
+
+            tags = _normalize_asset_tags(asset_match.group(1), node_id)
+            if not tags:
+                continue
+
+            display_name = _extract_display_name(label_content)
+            if not display_name:
+                display_name = node_id
+
+            existing = result.get(display_name)
+            if existing is None:
+                result[display_name] = tags
+                continue
+
+            merged = sorted(set(existing) | set(tags))
+            if merged != existing:
+                print(
+                    f"Warning: component {display_name!r} has multiple asset "
+                    f"declarations; merged tags: {merged}",
+                    file=sys.stderr,
+                )
+            result[display_name] = merged
+
+    return result
+
+
+def _select_mermaid_scan_blocks(content: str) -> list:
+    """Return the substrings of ``content`` that should be scanned for nodes.
+
+    When at least one fenced `````mermaid`` block is present,
+    only those blocks are scanned (avoiding false matches on prose that
+    happens to contain ``[asset:...]``). When no fence is present, the entire
+    content is scanned as-is so callers passing raw Mermaid still work.
+    """
+    fences = re.findall(r"```mermaid\s*\n(.*?)\n```", content, re.DOTALL)
+    if fences:
+        return fences
+    return [content]
+
+
+def _normalize_asset_tags(raw: str, node_id: str) -> list:
+    """Split a raw ``[asset:...]`` body into a sorted list of valid tags.
+
+    Tags are lowercased and stripped. Unknown tags (not in
+    :data:`VALID_ASSET_TAGS`) are dropped with a per-occurrence stderr warning.
+    Empty tag lists collapse to ``[]``.
+    """
+    candidates = [t.strip().lower() for t in raw.split(",")]
+    candidates = [t for t in candidates if t]
+
+    valid: list = []
+    for tag in candidates:
+        if tag in VALID_ASSET_TAGS:
+            valid.append(tag)
+        else:
+            print(
+                f"Warning: unknown asset tag {tag!r} on node {node_id!r}; "
+                f"valid tags: {list(VALID_ASSET_TAGS)}",
+                file=sys.stderr,
+            )
+
+    return sorted(set(valid))
+
+
+def _extract_display_name(label_content: str) -> str:
+    """Return the human-readable component name from a quoted Mermaid label.
+
+    Strips the ``[asset:...]`` block, ``<br/>`` line breaks, and surrounding
+    whitespace so the result joins cleanly against the component_zone_map
+    keys produced from threats.md Section 2 (which also uses display names).
+    """
+    cleaned = _ASSET_BLOCK_PATTERN.sub("", label_content)
+    cleaned = _BR_TAG_PATTERN.sub(" ", cleaned)
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned.strip()

--- a/tests/scripts/test_asset_sensitivity_tags.py
+++ b/tests/scripts/test_asset_sensitivity_tags.py
@@ -1,0 +1,380 @@
+"""Unit tests for the Issue #260 asset-sensitivity tag parser.
+
+Exercises :func:`parse_component_asset_map` and :data:`VALID_ASSET_TAGS` in
+``scripts/tachi_parsers.py``. The parser scans a Mermaid architecture
+description for ``[asset:tag1,tag2]`` blocks embedded in quoted node labels
+and returns a ``component_asset_map`` consumed by the risk-scorer's Section
+3.5 modifier pass.
+
+Test coverage targets:
+
+* Empty / no-mermaid / no-tag inputs return an empty dict.
+* Quoted rectangle, cylinder, and subroutine bracket shapes all parse.
+* Display-name extraction strips the asset block and ``<br/>`` cleanly.
+* Tag normalization is case-insensitive and tolerant of whitespace.
+* Multi-tag and multi-component inputs round-trip with sorted, deduped lists.
+* Unknown tags emit a stderr warning and are dropped.
+* Duplicate component declarations merge tag sets with a stderr warning.
+* Asset blocks outside `````mermaid`` fences are ignored.
+* Raw-Mermaid input (no fence) still parses.
+
+Stdlib-only per PAT-014 — no PyYAML, no Path operations beyond importlib.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from tachi_parsers import (  # noqa: E402  -- import after sys.path mutation
+    VALID_ASSET_TAGS,
+    parse_component_asset_map,
+)
+
+
+# =============================================================================
+# Empty / negative inputs
+# =============================================================================
+
+
+@pytest.mark.parametrize("content", ["", "   ", "\n\n", None])
+def test_empty_input_returns_empty_dict(content):
+    """Empty, whitespace-only, and None content all collapse to {}."""
+    assert parse_component_asset_map(content or "") == {}
+
+
+def test_no_mermaid_block_returns_empty_dict():
+    """Plain prose without any Mermaid syntax produces no map entries."""
+    content = (
+        "# My Architecture\n\n"
+        "This system has a database that stores PII. "
+        "We protect it with auth controls.\n"
+    )
+    assert parse_component_asset_map(content) == {}
+
+
+def test_mermaid_block_without_asset_tags_returns_empty_dict():
+    """Mermaid diagrams with no [asset:] blocks produce no entries."""
+    content = (
+        "```mermaid\n"
+        "flowchart TD\n"
+        "    User[User]\n"
+        "    DB[(Database)]\n"
+        "    User --> DB\n"
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {}
+
+
+# =============================================================================
+# Bracket-shape coverage
+# =============================================================================
+
+
+def test_quoted_rectangle_node_parses():
+    """``id["label<br/>[asset:tag]"]`` — Mermaid rectangle shape."""
+    content = (
+        "```mermaid\n"
+        '    Vault["Secrets Vault<br/>[asset:secrets]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Secrets Vault": ["secrets"]}
+
+
+def test_quoted_cylinder_node_parses():
+    """``id[("label<br/>[asset:tag]")]`` — Mermaid cylinder (data store) shape."""
+    content = (
+        "```mermaid\n"
+        '    DB[("Postgres DB<br/>[asset:pii,auth]")]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Postgres DB": ["auth", "pii"]}
+
+
+def test_quoted_subroutine_node_parses():
+    """``id[["label<br/>[asset:tag]"]]`` — Mermaid subroutine shape."""
+    content = (
+        "```mermaid\n"
+        '    Svc[["Payment Service<br/>[asset:financial]"]]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Payment Service": ["financial"]}
+
+
+# =============================================================================
+# Display-name extraction
+# =============================================================================
+
+
+def test_br_tag_stripped_from_display_name():
+    """``<br/>`` is removed and surrounding whitespace collapsed."""
+    content = (
+        "```mermaid\n"
+        '    DB["My Database<br/>[asset:pii]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    assert "My Database" in result
+
+
+def test_display_name_falls_back_to_node_id_when_label_is_only_asset_block():
+    """When the label contains only an asset block, the node id is the key."""
+    content = (
+        "```mermaid\n"
+        '    SecretsVault["[asset:secrets]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    assert result == {"SecretsVault": ["secrets"]}
+
+
+def test_multiline_br_tag_variants():
+    """``<br>`` and ``<br />`` (with space, no slash) parse identically."""
+    content = (
+        "```mermaid\n"
+        '    DB1["Store One<br>[asset:pii]"]\n'
+        '    DB2["Store Two<br />[asset:phi]"]\n'
+        '    DB3["Store Three<br/>[asset:auth]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    assert result == {
+        "Store One": ["pii"],
+        "Store Two": ["phi"],
+        "Store Three": ["auth"],
+    }
+
+
+# =============================================================================
+# Tag normalization
+# =============================================================================
+
+
+def test_tags_lowercased():
+    """Tag names are case-insensitive on input; canonical storage is lowercase."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:PII,Auth]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Database": ["auth", "pii"]}
+
+
+def test_tags_whitespace_tolerant():
+    """Whitespace around commas in the tag list is stripped."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset: pii , auth ]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Database": ["auth", "pii"]}
+
+
+def test_tags_deduped_within_node():
+    """Repeated tags inside a single asset block are deduplicated."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:pii,pii,pii]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {"Database": ["pii"]}
+
+
+def test_tag_list_sorted():
+    """Returned tag list is sorted alphabetically for deterministic output."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:secrets,pii,auth]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {
+        "Database": ["auth", "pii", "secrets"],
+    }
+
+
+def test_all_six_tags_recognized():
+    """The full closed enum (pii|phi|auth|secrets|financial|safety) all parse."""
+    content = (
+        "```mermaid\n"
+        '    A["A<br/>[asset:pii]"]\n'
+        '    B["B<br/>[asset:phi]"]\n'
+        '    C["C<br/>[asset:auth]"]\n'
+        '    D["D<br/>[asset:secrets]"]\n'
+        '    E["E<br/>[asset:financial]"]\n'
+        '    F["F<br/>[asset:safety]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    assert set(result.keys()) == {"A", "B", "C", "D", "E", "F"}
+    assert all(len(tags) == 1 for tags in result.values())
+    assert {tag for tags in result.values() for tag in tags} == set(VALID_ASSET_TAGS)
+
+
+# =============================================================================
+# Unknown tag handling
+# =============================================================================
+
+
+def test_unknown_tag_dropped_with_warning(capsys):
+    """Tags outside the closed enum are dropped and a stderr warning is emitted."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:pii,unknown_tag,auth]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    captured = capsys.readouterr()
+
+    assert result == {"Database": ["auth", "pii"]}
+    assert "unknown asset tag" in captured.err.lower()
+    assert "unknown_tag" in captured.err
+
+
+def test_only_unknown_tags_produces_no_entry(capsys):
+    """When every tag is unknown, the component is omitted from the result."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:foo,bar,baz]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    captured = capsys.readouterr()
+
+    assert result == {}
+    # Three unknown tags → three warnings.
+    assert captured.err.lower().count("unknown asset tag") == 3
+
+
+# =============================================================================
+# Duplicate node declarations
+# =============================================================================
+
+
+def test_duplicate_component_declarations_merge_tags(capsys):
+    """Two declarations of the same component union their tag sets with a warning."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:pii]"]\n'
+        '    DB["Database<br/>[asset:auth]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    captured = capsys.readouterr()
+
+    assert result == {"Database": ["auth", "pii"]}
+    assert "multiple asset declarations" in captured.err.lower()
+
+
+def test_duplicate_component_same_tag_no_warning(capsys):
+    """Re-declaring the same tag on the same component is a silent no-op."""
+    content = (
+        "```mermaid\n"
+        '    DB["Database<br/>[asset:pii]"]\n'
+        '    DB["Database<br/>[asset:pii]"]\n'
+        "```\n"
+    )
+    result = parse_component_asset_map(content)
+    captured = capsys.readouterr()
+
+    assert result == {"Database": ["pii"]}
+    assert "multiple asset declarations" not in captured.err.lower()
+
+
+# =============================================================================
+# Fence-scope discipline
+# =============================================================================
+
+
+def test_asset_block_outside_mermaid_fence_ignored():
+    """``[asset:...]`` text in prose paragraphs is not parsed."""
+    content = (
+        "# Architecture\n\n"
+        "Our database carries [asset:pii] tags but this is just prose.\n\n"
+        "```mermaid\n"
+        '    DB["Real DB<br/>[asset:auth]"]\n'
+        "```\n\n"
+        "Trailing prose with [asset:financial] also ignored.\n"
+    )
+    assert parse_component_asset_map(content) == {"Real DB": ["auth"]}
+
+
+def test_raw_mermaid_without_fence_still_parses():
+    """When no fence is present, the entire content is scanned as Mermaid."""
+    content = (
+        "flowchart TD\n"
+        '    DB["Database<br/>[asset:pii]"]\n'
+        "    User --> DB\n"
+    )
+    assert parse_component_asset_map(content) == {"Database": ["pii"]}
+
+
+def test_multiple_fences_all_scanned():
+    """Multiple fenced Mermaid blocks are all scanned."""
+    content = (
+        "```mermaid\n"
+        '    DB1["Store One<br/>[asset:pii]"]\n'
+        "```\n\n"
+        "Some prose between blocks.\n\n"
+        "```mermaid\n"
+        '    DB2["Store Two<br/>[asset:auth]"]\n'
+        "```\n"
+    )
+    assert parse_component_asset_map(content) == {
+        "Store One": ["pii"],
+        "Store Two": ["auth"],
+    }
+
+
+# =============================================================================
+# Worked-example smoke test
+# =============================================================================
+
+
+def test_agentic_app_worked_example_parses():
+    """The Issue #260 worked example file produces the expected map."""
+    example_path = (
+        REPO_ROOT
+        / "examples"
+        / "agentic-app"
+        / "architecture-with-asset-tags.md"
+    )
+    if not example_path.is_file():
+        pytest.skip(f"Worked example not present at {example_path}")
+
+    content = example_path.read_text(encoding="utf-8")
+    result = parse_component_asset_map(content)
+
+    # Only the four annotated components from the worked example.
+    assert set(result.keys()) == {
+        "Knowledge Base",
+        "Audit Logger",
+        "Long-Running Learning Loop",
+        "Clinical Advisory Sub-Agent",
+    }
+    assert result["Knowledge Base"] == ["phi", "pii"]
+    assert result["Audit Logger"] == ["auth"]
+    assert result["Long-Running Learning Loop"] == ["safety"]
+    assert result["Clinical Advisory Sub-Agent"] == ["phi"]
+
+
+# =============================================================================
+# Enum constant
+# =============================================================================
+
+
+def test_valid_asset_tags_is_closed_six_value_enum():
+    """The exported enum matches the schema contract (Issue #260 prototype)."""
+    assert VALID_ASSET_TAGS == (
+        "pii",
+        "phi",
+        "auth",
+        "secrets",
+        "financial",
+        "safety",
+    )


### PR DESCRIPTION
## Summary

Prototype for #260 (community-contributed; opens for architect review when @davidmatousek is ready). Adds an optional asset-sensitivity tag pass to the risk-scorer that closes the asset-value gap in the four-dimensional composite. Reachability scores how exposed a component is; this scores what would be lost if the component were compromised.

## Related Issue

Refs #260
Discussion: https://github.com/davidmatousek/tachi/discussions/246

## Scope (per direction in #246, 2026-05-05)

- **Mermaid parser pass**: `parse_component_asset_map()` in `scripts/tachi_parsers.py` extracts `[asset:tag1,tag2]` blocks from quoted node labels into a component-to-tag dict that mirrors `component_zone_map`'s shape.
- **`asset_modifiers` table** in `schemas/risk-scoring.yaml` with the closed six-tag enum (`pii | phi | auth | secrets | financial | safety`) and a `modifier_ceiling` (`9.5`, prototype default).
- **risk-scorer Section 3.5** wires the modifier pass *after* the `score_bounds` +/-1.0 clamp, with a new `asset-modifiers.md` skill reference describing floor-only semantics, parsing rules, and a worked example.
- **Worked example** at `examples/agentic-app/architecture-with-asset-tags.md` — added as a parallel file so the canonical `architecture.md` and the six SC-003 byte-identical baselines stay untouched.
- **26 pytest cases** in `tests/scripts/test_asset_sensitivity_tags.py`. CVSS arithmetic in the worked example verified against the CVSS 3.1 base-score formula.

## Explicit decisions resolved per #246 reply

| Open question | Direction | How implemented |
|---|---|---|
| Modifier vs clamp ordering | Apply *after* clamp | Section 3.5 placed after Section 3 bounded-scoring step; explicit ordering rationale in the skill ref |
| Vocabulary scope | Hardcoded enum first | Closed six-tag tuple in both `VALID_ASSET_TAGS` (parser) and `asset_modifiers.tags` (schema) |
| Tag location | Inline in node labels | Only the quoted-label form (`id["...[asset:...]..."]`) is parsed; sidecar avoided |
| Hard ceiling | 9.0-9.5 range | `modifier_ceiling: 9.5` (high end; pinned at architect review) |

## Explicitly deferred to architect review

- `finding.yaml` `affected_assets[]` field (skipped per "design review and we'll handle them when the spec opens").
- SARIF property bag emission for elevated `cvss_base` values.
- `risk-scoring.yaml` `schema_version` bump (left at `1.1`; maintainer pins on landing).
- Final `modifier_ceiling` value.
- Populator wiring inside the 11 detection agents (F-A3-style follow-up).

## Worked-example modifier effect

CVSS values computed from category defaults using the CVSS 3.1 formula:

| Finding shape | Component | Tags | `cvss_base` before | `cvss_base` after | Composite delta (x0.35) |
|---|---|---|---|---|---|
| Tampering on Knowledge Base | KB | `pii, phi` | 7.1 | 8.3 | +0.42 |
| Repudiation on Audit Logger | AuditLog | `auth` | 4.3 | 8.1 | +1.33 |
| Tampering on Long-Running Learning Loop | LearningLoop | `safety` | 7.1 | 8.1 | +0.35 |
| Info-disclosure on Knowledge Base | KB | `pii, phi` | 6.5 | 6.5 | 0 (no-op) |

The "no-op" row is the floor-only correctness check — info-disclosure already has `C:H` at the category default, so PII tags add nothing on that finding shape.

## Checklist

- [x] Changes follow existing patterns and conventions
- [x] Documentation updated (skill reference + agent edits + worked example)
- [x] No secrets, credentials, or PII in committed files
- [x] Tested locally (26/26 pytest cases pass; full suite has the same 25 pre-existing failures present on `main` — none introduced by this PR)
- [x] Conventional Commit PR title (`feat(260):`) per `.claude/rules/git-workflow.md`
- [x] Co-Authored-By trailer per Constitution IX
- [x] Branch `260-asset-sensitivity-tags` keyed to Issue number
- [x] Stdlib-only parser per PAT-014 (no PyYAML)
- [x] Additive-only, opt-in semantics — components without tags preserve existing scoring exactly

## Transparency

Drafted with Claude Code (Opus 4.7) assistance; @north-echo reviewed every diff and stands behind the design choices. Happy to discuss any part of the approach or rework as needed.