### PR TITLE
docs(183): post-delivery quality review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Feature 183 — Citation-URL Link-Rot Monitoring (BLP-05 Wave 3 / F-3, #183) — feat(183)
+
+Keeps the framework-crosswalk catalog's cited authority URLs verifiably live: a
+weekly scheduled job probes every citation URL, classifies link-rot, and maintains
+a single self-healing GitHub tracking issue — without ever blocking a merge. Final
+feature of the BLP-05 framework-mapping initiative (6/6 complete).
+
+**Added**
+- Scheduled GitHub Actions workflow `.github/workflows/tachi-citation-linkrot.yml`
+  (cron `17 9 * * 1` + manual `workflow_dispatch`) that probes every taxonomy
+  crosswalk citation URL and reconciles one tracking issue. **Scheduled-only** (never
+  `pull_request`/`push`) and **monitor-not-gate** (exits 0 even when rot is found) so a
+  flaky external host can never redden an unrelated merge (NFR-001). Least-privilege
+  `contents: read` + `issues: write` via the ambient `GITHUB_TOKEN` — no PAT, no new
+  secret.
+- Zero-dependency checker `scripts/check-citation-urls.py` (stdlib `urllib` +
+  `concurrent.futures` + existing `pyyaml`; **no new runtime dependency**): per-host
+  throttled fetch (HEAD→ranged-GET), four-tier classification (HEALTHY / LINK_ROT
+  404·410 / NEEDS_REVIEW 401·403·429 / TRANSIENT 5xx·timeout, never reported), a
+  cache-persisted ledger, and a single self-healing tracking issue that opens on
+  confirmed rot, updates in place, and self-closes on recovery.
+- Offline test suite `tests/schemas/test_citation_linkrot_parity.py` (17 tests):
+  both-surface/both-direction URL parity guard, the full classifier matrix, and an
+  NFR-001 boundary assertion that the module opens no socket at import time.
+
+**Changed**
+- `schemas/taxonomy/README.md`: the link-rot "out of F-A1 scope" deferral now points
+  to the live scheduled monitor.
+
 ### Feature 185 — CWE Catalog Expansion + T029 Drift-Edge Restoration (BLP-05 Wave 2 / F-A1.2, #185) — feat(185)
 
 Closed the last cwe.yaml residual from Feature 180's T029 cleanup: the 40

--- a/scripts/check-citation-urls.py
+++ b/scripts/check-citation-urls.py
@@ -314,11 +314,11 @@ def _transient_token_for_exception(exc: BaseException) -> str:
     connection error so the ``detail`` string is diagnostic (data-model.md
     §Classification — e.g. ``"timeout x3"``).
     """
-    if isinstance(exc, TimeoutError) or isinstance(exc, socket.timeout):
-        return "timeout"
-    # urllib wraps the underlying socket error in URLError.reason.
+    # urllib wraps the underlying socket error in URLError.reason; for a bare
+    # timeout/socket error (no .reason attr) getattr falls back to exc itself,
+    # so this single check covers both the wrapped and unwrapped cases.
     reason = getattr(exc, "reason", exc)
-    if isinstance(reason, TimeoutError) or isinstance(reason, socket.timeout):
+    if isinstance(reason, (TimeoutError, socket.timeout)):
         return "timeout"
     if isinstance(reason, socket.gaierror):
         return "dns"
@@ -851,7 +851,6 @@ def manage_tracking_issue(
     """
     has_rot = len(confirmed_rot) > 0
     open_number = _find_open_issue(ISSUE_TITLE_SENTINEL)
-    run_date = run_timestamp
 
     if has_rot and open_number is None:
         # Create the one tracking issue. Best-effort ensure the convenience label
@@ -871,7 +870,7 @@ def manage_tracking_issue(
         _run_gh(["issue", "edit", str(open_number), "--body", rendered_body])
         comment = _run_gh(
             ["issue", "comment", str(open_number),
-             "--body", _delta_comment_body(confirmed_rot, run_date)],
+             "--body", _delta_comment_body(confirmed_rot, run_timestamp)],
             fatal=False,
         )
         if comment.returncode != 0:
@@ -884,7 +883,7 @@ def manage_tracking_issue(
         # Recovery: ALWAYS comment before closing (audit trail), both fatal — a
         # failed close would silently leave a stale open issue.
         _run_gh(["issue", "comment", str(open_number),
-                 "--body", f"All citations healthy as of {run_date}. Closing."])
+                 "--body", f"All citations healthy as of {run_timestamp}. Closing."])
         _run_gh(["issue", "close", str(open_number)])
         return IssueOutcome("closed", open_number)
 


### PR DESCRIPTION
## Summary
Post-delivery documentation review for Feature 183 (Citation-URL Link-Rot Monitoring).

- **refactor(183)**: two behavior-preserving simplifications in `scripts/check-citation-urls.py` per `/simplify` (redundant timeout-check collapse + `run_date` alias inlined). Verified: 17/17 offline suite + 5/5 integrity, 0 regressions. `/simplify` reuse + altitude angles returned clean; efficiency findings skipped (negligible vs. 930 live HTTP probes).
- **docs(183)**: added the Feature 183 entry to the CHANGELOG Unreleased section (the feature branch shipped no CHANGELOG prose).

Docs-lint: `check-citation-urls.py` fully documented (T018); 1 test-helper `__call__` skipped (class docstring already covers it). API sync: no OpenAPI spec. KB: Entry 17 reviewed (accurate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)