### PR TITLE
docs(295): post-delivery quality review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Feature 295 — F-292 Post-Merge Verification Runs (T017 + T026 executed fail-closed, BLP-06 Wave 3, #295) — feat(295)
+
+Executes the two verification runs F-292 deferred at its 2026-05-14 close (KB Entry 7 → #295), with
+fail-closed, false-pass-guarded gates where the deliverable is the committed verification record and
+failure disposition is pre-decided (fix-vs-file). SC-003 (T017, agentic-app OI no-emission): **PASS** —
+attempt 1's single-agent dispatch returned NO_FINDINGS and was correctly treated as a gate ERROR, never
+"zero emissions = pass"; attempt 2's scoped-full fallback matched the pre-292 anchor (OI-1..OI-4) on all
+D-1 gate fields, with every byte-delta attributed. SC-015 (T026, multi-tenant-rag-app Cat 6 baseline):
+**gate FAIL, honest-stop** — the Cat 6 threat WAS detected but Phase-3 compilation absorbed the OI
+findings into the LLM-N ID sequence, dropping the OI- prefix and CWE-943 citations → defect #356; no
+baseline committed; the US-3 CI byte-identity check is structurally deferred to #356. Ships one enabler:
+`generate-threats-sarif.py` now derives the SARIF source URI from its input path (FR-014; 4 covering
+assertions; agentic-app regeneration byte-unchanged). Follow-ups filed: #354 (F-292 contract §3/§6
+defects), #355 (sample-report duplicate legacy IDs), #356 (Phase-3 compilation defect), #357
+(risk-scores generator parameterization). Verification records: `specs/295-f292-verification-runs/`.
+KB Entry 22.
+
 ### Feature 217 — Detect-Images Duplicate Cleanup (opt-in mislabeled-image removal, BLP-06 Wave 3, #217) — feat(217)
 
 Ships the decided remedy for the #215/#216 follow-on: the non-destructive self-heal left every

--- a/scripts/generate-threats-sarif.py
+++ b/scripts/generate-threats-sarif.py
@@ -15,15 +15,19 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-REPO_ROOT = Path(__file__).resolve().parent.parent
 
 from sarif_common import (
     PREFIX_TO_RULE,
+    REPO_ROOT,
     SEVERITY_TO_LEVEL,
     build_sarif_envelope,
     parse_affected_assets,
     parse_component_metadata,
 )
+
+# Pre-FR-014 emission, preserved as the omitted-arg seam: callers that do not
+# pass source_uri (the pre-existing SC-006 suite) keep this uri byte-for-byte.
+DEFAULT_SOURCE_URI = "examples/agentic-app/sample-report/threats.md"
 
 
 def artifact_uri_for(input_path: Path) -> str:
@@ -418,7 +422,7 @@ def build_result(
     finding: dict,
     component_meta: dict[str, dict[str, str]],
     affected_assets_by_id: dict[str, list[str]],
-    source_uri: str = "examples/agentic-app/sample-report/threats.md",
+    source_uri: str,
     run_id_baseline: str = "2026-04-19T03-20-30",
 ) -> dict:
     """Build one SARIF 2.1.0 result entry from a parsed finding row.
@@ -539,7 +543,7 @@ def build_sarif(
     findings: list[dict],
     component_meta: dict[str, dict[str, str]],
     affected_assets_by_id: dict[str, list[str]],
-    source_uri: str = "examples/agentic-app/sample-report/threats.md",
+    source_uri: str = DEFAULT_SOURCE_URI,
 ) -> dict:
     results = [
         build_result(f, component_meta, affected_assets_by_id, source_uri)

--- a/scripts/sarif_common.py
+++ b/scripts/sarif_common.py
@@ -18,6 +18,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from tachi_parsers import parse_scope_data  # noqa: E402
 
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
 SARIF_SCHEMA_URI = (
     "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/"
     "schema/sarif-schema-2.1.0.json"


### PR DESCRIPTION
## Summary
Post-delivery documentation review for Feature 295.

- refactor(295): simplify per /simplify review — source_uri seam only on build_sarif (dead build_result default removed), DEFAULT_SOURCE_URI named constant, REPO_ROOT centralized in sarif_common.py. Output-preserving: regen byte-identical pre-vs-post; 39/39 + 13/13 suites green.
- docs(295): CHANGELOG Feature 295 section (verification outcomes, FR-014 enabler, follow-ups #354–#357, KB Entry 22).

Docs-lint: no undocumented complex functions. API sync: no OpenAPI spec (N/A). KB Entry 22 confirmed accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)