### PR TITLE
docs(282): post-delivery quality review

### DIFF
--- a/tests/fixtures/gitleaks-rule-interaction/run.sh
+++ b/tests/fixtures/gitleaks-rule-interaction/run.sh
@@ -94,12 +94,16 @@ scan_case() {
     findings=$count
   fi
 
+  local passed=0
   if [ "$expected" = "fire" ] && [ "$findings" -ge 1 ]; then
-    PASS=$((PASS + 1))
-    printf "%sPASS%s %s (expected fire, got %s finding(s))\n" "$GREEN" "$NC" "$case_id" "$findings"
+    passed=1
   elif [ "$expected" = "nofire" ] && [ "$findings" -eq 0 ]; then
+    passed=1
+  fi
+
+  if [ "$passed" -eq 1 ]; then
     PASS=$((PASS + 1))
-    printf "%sPASS%s %s (expected nofire, got %s finding(s))\n" "$GREEN" "$NC" "$case_id" "$findings"
+    printf "%sPASS%s %s (expected %s, got %s finding(s))\n" "$GREEN" "$NC" "$case_id" "$expected" "$findings"
   else
     FAIL=$((FAIL + 1))
     printf "%sFAIL%s %s (expected %s, got %s finding(s))\n" "$RED" "$NC" "$case_id" "$expected" "$findings"

--- a/tests/scripts/test_init_precommit_matrix.py
+++ b/tests/scripts/test_init_precommit_matrix.py
@@ -1,20 +1,15 @@
-"""F-5 init.sh prompt-flag matrix test (CONCERN-2 / Pre-Mortem FM-3).
+"""init.sh pre-commit prompt-flag matrix test (F-5).
 
 Tests the 6-case matrix `[TTY/no-TTY] × [no-flag/--no-precommit/--precommit]`
-introduced by T015 (init.sh delta inserting an opt-in pre-commit prompt at
-the line 177-185 region after personalization confirmation).
+covering the opt-in pre-commit prompt inserted after personalization
+confirmation in scripts/init.sh.
 
 Each test asserts:
   - Whether the pre-commit prompt was emitted to the user
   - Whether init.sh attempted `pre-commit install` (success or graceful WARN)
 
-Per F-256 KB Entry 3 (lock-step pattern): this test file's path is added to
-`.github/workflows/tachi-pytest.yml` `paths:` AND the pytest invocation in
-the same commit (T014a, paired with T014).
-
-Auto-skip pattern: until T015 lands in the cloned tree's `scripts/init.sh`,
-the cases auto-skip with a clear reason. Once T015 lands (Wave 3), the tests
-auto-activate. No manual unskip step required.
+Auto-skip pattern: if the cloned tree's scripts/init.sh lacks the pre-commit
+prompt block, cases auto-skip with a clear reason.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Post-delivery documentation review for Feature 282 (F-5 Pre-commit Secret-Scanning Defaults).

- `refactor(282)`: /simplify review fixes:
  - `tests/fixtures/gitleaks-rule-interaction/run.sh` — collapsed duplicate printf PASS branches into a single conditional via `passed` flag (Quality Agent 2 actionable finding; 16/16 fixture matrix still PASS)
  - `tests/scripts/test_init_precommit_matrix.py` — trimmed post-merge-obsolete historical references from module docstring (Wave 3 / T015 / F-256 KB Entry 3 / line-region pointer)

Other /simplify findings (parametrize collapse, `_run_init_with_flags` helper refactor, inline comments) deferred per agent guidance.

Docs-lint, CHANGELOG, API-sync, and KB-review steps all reported up-to-date or no-action-required (all 4 Python helpers documented; CHANGELOG F-5 entry already in place with sibling-h3 BLP-02-cluster placement per KB Entry 4; no OpenAPI spec; F-5 KB entry intentionally skipped per delivery retrospective).

## Test plan

- [x] Refactored run.sh produces 16/16 PASS (verified locally post-refactor)
- [x] No semantic changes to behavior — docstring/printf only
- [ ] CI green (gitleaks + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)