### PR TITLE
docs(299): surface /tachi.architecture in Developer Guide Step 4

### DIFF
--- a/docs/guides/DEVELOPER_GUIDE_TACHI.md
+++ b/docs/guides/DEVELOPER_GUIDE_TACHI.md
@@ -144,7 +144,17 @@ ls brand/final/                                 # tachi logo PNGs (optional, for
 
 ## Step 4: Create Your Architecture File
 
-You need a `docs/security/architecture.md` file that describes your system's components, data flows, and trust boundaries. You can ask Claude Code to create it for you:
+You need a `docs/security/architecture.md` file that describes your system's components, data flows, and trust boundaries. There are three ways to create it, easiest first.
+
+**Option A: Generate it with `/tachi.architecture` (recommended).** Tachi ships a purpose-built command for exactly this step. It explores your codebase (source, config, infrastructure definitions, existing docs) and writes the file for you:
+
+```
+/tachi.architecture
+```
+
+By default it writes to `docs/security/architecture.md`, capturing components, data flows, trust boundaries, and external entities, and it detects LLM/agent/tool components so the AI threat agents activate. Re-running it archives the previous version and walks you through what changed (guided update mode), so it is safe to regenerate as your system evolves. When it finishes it points you straight at `/tachi.threat-model`.
+
+**Option B: Ask Claude Code with a custom prompt.** If you want to steer the analysis yourself, describe what you want directly:
 
 ```
 Investigate this repository's architecture — source code, config files, infrastructure
@@ -161,7 +171,7 @@ docs/security/architecture.md as a Mermaid flowchart that includes:
 
 Claude Code will explore your codebase and produce an architecture description tailored to your actual system.
 
-**If you prefer to write it yourself**, here is a minimal 3-component example in Mermaid format:
+**Option C: Write it yourself.** Here is a minimal 3-component example in Mermaid format:
 
 ~~~markdown
 ```mermaid


### PR DESCRIPTION
Restructures **Step 4 of the Developer Guide** ("Create Your Architecture File") into three options, easiest first:

- **A — `/tachi.architecture`** (recommended): the purpose-built command that explores the codebase and writes `docs/security/architecture.md`, with guided-update mode on re-run.
- **B — custom Claude Code prompt**: steer the analysis manually.
- **C — write it yourself**: the existing minimal Mermaid example.

Surfaces the purpose-built command as the recommended onboarding path. Docs-only; release-please skips.

Closes #299

🤖 Generated with [Claude Code](https://claude.com/claude-code)