### PR TITLE
fix(266): retitle CONTRIBUTING.md for tachi

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,30 +1,66 @@
-# Contributing to AOD Kit
+# Contributing to tachi
 
-Thank you for your interest in contributing to the Agentic Oriented Development Kit.
+Thank you for your interest in contributing to tachi — the threat modeling and AI-reasoning vulnerability detection harness for Claude Code.
 
-## How to Contribute
+## Where to start
 
-1. **File an Issue**: For bugs, use the [bug report template](.github/ISSUE_TEMPLATE/bug_report.md). For features, use the [feature request template](.github/ISSUE_TEMPLATE/feature_request.md).
-2. **Fork and Branch**: Fork the repository and create a feature branch (`NNN-descriptive-name`).
-3. **Make Changes**: Follow the existing code style and governance patterns.
-4. **Test**: Run `make check` to verify your changes.
-5. **Submit a PR**: Open a pull request against `main` with a clear description of your changes.
+| What you have | Where it goes |
+|---------------|---------------|
+| **Reproducible bug** | [GitHub Issue](https://github.com/davidmatousek/tachi/issues) using the bug-report template |
+| **Question or unclear behavior** | [Discussions → Q&A](https://github.com/davidmatousek/tachi/discussions/categories/q-a) |
+| **Feature idea** | [Discussions → Feature Requests](https://github.com/davidmatousek/tachi/discussions/categories/feature-requests) (not Issues — see below) |
+| **Real-world usage report** | [Discussions → In the Wild](https://github.com/davidmatousek/tachi/discussions/categories/in-the-wild) |
+| **Security vulnerability** | [Private advisory](https://github.com/davidmatousek/tachi/security/advisories/new) — do NOT post publicly |
 
-## Development Setup
+## Development setup
 
 ```bash
-git clone https://github.com/your-org/agentic-oriented-development-kit.git
-cd agentic-oriented-development-kit
+git clone https://github.com/davidmatousek/tachi.git
+cd tachi
 make init
 make check
 ```
 
+The full pipeline requires two external CLIs:
+
+- `typst` — PDF security report compilation
+- `mmdc` (`@mermaid-js/mermaid-cli`) — attack tree rendering
+
+See [README.md](README.md) "Prerequisites" for platform-specific install commands.
+
+## How feature requests become work
+
+Feature requests start as Discussions, not Issues. The lifecycle:
+
+1. **Propose** — Open a thread in [Discussions → Feature Requests](https://github.com/davidmatousek/tachi/discussions/categories/feature-requests) describing the problem you're trying to solve.
+2. **Triage** — Maintainer reviews, asks clarifying questions, gathers community signal.
+3. **Promote** — Once a thread has traction and an [ICE score](docs/AOD_TRIAD.md), the maintainer promotes it to a GitHub Issue (auto-labeled `enhancement`, `stage:discover`).
+4. **Pick up** — Contributors take the Issue through the AOD lifecycle: `/aod.define` → `/aod.plan` → `/aod.build` → `/aod.deliver`. See [docs/AOD_TRIAD.md](docs/AOD_TRIAD.md) for the governance overview.
+
+Why the gate? It keeps the Issue tracker focused on actionable, scoped, traction-validated work. Discussions are where ideas grow; Issues are where work happens.
+
+## Branch and PR workflow
+
+**Always use feature branches** — never commit to main directly.
+
+- **Branch format**: `NNN-descriptive-name` where `NNN` is the GitHub Issue number, zero-padded to 3 digits (e.g., `266-tachi-flavor-contributing`).
+- **PR title**: must be Conventional-Commit-formatted because squash-merge subjects feed into release-please:
+  - `feat(NNN): <description>` — new feature or user-visible improvement (minor bump)
+  - `fix(NNN): <description>` — bug fix (patch bump)
+  - `perf(NNN): <description>` — performance improvement (patch bump)
+  - `docs:` / `chore:` / `refactor:` / `test:` / `style:` — hidden bump, no release
+- **Draft PR**: open at plan stage for early visibility; mark ready at delivery time.
+- **Triad sign-offs**: PRs touching `spec.md`, `plan.md`, or `tasks.md` require PM / Architect / Team-Lead sign-offs per [docs/AOD_TRIAD.md](docs/AOD_TRIAD.md).
+
+See [.claude/rules/git-workflow.md](.claude/rules/git-workflow.md) for the full git workflow including the post-merge release-please verification step.
+
 ## Guidelines
 
-- Follow the AOD Triad governance methodology for significant changes.
-- Keep commits atomic and use conventional commit messages (`feat:`, `fix:`, `docs:`).
-- Update documentation when changing workflows or templates.
-- Be respectful and constructive in all interactions.
+- Follow existing patterns and conventions
+- Keep commits atomic and focused on a single change
+- Update documentation when changing workflows or templates
+- No secrets, credentials, or PII in committed files (see [docs/security/OPEN_SOURCE_READINESS.md](docs/security/OPEN_SOURCE_READINESS.md))
+- Be respectful and constructive in all interactions
 
 ## Code of Conduct
 
@@ -32,4 +68,4 @@ All contributors must follow our [Code of Conduct](CODE_OF_CONDUCT.md).
 
 ## Questions?
 
-Open a discussion or issue if you have questions about contributing.
+Open a [Discussion](https://github.com/davidmatousek/tachi/discussions) — happy to help.


### PR DESCRIPTION
## Summary

- Retitles CONTRIBUTING.md as `# Contributing to tachi` (was: `# Contributing to AOD Kit` — stale fork-leftover).
- Replaces clone URL with the correct `davidmatousek/tachi` repo.
- Adds a "Where to start" router and a `## How feature requests become work` section — the latter creates the missing anchor that `.github/ISSUE_TEMPLATE/feature_request.md` already links to.

## Why

`CONTRIBUTING.md` was last updated when tachi was a derivative of AOD-Kit. Three specific issues:

1. Title and body still claimed the file was for "the Agentic Oriented Development Kit"
2. Dev-setup `git clone` pointed at `your-org/agentic-oriented-development-kit.git` — wrong repo, wrong org
3. `feature_request.md` issue template (added recently) references `CONTRIBUTING.md#how-feature-requests-become-work` — an anchor that didn't exist anywhere in the file

Result: first-time external contributors saw the wrong project name on their first contact with the contributing flow, plus a 404'd anchor.

## What changed

- New "Where to start" table routes by intent (bug / question / feature / vuln / usage report)
- New `## How feature requests become work` section documents the actual lifecycle the project uses: Discussions → ICE → Issue → AOD lifecycle (`/aod.define` → `/aod.plan` → `/aod.build` → `/aod.deliver`)
- New "Branch and PR workflow" section documents the Conventional Commit + draft-PR rules from `.claude/rules/git-workflow.md` so external contributors understand release-please's release-triggering rules
- All product references updated to use the new dual-frame phrasing ("threat modeling and AI-reasoning vulnerability detection harness for Claude Code")
- File length: 36 lines → ~75 lines (was too thin to be useful)

## Out of scope

- No agent or workflow behavior changes
- `.github/ISSUE_TEMPLATE/` files unchanged (already tachi-flavored)
- `CODE_OF_CONDUCT.md` unchanged (referenced, not modified)
- This is `fix:` not `feat:` — release-please will hidden-bump, no version cut needed for a CONTRIBUTING.md cleanup

## Test plan

- [ ] Render CONTRIBUTING.md on GitHub and confirm all links resolve
- [ ] Click through from `feature_request.md` template's `#how-feature-requests-become-work` anchor and confirm it lands on the new section
- [ ] Verify the dev-setup `git clone` line points at `davidmatousek/tachi` (not the AOD-Kit repo)

## Relationship to other PRs

Independent of PR #265 (dual-frame public positioning) — branched off main. Both can merge in any order.

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)