### PR TITLE
fix(deps): raise nextjs-supabase scaffold next/vitest floors past vulnerable ranges

### DIFF
--- a/stacks/nextjs-supabase/scaffold/package.json
+++ b/stacks/nextjs-supabase/scaffold/package.json
@@ -18,7 +18,7 @@
     "test:e2e": "playwright test"
   },
   "dependencies": {
-    "next": ">=16.2.3",
+    "next": ">=16.2.6",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0",
     "@supabase/supabase-js": ">=2.45.0",
@@ -31,7 +31,7 @@
     "tailwindcss": ">=4.0.0",
     "@biomejs/biome": ">=2.0.0",
     "prisma": ">=7.0.0",
-    "vitest": ">=4.0.0",
+    "vitest": ">=4.1.0",
     "@testing-library/react": ">=16.0.0",
     "playwright": ">=1.55.1",
     "@types/node": ">=20.0.0",


### PR DESCRIPTION
## Summary

Clears all **14 Dependabot alerts** on `main` (1 critical / 7 high / 4 moderate / 2 low), every one scoped to `stacks/nextjs-supabase/scaffold/package.json`. The vulnerability is that each dependency-range **floor** sat inside the advisory's vulnerable band.

| Dep | Before | After | Alerts cleared |
|-----|--------|-------|----------------|
| `next` | `>=16.2.3` | `>=16.2.6` | 13 (7 high, 4 mod, 2 low) — `16.2.6` covers the segment-prefetch incomplete-fix (GHSA needing 16.2.6); the rest patch at 16.2.5 |
| `vitest` | `>=4.0.0` | `>=4.1.0` | 1 **critical** — UI-server arbitrary file read/exec (vulnerable `>=4.0.0,<4.1.0`) |

## Why this is safe

- **No major bump** — `next` stays `16.x`, `vitest` stays `4.x`. No breaking change; the BLP-06 M3 split-valve (escalate code-touching major bumps to Wave 2) does **not** trigger.
- **Scaffold template only** — no lockfile, and no test reads this file. Verified zero test impact: `pytest tests/scripts/` reports an identical `32 failed / 876 passed` with and without this change (those 32 are a pre-existing, unrelated red main — tracked separately).
- The other two scaffolds (`fastapi-react*`) use `vitest ^3.x` (outside the vulnerable band) and carry no `next` — correctly unflagged.

Part of BLP-06 Maintenance Lane (M3 — dependency vulnerability triage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)