### PR TITLE
fix(268): disentangle tachi-scanner from AOD-Kit positioning in scope.md

### DIFF
--- a/.claude/rules/scope.md
+++ b/.claude/rules/scope.md
@@ -5,33 +5,41 @@
 
 ## Overview
 
-This file defines what tachi is (and isn't) to set clear expectations for template adopters.
+This file defines what tachi is (and isn't) to set clear expectations for adopters. tachi-the-scanner and AOD-Kit-the-methodology are kept separate here — see "Built with AOD-Kit" at the end for the relationship.
 
 ---
 
-## What This Is
+## What tachi Is
 
-**tachi is:**
-- Threat modeling and AI-reasoning vulnerability detection harness for Claude Code (STRIDE + AI + MAESTRO).
-- Agentic-oriented development with clear governance workflows
-- Works with any agent workflow or framework (not Claude Code-specific)
-- Methodology and governance template (not application code)
-- Unified Triad workflow with built-in governance and quality gates
+- A **threat modeling and AI-reasoning vulnerability detection harness for Claude Code** (STRIDE + AI + MAESTRO).
+- A new scanning column alongside SAST / SCA / Secrets — same role, logic-level instead of syntax-level.
+- An instrumentation harness, not a SaaS — adopters install it into their own project and run it locally; architecture descriptions never leave their machine.
+- Open source under Apache 2.0.
 
-**Key Features:**
-- SDLC Triad governance (PM → Architect → Team-Lead sign-offs)
-- Modular `.claude/rules/` for easy customization
-- Local-first `.aod/` file workflows
-- Compatible with any tech stack or cloud provider
+## Key Features
+
+- 14 specialized threat agents (6 STRIDE + 5 LLM + 3 Agentic) dispatched against your architecture description
+- 6 slash commands producing 20+ artifacts: `threats.md`, SARIF, narrative report, attack trees, MAESTRO classification, risk scores, compensating controls, infographics, PDF security report
+- 5 input formats (Mermaid, free-text, ASCII, PlantUML, C4)
+- 50/50 OWASP coverage across LLM 2025, Agentic 2026, ML 2023, Mobile 2024, Web/API 2021/2023
+- MAESTRO seven-layer classification (L1–L7) and cross-layer attack-chain detection
+- Baseline delta tracking across runs
 
 ---
 
-## What This Isn't
+## What tachi Is NOT
 
-**tachi is NOT:**
-- NOT a quick prototype tool (we follow proper process)
-- NOT limited to a single AI agent (supports multi-agent workflows)
-- NOT skipping governance for speed (governance is built into every command)
-- NOT application code (users bring their own backend/, frontend/, etc.)
-- NOT a CI/CD tool (you integrate with your own pipelines)
-- NOT a replacement for human oversight (agents assist, humans decide)
+- **NOT a SAST/SCA replacement** — complementary scanning column for logic-level risks SAST cannot reach
+- **NOT application code** — adopters bring their own architecture description (`docs/security/architecture.md`)
+- **NOT a CI/CD tool** — adopters integrate it into their own pipelines (SARIF outputs feed GitHub Code Scanning)
+- **NOT a replacement for human oversight** — the harness surfaces findings; remediation decisions are yours
+- **NOT agent-agnostic** — the scanner runs inside Claude Code (the AOD-Kit methodology backing tachi's development IS portable, but the scanner itself is not)
+- **NOT a SaaS** — no telemetry, no remote inference, no data leaving your environment
+
+---
+
+## Built with AOD-Kit
+
+Tachi's own development is governed by the [Agentic Oriented Development Kit (AOD-Kit)](https://github.com/davidmatousek/agentic-oriented-development-kit) — the SDLC Triad methodology (PM + Architect + Team-Lead sign-offs) and quality gates that govern how tachi is built and maintained.
+
+AOD-Kit is a separate project; tachi adopts it as its own development discipline. **Adopters consuming tachi as a scanner do not need to use AOD-Kit themselves.** The two products serve different purposes: AOD-Kit is for building software with AI agents; tachi is for analyzing software architecture for security risks.


### PR DESCRIPTION
## Summary

- Rewrites `.claude/rules/scope.md` to separate **tachi-the-scanner** positioning from **AOD-Kit-the-methodology** features.
- Removes the bullet that contradicted the new deployment context (`Works with any agent workflow or framework — not Claude Code-specific`).
- Adds an explicit closing "Built with AOD-Kit" section that names the relationship without conflating identities.

## Why

`scope.md` mixed two distinct products into one identity:

1. **tachi-the-scanner** — runs in Claude Code, threat modeling + AI-reasoning vulnerability detection harness, OWASP coverage, MAESTRO classification
2. **AOD-Kit-the-methodology** — Triad governance, `.aod/` workflows, agent-agnostic SDLC framework

Specific contradictions resolved:

| Old text | Resolution |
|----------|------------|
| `Works with any agent workflow or framework (not Claude Code-specific)` | Removed; replaced with explicit "scanner runs inside Claude Code" framing |
| `Agentic-oriented development with clear governance workflows` (bullet 2 of "What This Is") | Moved to closing "Built with AOD-Kit" pointer |
| `SDLC Triad governance` in "Key Features" | Replaced with tachi-scanner features: 14 agents, 6 commands, 50/50 OWASP coverage, MAESTRO L1–L7, baseline delta tracking |
| `NOT limited to a single AI agent (supports multi-agent workflows)` — true for AOD-Kit, false for tachi-the-scanner | Replaced with `NOT agent-agnostic — the scanner runs inside Claude Code` |
| (unstated local-first guarantee) | Added explicit `NOT a SaaS — no telemetry, no remote inference, no data leaving your environment` |

This file is distributed to adopters via `scripts/install.sh`. Fixing the conflation here propagates the correct framing to every adopter project.

## What changed

- "What This Is" / "What This Isn't" → "What tachi Is" / "What tachi Is NOT"
- Key Features list rewritten to enumerate tachi-scanner capabilities only
- New closing section: **"Built with AOD-Kit"** — names AOD-Kit as a separate project that backs tachi's development, with the disentangling line: "Adopters consuming tachi as a scanner do not need to use AOD-Kit themselves."
- Preserved CLAUDE.md @-syntax HTML comment (still resolves)
- File length: 38 lines → 50 lines

## Out of scope

- No agent or workflow behavior changes — `scope.md` is positioning, not policy
- Does not modify the AOD-Kit governance methodology that backs tachi's development
- Does not touch CLAUDE.md or any other file

## Note

Replaces closed PR #269 (which was auto-closed when its parent branch `264-dual-frame-public-positioning` was deleted via #265's squash-merge). This PR's branch was rebased onto main; git correctly skipped the already-applied dual-frame commit, leaving only the scope.md disentanglement as the diff.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)