### PR TITLE
chore(280): pre-commit jq + AC-2 cross-check for claude permissions

### DIFF
--- a/.aod/scripts/bash/claude-permissions-ac2-crosscheck.sh
+++ b/.aod/scripts/bash/claude-permissions-ac2-crosscheck.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# =============================================================================
+# claude-permissions-ac2-crosscheck.sh — F-4 AC-2 cross-check (FR-002)
+# =============================================================================
+# Verifies that every non-built-in rule in `.claude/settings.json` appears in
+# the §4 per-rule rationale table of `docs/standards/CLAUDE_PERMISSIONS.md`,
+# AND that every §4 table row references a rule present in settings.json.
+#
+# Implements the awk-section-marker form codified in PR #278 commit ec0b628
+# (architect P1 Minor #2 reconciliation). Section extraction is restricted to
+# §4 so §5 (built-in read-only set) and §6 (opt-out paths) illustrative
+# examples don't produce false-positive orphans. Markdown-pipe unescape
+# (`\|` → `|`) ensures clean diff against JSON-literal rules containing pipes
+# such as `Bash(curl * | sh)`.
+#
+# Invocation contexts:
+#   - `.pre-commit-config.yaml` local hook on edits to `.claude/settings.json`
+#     or `docs/standards/CLAUDE_PERMISSIONS.md` (issue #280)
+#   - Manual run from repo root: `bash .aod/scripts/bash/claude-permissions-ac2-crosscheck.sh`
+#   - Future CI workflow per #281
+#
+# Bash 3.2 compatible (macOS-native). No associative arrays, no `mapfile`.
+#
+# Exit codes:
+#   0 — empty diff (PASS); JSON rules and §4 table rows match exactly.
+#   1 — non-empty diff (FAIL); structured stderr lists the orphans.
+#   2 — invariant violation (missing files, jq parse error, awk section empty).
+# =============================================================================
+
+set -u
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+SETTINGS="${ROOT}/.claude/settings.json"
+DOCS="${ROOT}/docs/standards/CLAUDE_PERMISSIONS.md"
+
+if [ ! -f "$SETTINGS" ]; then
+  echo "[ac2-crosscheck] FATAL: $SETTINGS not found" >&2
+  exit 2
+fi
+if [ ! -f "$DOCS" ]; then
+  echo "[ac2-crosscheck] FATAL: $DOCS not found" >&2
+  exit 2
+fi
+
+TMP="$(mktemp -d -t ac2-crosscheck.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+RULES="${TMP}/rules.txt"
+DOC_RULES="${TMP}/doc-rules.txt"
+
+# Extract every rule from settings.json (deny + ask + allow combined).
+# `jq` exits non-zero on parse error; the `||` branch reports it.
+if ! jq -r '.permissions.deny[], .permissions.ask[], .permissions.allow[]' \
+     "$SETTINGS" 2>/dev/null | sort -u > "$RULES"; then
+  echo "[ac2-crosscheck] FATAL: jq parse failed on $SETTINGS" >&2
+  exit 2
+fi
+
+# Extract rules from §4 (Per-rule rationale table) of CLAUDE_PERMISSIONS.md.
+# `awk '/^## 4\./,/^## 5\./'` selects the inclusive block between §4 and §5
+# headers. `grep -E '^\| \`'` keeps only table data rows (the header row
+# starts with `| Rule |` not `| \`Bash...`). `sed -E` extracts the
+# back-tick-quoted rule literal. The final `sed 's/\\|/|/g'` unescapes the
+# markdown pipe character.
+awk '/^## 4\./,/^## 5\./' "$DOCS" \
+  | grep -E '^\| `' \
+  | sed -E 's/^\| `([^`]+)` \|.*/\1/' \
+  | sed 's/\\|/|/g' \
+  | sort -u > "$DOC_RULES"
+
+if [ ! -s "$DOC_RULES" ]; then
+  echo "[ac2-crosscheck] FATAL: §4 extraction produced empty rule list — verify section headers (## 4. … ## 5.) in $DOCS" >&2
+  exit 2
+fi
+
+# Compare. `diff -u` produces a unified diff; we use plain `diff` here so the
+# orphan classification (left-only vs right-only) is unambiguous.
+if diff "$RULES" "$DOC_RULES" > "${TMP}/diff.out" 2>&1; then
+  exit 0
+fi
+
+# Non-empty diff. Print structured stderr and fail.
+{
+  echo ""
+  echo "──────────────────────────────────────────────────────────────"
+  echo "Commit refused: F-4 AC-2 cross-check (FR-002) found drift between"
+  echo "  .claude/settings.json  ↔  docs/standards/CLAUDE_PERMISSIONS.md §4"
+  echo ""
+  echo "  Diff (< rules in settings.json missing from §4 table;"
+  echo "        > rows in §4 table referencing rules not in settings.json):"
+  echo ""
+  sed 's/^/      /' "${TMP}/diff.out"
+  echo ""
+  echo "  Fix: add the missing rule to the §4 per-rule rationale table"
+  echo "       OR remove the orphaned table row, depending on intent."
+  echo "       Reference: docs/standards/CLAUDE_PERMISSIONS.md §4"
+  echo "                  (Per-rule rationale table)"
+  echo "──────────────────────────────────────────────────────────────"
+} >&2
+
+exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,3 +37,28 @@ repos:
         # the gitleaks binary into a managed Go env on first invocation.
         pass_filenames: false
         stages: [pre-commit]
+
+  # ---------------------------------------------------------------------------
+  # Local hooks — F-4 verification recipe (jq + AC-2 cross-check) per Issue #280
+  # ---------------------------------------------------------------------------
+  # Triggered only when `.claude/settings.json` or
+  # `docs/standards/CLAUDE_PERMISSIONS.md` are touched, so day-to-day commits
+  # pay zero hook cost. AC-7 (subdomain probe) and AC-12 (cross-file deny
+  # precedence) sub-checks remain `[MANUAL-ONLY]` because they require an
+  # interactive Claude Code session — see Issue #281 for the CI port plan.
+  - repo: local
+    hooks:
+      - id: claude-settings-jq-validity
+        name: claude/settings.json — jq parse (F-4 AC-1 / FR-001)
+        entry: jq empty .claude/settings.json
+        language: system
+        files: ^\.claude/settings\.json$
+        pass_filenames: false
+        stages: [pre-commit]
+      - id: claude-permissions-ac2-crosscheck
+        name: claude/settings.json ↔ CLAUDE_PERMISSIONS.md §4 cross-check (F-4 AC-2 / FR-002)
+        entry: .aod/scripts/bash/claude-permissions-ac2-crosscheck.sh
+        language: system
+        files: ^(\.claude/settings\.json|docs/standards/CLAUDE_PERMISSIONS\.md)$
+        pass_filenames: false
+        stages: [pre-commit]


### PR DESCRIPTION
## Summary

- Adds two **local** pre-commit hooks (`claude-settings-jq-validity` and `claude-permissions-ac2-crosscheck`) gated to changes touching `.claude/settings.json` or `docs/standards/CLAUDE_PERMISSIONS.md` — day-to-day commits pay zero hook cost.
- New `.aod/scripts/bash/claude-permissions-ac2-crosscheck.sh` mechanizes the awk-section-marker AC-2 form codified in PR #278 commit `ec0b628` (architect P1 Minor #2 reconciliation). Verifies every non-built-in rule in settings.json has a §4 row in CLAUDE_PERMISSIONS.md and vice-versa.
- Closes F-4 nice-to-have **AC-15** (FR-001 + FR-002 mechanization). Triaged at the BLP-02 closure tracker (#289) post-5/5 delivery.

## Why this fits Issue #280

Issue body asked for: *"Pre-commit hook running `jq empty .claude/settings.json` + AC-2 cross-check (every non-built-in rule documented in CLAUDE_PERMISSIONS.md per-rule table) on edits touching either file."*

The hook design honors the Issue's explicit guidance: *"Hook should inherit the awk-section-marker AC-2 form codified in PR #278 (architect P1 Minor #2 reconciliation in `ec0b628`)."*

## Smoke tests performed

- [x] `pre-commit validate-config` passes
- [x] `pre-commit run claude-settings-jq-validity --files .claude/settings.json` → PASSED
- [x] `pre-commit run claude-permissions-ac2-crosscheck --files .claude/settings.json docs/standards/CLAUDE_PERMISSIONS.md` → PASSED
- [x] Failure-path injection test: added orphan rule `Bash(orphan-test-rule:*)` to `.claude/settings.json`; script exited rc=1 with structured stderr identifying the orphan; clean restore returned rc=0
- [x] Bash 3.2 compatibility (macOS-native; precommit-wrap.sh + common.sh precedent): no `mapfile`, no associative arrays, no `&>`, no `${var,,}`

## Test plan

- [ ] CI: gitleaks workflow stays green (pre-existing hook unchanged)
- [ ] Local validation: `pre-commit run --all-files` skips both new hooks (correct — no governed file changes in PR)
- [ ] Adopter validation: re-run `pre-commit run claude-permissions-ac2-crosscheck` against `.claude/settings.json` + `docs/standards/CLAUDE_PERMISSIONS.md` after merge → PASS

## Out of scope

- AC-7 (WebFetch subdomain probe) and AC-12 (cross-file deny precedence) remain permanently `[MANUAL-ONLY]` — they require an interactive Claude Code session, not a pre-commit or CI context.
- CI port of the same 3 deterministic checks tracked under #281 (now ~30min of `actions/checkout` + `bash <script>` once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)